### PR TITLE
Expand README with usage examples, provider registration, and contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,175 @@
 # DbSqlLikeMem
-InMemory C# Database for Unit Test (Mysql, SqlServer, Oracle, Postgre) 
+
+In-memory C# database engine for unit tests that emulates SQL dialects and ADO.NET behavior for **MySQL**, **SQL Server**, **Oracle**, and **PostgreSQL (Npgsql)**.
+
+This project lets you test data access code without a real database by using provider-specific connection mocks and a SQL parser/executor built into the library.
+
+## Features
+
+- Provider-specific mocks: MySQL, SQL Server, Oracle, PostgreSQL (Npgsql)
+- SQL parsing + execution for common DDL/DML
+- Fluent schema definition and seeding helpers
+- Dapper-friendly execution (implements common ADO.NET behaviors)
+- Dialect-aware behavior differences
+
+## Requirements
+
+- .NET 8.0 (see `Directory.Build.props`)
+
+## Supported Providers
+
+| Provider | Package/Project |
+| --- | --- |
+| MySQL | `DbSqlLikeMem.MySql` |
+| SQL Server | `DbSqlLikeMem.SqlServer` |
+| Oracle | `DbSqlLikeMem.Oracle` |
+| PostgreSQL | `DbSqlLikeMem.Npgsql` |
+
+## Installation
+
+### Option 1: Project reference (recommended for local development)
+
+Add a reference to the core library and the provider you want:
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="../DbSqlLikeMem/DbSqlLikeMem.csproj" />
+  <ProjectReference Include="../DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj" />
+</ItemGroup>
+```
+
+### Option 2: Reference compiled DLLs
+
+Build the solution and reference the DLLs from your test project:
+
+```bash
+dotnet build src/DbSqlLikeMem.slnx
+```
+
+Then add references to:
+
+- `DbSqlLikeMem.dll`
+- One provider DLL (e.g., `DbSqlLikeMem.SqlServer.dll`)
+
+## Registering the provider DLL (choosing a database at runtime)
+
+When the database is chosen by the user at runtime, load the corresponding provider assembly and create its connection mock. A simple factory approach looks like this:
+
+```csharp
+using DbSqlLikeMem.MySql;
+using DbSqlLikeMem.Npgsql;
+using DbSqlLikeMem.Oracle;
+using DbSqlLikeMem.SqlServer;
+
+public static class DbSqlLikeMemFactory
+{
+    public static DbConnection Create(string provider)
+    {
+        return provider.ToLowerInvariant() switch
+        {
+            "mysql" => new MySqlConnectionMock(new MySqlDbMock()),
+            "sqlserver" => new SqlServerConnectionMock(new SqlServerDbMock()),
+            "oracle" => new OracleConnectionMock(new OracleDbMock()),
+            "postgres" or "postgresql" or "npgsql" => new NpgsqlConnectionMock(new NpgsqlDbMock()),
+            _ => throw new ArgumentException($"Unsupported provider: {provider}")
+        };
+    }
+}
+```
+
+If you load DLLs dynamically, ensure the provider assembly is available to your test runner (e.g., by referencing the DLL or using `AssemblyLoadContext` to load it from disk before creating the connection).
+
+## Test assembly setup (InternalsVisibleTo)
+
+Some internal members are used by the provider projects and tests. The core project already declares `InternalsVisibleTo` for all provider and test assemblies. If you create your own test assembly and need access to internals, add an `InternalsVisibleTo` entry in `DbSqlLikeMem.csproj` **or** create an `AssemblyInfo.cs` in the core project with:
+
+```csharp
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MyCustomTestAssembly")]
+```
+
+Then reference the core and provider DLLs in your test project.
+
+## Usage Examples
+
+### 1) Fluent schema + Dapper-compatible execution (SQL Server example)
+
+```csharp
+using DbSqlLikeMem.SqlServer;
+
+var db = new SqlServerDbMock { ThreadSafe = true };
+using var connection = new SqlServerConnectionMock(db);
+
+connection.DefineTable("user")
+    .Column<int>("id", pk: true, identity: true)
+    .Column<string>("name")
+    .Column<string>("email", nullable: true)
+    .Column<DateTime>("created", nullable: false);
+
+connection.Open();
+
+connection.Execute(
+    "INSERT INTO user (name, email, created) VALUES (@name, @email, @created)",
+    new { name = "Alice", email = "alice@mail.com", created = DateTime.UtcNow });
+
+var users = connection.Query("SELECT * FROM user").ToList();
+```
+
+### 2) Manual schema + seed data (PostgreSQL example)
+
+```csharp
+using DbSqlLikeMem.Npgsql;
+
+var db = new NpgsqlDbMock();
+var table = db.AddTable("Users");
+
+table.Columns["Id"] = new(0, DbType.Int32, false);
+table.Columns["Name"] = new(1, DbType.String, false);
+
+table.Add(new Dictionary<int, object?>
+{
+    { 0, 1 },
+    { 1, "John Doe" }
+});
+
+using var connection = new NpgsqlConnectionMock(db);
+var result = connection.Query("SELECT * FROM Users WHERE Id = @Id", new { Id = 1 });
+```
+
+### 3) Using the right provider for each database
+
+```csharp
+// MySQL
+using DbSqlLikeMem.MySql;
+var mysql = new MySqlConnectionMock(new MySqlDbMock());
+
+// Oracle
+using DbSqlLikeMem.Oracle;
+var oracle = new OracleConnectionMock(new OracleDbMock());
+
+// SQL Server
+using DbSqlLikeMem.SqlServer;
+var sqlServer = new SqlServerConnectionMock(new SqlServerDbMock());
+
+// PostgreSQL
+using DbSqlLikeMem.Npgsql;
+var postgres = new NpgsqlConnectionMock(new NpgsqlDbMock());
+```
+
+## Running Tests
+
+```bash
+dotnet test src/DbSqlLikeMem.slnx
+```
+
+## Contributing
+
+Contributions are welcome! If you want to help improve DbSqlLikeMem, please open an issue to discuss your idea or submit a pull request. Areas where help is especially valuable:
+
+- Expanding SQL compatibility for each dialect
+- Adding more examples or documentation
+- Improving performance and error diagnostics
+- Increasing test coverage
+
+Thank you for helping the project evolve.


### PR DESCRIPTION
### Motivation

- Provide a complete, English README suitable for a public repository that documents installation, how to register/select a provider DLL at runtime, and how to set up test assemblies.

### Description

- Rewrote and expanded `README.md` to include an overview, features, requirements, supported providers, and two installation options (`ProjectReference` and compiled DLLs). 
- Added a runtime provider factory example showing how to create provider-specific connection mocks for `MySql`, `SqlServer`, `Oracle`, and `Npgsql` and guidance for dynamic assembly loading. 
- Documented `InternalsVisibleTo` usage and test assembly setup to match how the projects use `InternalsVisibleTo`, plus multiple usage examples (fluent schema, manual seeding, provider-specific connection mocks) and a `dotnet test` command example. 
- Included a concise contributing section that invites issues and pull requests and highlights areas for help (SQL compatibility, docs, performance, and tests).

### Testing

- This is a documentation-only change and no automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a135becc0832c921ccfeb911393ae)