### PR TITLE
Apply defaults on TableMock.Add for consistent inserts

### DIFF
--- a/src/DbSqlLikeMem/Extensions/DbSeedExtensions.cs
+++ b/src/DbSqlLikeMem/Extensions/DbSeedExtensions.cs
@@ -156,8 +156,11 @@ public static class DbSeedExtensions
         foreach (var arr in rows)
         {
             var dic = new Dictionary<int, object?>();
+            var orderedCols = tb.Columns.Values.OrderBy(c => c.Index).ToList();
+            if (arr.Length > orderedCols.Count)
+                throw new InvalidOperationException($"Seed row has {arr.Length} values, but table '{tableName}' has only {orderedCols.Count} columns.");
             for (int i = 0; i < arr.Length; i++)
-                dic[i] = arr[i];
+                dic[orderedCols[i].Index] = arr[i];
             tb.Add(dic);
         }
         return cnn;

--- a/src/DbSqlLikeMem/Models/TableMock.cs
+++ b/src/DbSqlLikeMem/Models/TableMock.cs
@@ -166,6 +166,7 @@ public abstract class TableMock
 
     public new void Add(Dictionary<int, object?> value)
     {
+        ApplyDefaultValues(value);
         // Before adding, enforce unique indexes
         foreach (var idx in Indexes.GetUnique())
         {
@@ -182,6 +183,17 @@ public abstract class TableMock
         int newIdx = Count - 1;
         foreach (var idx in Indexes)
             UpdateIndexesWithRow(newIdx);
+    }
+
+    private void ApplyDefaultValues(Dictionary<int, object?> value)
+    {
+        foreach (var (key, col) in Columns)
+        {
+            if (value.ContainsKey(col.Index)) continue;
+            if (col.Identity) value[col.Index] = NextIdentity++;
+            else if (col.DefaultValue != null) value[col.Index] = col.DefaultValue;
+            else if (!col.Nullable) throw ColumnCannotBeNull(key);
+        }
     }
 
     private List<Dictionary<int, object?>>? _backup;


### PR DESCRIPTION
### Motivation

- Ensure that identity increments, column `DefaultValue` and `NOT NULL` enforcement are applied consistently for all row insertions rather than only in specific seed helpers.
- Fix inconsistent behavior where seeding and other insertion paths could omit default/identity application and produce null/PK errors.

### Description

- Added `ApplyDefaultValues(Dictionary<int, object?>)` to `TableMock` and call it at the start of `TableMock.Add` to centralize `Identity`, `DefaultValue`, and non-null enforcement (file: `src/DbSqlLikeMem/Models/TableMock.cs`).
- Removed the separate `ApplySeedDefaults` usage and rely on `TableMock.Add` for defaults; the positional `Seed` now maps input values to table columns ordered by `Index` and validates row length before calling `Add` (file: `src/DbSqlLikeMem/Extensions/DbSeedExtensions.cs`).
- Kept existing unique-index checks and index updates intact after defaults are applied to ensure consistent duplicate-key behavior and proper index maintenance.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a182185f0832c87967834c817e593)