### PR TITLE
Disallow row value IN without parentheses

### DIFF
--- a/src/DbSqlLikeMem/Parser/SqlExpressionParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlExpressionParser.cs
@@ -168,6 +168,9 @@ internal sealed class SqlExpressionParser(
         Consume(); // NOT
         Consume(); // IN
 
+        if (left is RowExpr && !IsSymbol(Peek(), "("))
+            throw Error("Row value IN requires parentheses", notTok);
+
         // NOT IN ( ... )  ou NOT IN ( (SELECT ...) )
         var payload = ParseInPayload(notTok, "NOT IN"); // retorna lista de SqlExpr ou SubqueryExpr embrulhado
         left = new UnaryExpr(SqlUnaryOp.Not, new InExpr(left, payload));
@@ -294,6 +297,9 @@ internal sealed class SqlExpressionParser(
 
         var inTok = t;
         Consume(); // IN
+
+        if (left is RowExpr && !IsSymbol(Peek(), "("))
+            throw Error("Row value IN requires parentheses", inTok);
 
         var payload = ParseInPayload(inTok, "IN");
 


### PR DESCRIPTION
### Motivation
- Reject row-value `IN`/`NOT IN` expressions that use a bare parameter or list without surrounding parentheses to match parser expectations and the unsupported-expression tests.

### Description
- Add validation in `TryParseInInfix` to throw `Error("Row value IN requires parentheses", inTok)` when `left` is `RowExpr` and the next token is not `("(")`.
- Add the same validation in `TryParseNotIn` using the `notTok` context token so `NOT IN` row-value usages are also rejected.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1fe85220832ca157762be1c2c115)