### PR TITLE
Configure NuGet package metadata and per-project descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,175 @@
 # DbSqlLikeMem
-InMemory C# Database for Unit Test (Mysql, SqlServer, Oracle, Postgre) 
+
+In-memory C# database engine for unit tests that emulates SQL dialects and ADO.NET behavior for **MySQL**, **SQL Server**, **Oracle**, and **PostgreSQL (Npgsql)**.
+
+This project lets you test data access code without a real database by using provider-specific connection mocks and a SQL parser/executor built into the library.
+
+## Features
+
+- Provider-specific mocks: MySQL, SQL Server, Oracle, PostgreSQL (Npgsql)
+- SQL parsing + execution for common DDL/DML
+- Fluent schema definition and seeding helpers
+- Dapper-friendly execution (implements common ADO.NET behaviors)
+- Dialect-aware behavior differences
+
+## Requirements
+
+- .NET 8.0 (see `Directory.Build.props`)
+
+## Supported Providers
+
+| Provider | Package/Project |
+| --- | --- |
+| MySQL | `DbSqlLikeMem.MySql` |
+| SQL Server | `DbSqlLikeMem.SqlServer` |
+| Oracle | `DbSqlLikeMem.Oracle` |
+| PostgreSQL | `DbSqlLikeMem.Npgsql` |
+
+## Installation
+
+### Option 1: Project reference (recommended for local development)
+
+Add a reference to the core library and the provider you want:
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="../DbSqlLikeMem/DbSqlLikeMem.csproj" />
+  <ProjectReference Include="../DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj" />
+</ItemGroup>
+```
+
+### Option 2: Reference compiled DLLs
+
+Build the solution and reference the DLLs from your test project:
+
+```bash
+dotnet build src/DbSqlLikeMem.slnx
+```
+
+Then add references to:
+
+- `DbSqlLikeMem.dll`
+- One provider DLL (e.g., `DbSqlLikeMem.SqlServer.dll`)
+
+## Registering the provider DLL (choosing a database at runtime)
+
+When the database is chosen by the user at runtime, load the corresponding provider assembly and create its connection mock. A simple factory approach looks like this:
+
+```csharp
+using DbSqlLikeMem.MySql;
+using DbSqlLikeMem.Npgsql;
+using DbSqlLikeMem.Oracle;
+using DbSqlLikeMem.SqlServer;
+
+public static class DbSqlLikeMemFactory
+{
+    public static DbConnection Create(string provider)
+    {
+        return provider.ToLowerInvariant() switch
+        {
+            "mysql" => new MySqlConnectionMock(new MySqlDbMock()),
+            "sqlserver" => new SqlServerConnectionMock(new SqlServerDbMock()),
+            "oracle" => new OracleConnectionMock(new OracleDbMock()),
+            "postgres" or "postgresql" or "npgsql" => new NpgsqlConnectionMock(new NpgsqlDbMock()),
+            _ => throw new ArgumentException($"Unsupported provider: {provider}")
+        };
+    }
+}
+```
+
+If you load DLLs dynamically, ensure the provider assembly is available to your test runner (e.g., by referencing the DLL or using `AssemblyLoadContext` to load it from disk before creating the connection).
+
+## Test assembly setup (InternalsVisibleTo)
+
+Some internal members are used by the provider projects and tests. The core project already declares `InternalsVisibleTo` for all provider and test assemblies. If you create your own test assembly and need access to internals, add an `InternalsVisibleTo` entry in `DbSqlLikeMem.csproj` **or** create an `AssemblyInfo.cs` in the core project with:
+
+```csharp
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MyCustomTestAssembly")]
+```
+
+Then reference the core and provider DLLs in your test project.
+
+## Usage Examples
+
+### 1) Fluent schema + Dapper-compatible execution (SQL Server example)
+
+```csharp
+using DbSqlLikeMem.SqlServer;
+
+var db = new SqlServerDbMock { ThreadSafe = true };
+using var connection = new SqlServerConnectionMock(db);
+
+connection.DefineTable("user")
+    .Column<int>("id", pk: true, identity: true)
+    .Column<string>("name")
+    .Column<string>("email", nullable: true)
+    .Column<DateTime>("created", nullable: false);
+
+connection.Open();
+
+connection.Execute(
+    "INSERT INTO user (name, email, created) VALUES (@name, @email, @created)",
+    new { name = "Alice", email = "alice@mail.com", created = DateTime.UtcNow });
+
+var users = connection.Query("SELECT * FROM user").ToList();
+```
+
+### 2) Manual schema + seed data (PostgreSQL example)
+
+```csharp
+using DbSqlLikeMem.Npgsql;
+
+var db = new NpgsqlDbMock();
+var table = db.AddTable("Users");
+
+table.Columns["Id"] = new(0, DbType.Int32, false);
+table.Columns["Name"] = new(1, DbType.String, false);
+
+table.Add(new Dictionary<int, object?>
+{
+    { 0, 1 },
+    { 1, "John Doe" }
+});
+
+using var connection = new NpgsqlConnectionMock(db);
+var result = connection.Query("SELECT * FROM Users WHERE Id = @Id", new { Id = 1 });
+```
+
+### 3) Using the right provider for each database
+
+```csharp
+// MySQL
+using DbSqlLikeMem.MySql;
+var mysql = new MySqlConnectionMock(new MySqlDbMock());
+
+// Oracle
+using DbSqlLikeMem.Oracle;
+var oracle = new OracleConnectionMock(new OracleDbMock());
+
+// SQL Server
+using DbSqlLikeMem.SqlServer;
+var sqlServer = new SqlServerConnectionMock(new SqlServerDbMock());
+
+// PostgreSQL
+using DbSqlLikeMem.Npgsql;
+var postgres = new NpgsqlConnectionMock(new NpgsqlDbMock());
+```
+
+## Running Tests
+
+```bash
+dotnet test src/DbSqlLikeMem.slnx
+```
+
+## Contributing
+
+Contributions are welcome! If you want to help improve DbSqlLikeMem, please open an issue to discuss your idea or submit a pull request. Areas where help is especially valuable:
+
+- Expanding SQL compatibility for each dialect
+- Adding more examples or documentation
+- Improving performance and error diagnostics
+- Increasing test coverage
+
+Thank you for helping the project evolve.

--- a/src/DbSqlLikeMem.MySql/DbSqlLikeMem.MySql.csproj
+++ b/src/DbSqlLikeMem.MySql/DbSqlLikeMem.MySql.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Description>MySQL provider for the DbSqlLikeMem in-memory SQL-like database.</Description>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="MySql.Data" Version="9.6.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />

--- a/src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj
+++ b/src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Description>PostgreSQL (Npgsql) provider for the DbSqlLikeMem in-memory SQL-like database.</Description>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Npgsql" Version="10.0.1" />

--- a/src/DbSqlLikeMem.Oracle/DbSqlLikeMem.Oracle.csproj
+++ b/src/DbSqlLikeMem.Oracle/DbSqlLikeMem.Oracle.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Description>Oracle provider for the DbSqlLikeMem in-memory SQL-like database.</Description>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.26.100" />
 		<PackageReference Include="xunit" Version="2.9.3" />

--- a/src/DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj
+++ b/src/DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Description>SQL Server provider for the DbSqlLikeMem in-memory SQL-like database.</Description>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />

--- a/src/DbSqlLikeMem/DbSqlLikeMem.csproj
+++ b/src/DbSqlLikeMem/DbSqlLikeMem.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Description>In-memory SQL-like database engine for unit tests.</Description>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
 		<PackageReference Include="CsvHelper" Version="33.1.0" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,18 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<IsPackable>true</IsPackable>
+		<Authors>DbSqlLikeMem Contributors</Authors>
+		<PackageTags>in-memory;database;sql;unit-testing;mock;dapper</PackageTags>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<RepositoryType>git</RepositoryType>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<Version>0.1.0</Version>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Motivation

- Prepare the repository for publishing to NuGet by centralizing packing metadata and improving package metadata clarity for consumers.
- Ensure packaged artifacts include the `README.md` and generated XML docs to provide documentation on NuGet.

### Description

- Added shared NuGet packing metadata to `src/Directory.Build.props`, including `IsPackable`, `Authors`, `PackageTags`, `PackageReadmeFile`, `RepositoryType`, `PackageRequireLicenseAcceptance`, `Version`, and `GenerateDocumentationFile`.
- Included the repository `README.md` in packaged artifacts via a `None` entry in `src/Directory.Build.props` so the readme is packaged with the NuGet package.
- Added `Description` elements to the core project `src/DbSqlLikeMem/DbSqlLikeMem.csproj` and provider projects `src/DbSqlLikeMem.MySql/DbSqlLikeMem.MySql.csproj`, `src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj`, `src/DbSqlLikeMem.Oracle/DbSqlLikeMem.Oracle.csproj`, and `src/DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj` to surface human-readable package descriptions on NuGet.

### Testing

- No automated tests were run for this change since it only affects packaging metadata and project properties.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a135becc0832c921ccfeb911393ae)