### PR TITLE
Add Portuguese XML summaries for core public APIs

### DIFF
--- a/src/DbSqlLikeMem/Base/DbDataReaderMockBase.cs
+++ b/src/DbSqlLikeMem/Base/DbDataReaderMockBase.cs
@@ -2,6 +2,9 @@ using System.Collections;
 
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Implementa um leitor de dados em memória para resultados de consulta.
+/// </summary>
 public abstract class DbDataReaderMockBase(
     IList<TableResultMock> tables
     ) : DbDataReader
@@ -18,7 +21,13 @@ public abstract class DbDataReaderMockBase(
     private int _currentIndex = -1;
     private bool disposedValue;
 
+    /// <summary>
+    /// Obtém o valor da coluna pelo índice ordinal.
+    /// </summary>
     public override object this[int i] => _resultSets[_currentResultSetIndex][_currentIndex][i] ?? DBNull.Value;
+    /// <summary>
+    /// Obtém o valor da coluna pelo nome.
+    /// </summary>
     public override object this[string name]
     {
         get
@@ -28,40 +37,105 @@ public abstract class DbDataReaderMockBase(
         }
     }
 
+    /// <summary>
+    /// Profundidade do leitor (não utilizada).
+    /// </summary>
     public override int Depth { get; }
     private bool _isClosed;
+    /// <summary>
+    /// Indica se o leitor está fechado.
+    /// </summary>
     public override bool IsClosed => _isClosed;
+    /// <summary>
+    /// Número de registros afetados no conjunto atual.
+    /// </summary>
     public override int RecordsAffected => _resultSets[_currentResultSetIndex].Count;
+    /// <summary>
+    /// Quantidade de colunas do conjunto atual.
+    /// </summary>
     public override int FieldCount => _columnsDic[_currentResultSetIndex].Count;
 
+    /// <summary>
+    /// Indica se o conjunto atual possui linhas.
+    /// </summary>
     public override bool HasRows => _resultSets.Count > 0 && _resultSets[_currentResultSetIndex].Count > 0;
 
+    /// <summary>
+    /// Fecha o leitor.
+    /// </summary>
     public override void Close()
         => _isClosed = true;
 
+    /// <summary>
+    /// Obtém valor booleano da coluna indicada.
+    /// </summary>
     public override bool GetBoolean(int ordinal) => (bool)this[ordinal];
+    /// <summary>
+    /// Obtém valor byte da coluna indicada.
+    /// </summary>
     public override byte GetByte(int ordinal) => (byte)this[ordinal];
     public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) => throw new NotImplementedException();
+    /// <summary>
+    /// Obtém valor char da coluna indicada.
+    /// </summary>
     public override char GetChar(int ordinal) => (char)this[ordinal];
     public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => throw new NotImplementedException();
     protected override DbDataReader GetDbDataReader(int ordinal) => throw new NotImplementedException();
+    /// <summary>
+    /// Obtém o nome do tipo de dados da coluna.
+    /// </summary>
     public override string GetDataTypeName(int ordinal) => _columnsDic[_currentResultSetIndex][ordinal].DbType.ToString();
+    /// <summary>
+    /// Obtém valor DateTime da coluna indicada.
+    /// </summary>
     public override DateTime GetDateTime(int ordinal) => (DateTime)this[ordinal];
+    /// <summary>
+    /// Obtém valor decimal da coluna indicada.
+    /// </summary>
     public override decimal GetDecimal(int ordinal) => (decimal)this[ordinal];
+    /// <summary>
+    /// Obtém valor double da coluna indicada.
+    /// </summary>
     public override double GetDouble(int ordinal) => (double)this[ordinal];
+    /// <summary>
+    /// Obtém o tipo .NET da coluna indicada.
+    /// </summary>
     public override Type GetFieldType(int ordinal)
         => _columnsDic[_currentResultSetIndex][ordinal].DbType.ConvertDbTypeToType();
+    /// <summary>
+    /// Obtém valor float da coluna indicada.
+    /// </summary>
     public override float GetFloat(int ordinal) => (float)this[ordinal];
+    /// <summary>
+    /// Obtém valor Guid da coluna indicada.
+    /// </summary>
     public override Guid GetGuid(int ordinal) => (Guid)this[ordinal];
+    /// <summary>
+    /// Obtém valor Int16 da coluna indicada.
+    /// </summary>
     public override short GetInt16(int ordinal) => (short)this[ordinal];
+    /// <summary>
+    /// Obtém valor Int32 da coluna indicada.
+    /// </summary>
     public override int GetInt32(int ordinal) => (int)this[ordinal];
+    /// <summary>
+    /// Obtém valor Int64 da coluna indicada.
+    /// </summary>
     public override long GetInt64(int ordinal) => (long)this[ordinal];
+    /// <summary>
+    /// Obtém o nome da coluna pelo ordinal.
+    /// </summary>
     public override string GetName(int ordinal)
     {
         var n = _columnsDic[_currentResultSetIndex][ordinal].ColumName ?? string.Empty;
         return NormalizeColumnName(n);
     }
 
+    /// <summary>
+    /// Obtém o ordinal de uma coluna pelo nome.
+    /// </summary>
+    /// <param name="name">Nome da coluna.</param>
+    /// <returns>Índice da coluna.</returns>
     public override int GetOrdinal(string name)
     {
         name = NormalizeColumnName(name);
@@ -105,6 +179,9 @@ public abstract class DbDataReaderMockBase(
 
         return name;
     }
+    /// <summary>
+    /// Retorna uma DataTable com metadados das colunas.
+    /// </summary>
     public override DataTable GetSchemaTable()
     {
         var dt = new DataTable();
@@ -118,12 +195,23 @@ public abstract class DbDataReaderMockBase(
         return dt;
     }
 
+    /// <summary>
+    /// Obtém valor string da coluna indicada.
+    /// </summary>
     public override string GetString(int ordinal) => (string)this[ordinal];
+    /// <summary>
+    /// Obtém o valor da coluna indicada.
+    /// </summary>
     public override object GetValue(int ordinal)
     {
         var v = this[ordinal];
         return v is HashSet<string> hs ? string.Join(',', hs) : v;
     }
+    /// <summary>
+    /// Copia os valores da linha atual para o array fornecido.
+    /// </summary>
+    /// <param name="values">Array de destino.</param>
+    /// <returns>Número de colunas copiadas.</returns>
     public override int GetValues(object[] values)
     {
         ArgumentNullException.ThrowIfNull(values);
@@ -133,7 +221,13 @@ public abstract class DbDataReaderMockBase(
         }
         return FieldCount;
     }
+    /// <summary>
+    /// Indica se o valor da coluna é DBNull.
+    /// </summary>
     public override bool IsDBNull(int ordinal) => this[ordinal] == null || this[ordinal] == DBNull.Value;
+    /// <summary>
+    /// Avança para o próximo conjunto de resultados.
+    /// </summary>
     public override bool NextResult()
     {
         if (_currentResultSetIndex + 1 >= _resultSets.Count) return false;
@@ -142,6 +236,9 @@ public abstract class DbDataReaderMockBase(
         return true;
     }
 
+    /// <summary>
+    /// Avança para a próxima linha do conjunto atual.
+    /// </summary>
     public override bool Read()
     {
         if (_currentIndex + 1 >= _resultSets[_currentResultSetIndex].Count) return false;
@@ -149,6 +246,9 @@ public abstract class DbDataReaderMockBase(
         return true;
     }
 
+    /// <summary>
+    /// Retorna um enumerador dos conjuntos de resultados.
+    /// </summary>
     public override IEnumerator GetEnumerator() => _resultSets.GetEnumerator();
     protected override void Dispose(bool disposing)
     {

--- a/src/DbSqlLikeMem/Interfaces/IColumnDictionary.cs
+++ b/src/DbSqlLikeMem/Interfaces/IColumnDictionary.cs
@@ -1,4 +1,7 @@
 namespace DbSqlLikeMem;
+/// <summary>
+/// Define um dicionário de colunas acessível por nome.
+/// </summary>
 public interface IColumnDictionary : IDictionary<string, ColumnDef>
 {
 }

--- a/src/DbSqlLikeMem/Interfaces/ISchemaDictionary.cs
+++ b/src/DbSqlLikeMem/Interfaces/ISchemaDictionary.cs
@@ -1,4 +1,7 @@
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Define um dicionário somente leitura de schemas por nome.
+/// </summary>
 public interface ISchemaDictionary : IReadOnlyDictionary<string, ISchemaMock>
 { }

--- a/src/DbSqlLikeMem/Interfaces/ISchemaMock.cs
+++ b/src/DbSqlLikeMem/Interfaces/ISchemaMock.cs
@@ -1,17 +1,42 @@
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Define o contrato de um schema em memória com criação e recuperação de tabelas.
+/// </summary>
 public interface ISchemaMock
 {
+    /// <summary>
+    /// Cria uma tabela com colunas e linhas iniciais opcionais.
+    /// </summary>
+    /// <param name="tableName">Nome da tabela.</param>
+    /// <param name="columns">Colunas da tabela.</param>
+    /// <param name="rows">Linhas iniciais opcionais.</param>
+    /// <returns>Tabela criada.</returns>
     TableMock CreateTable(
         string tableName,
         IColumnDictionary columns,
         IEnumerable<Dictionary<int, object?>>? rows = null);
 
+    /// <summary>
+    /// Tenta obter uma tabela pelo nome do schema.
+    /// </summary>
+    /// <param name="key">Nome da tabela.</param>
+    /// <param name="value">Tabela encontrada, se houver.</param>
+    /// <returns>True se a tabela existir.</returns>
     bool TryGetTable(string key, out ITableMock? value);
 
+    /// <summary>
+    /// Realiza backup de todas as tabelas, ignorando falhas individuais.
+    /// </summary>
     void BackupAllTablesBestEffort();
 
+    /// <summary>
+    /// Restaura backup de todas as tabelas, ignorando falhas individuais.
+    /// </summary>
     void RestoreAllTablesBestEffort();
 
+    /// <summary>
+    /// Limpa backups armazenados para todas as tabelas.
+    /// </summary>
     void ClearBackupAllTablesBestEffort();
 }

--- a/src/DbSqlLikeMem/Interfaces/ITableDictionary.cs
+++ b/src/DbSqlLikeMem/Interfaces/ITableDictionary.cs
@@ -1,4 +1,7 @@
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Define um dicionário de tabelas acessível por nome.
+/// </summary>
 public interface ITableDictionary : IDictionary<string, ITableMock>
 { }

--- a/src/DbSqlLikeMem/Interfaces/ITableMock.cs
+++ b/src/DbSqlLikeMem/Interfaces/ITableMock.cs
@@ -1,51 +1,136 @@
 namespace DbSqlLikeMem;
+/// <summary>
+/// Define o contrato de uma tabela em memória, com dados, metadados e utilidades de índice.
+/// </summary>
 public interface ITableMock
     : IList<Dictionary<int, object?>>
 {
+    /// <summary>
+    /// Obtém ou define o próximo valor de identidade para colunas auto incrementais.
+    /// </summary>
     int NextIdentity { get; set; }
 
+    /// <summary>
+    /// Mantém os índices das colunas que compõem a chave primária.
+    /// </summary>
     HashSet<int> PrimaryKeyIndexes { get; }
 
+    /// <summary>
+    /// Expõe as chaves estrangeiras configuradas na tabela.
+    /// </summary>
     IReadOnlyList<(
         string Col, 
         string RefTable,
         string RefCol
         )> ForeignKeys { get; }
 
+    /// <summary>
+    /// Cria uma chave estrangeira ligando uma coluna local a uma coluna de outra tabela.
+    /// </summary>
+    /// <param name="col">Nome da coluna local.</param>
+    /// <param name="refTable">Tabela referenciada.</param>
+    /// <param name="refCol">Coluna referenciada.</param>
     void CreateForeignKey(
         string col,
         string refTable,
         string refCol);
 
+    /// <summary>
+    /// Obtém o dicionário de colunas da tabela.
+    /// </summary>
     IColumnDictionary Columns{ get; }
 
+    /// <summary>
+    /// Localiza uma coluna pelo nome ou lança erro se não existir.
+    /// </summary>
+    /// <param name="columnName">Nome da coluna.</param>
+    /// <returns>Definição da coluna encontrada.</returns>
     ColumnDef GetColumn(string columnName);
 
+    /// <summary>
+    /// Obtém os índices declarados para a tabela.
+    /// </summary>
     IndexDictionary Indexes { get; }
 
+    /// <summary>
+    /// Cria um índice com a definição informada.
+    /// </summary>
+    /// <param name="def">Definição do índice.</param>
     void CreateIndex(IndexDef def);
 
+    /// <summary>
+    /// Atualiza estruturas de índice usando a linha indicada.
+    /// </summary>
+    /// <param name="rowIdx">Índice da linha atualizada.</param>
     void UpdateIndexesWithRow(int rowIdx);
 
+    /// <summary>
+    /// Reconstrói todos os índices da tabela.
+    /// </summary>
     void RebuildAllIndexes();
+    /// <summary>
+    /// Executa uma busca em um índice com a chave informada.
+    /// </summary>
+    /// <param name="def">Definição do índice.</param>
+    /// <param name="key">Chave a buscar.</param>
+    /// <returns>Lista de posições ou null se não houver.</returns>
     IEnumerable<int>? Lookup(IndexDef def, string key);
 
+    /// <summary>
+    /// Adiciona múltiplos itens convertendo-os em linhas.
+    /// </summary>
+    /// <typeparam name="T">Tipo dos itens.</typeparam>
+    /// <param name="items">Itens a inserir.</param>
     void AddRangeItems<T>(IEnumerable<T> items);
 
+    /// <summary>
+    /// Adiciona um item convertendo-o em linha da tabela.
+    /// </summary>
+    /// <typeparam name="T">Tipo do item.</typeparam>
+    /// <param name="item">Item a inserir.</param>
     void AddItem<T>(T item);
 
+    /// <summary>
+    /// Adiciona um conjunto de linhas já materializadas.
+    /// </summary>
+    /// <param name="items">Linhas a inserir.</param>
     void AddRange(IEnumerable<Dictionary<int, object?>> items);
 
+    /// <summary>
+    /// Adiciona uma linha específica à tabela.
+    /// </summary>
+    /// <param name="value">Linha a inserir.</param>
     new void Add(Dictionary<int, object?> value);
 
+    /// <summary>
+    /// Realiza backup das linhas atuais para possível restauração.
+    /// </summary>
     void Backup();
 
+    /// <summary>
+    /// Restaura o último backup realizado.
+    /// </summary>
     void Restore();
 
+    /// <summary>
+    /// Limpa o backup armazenado.
+    /// </summary>
     void ClearBackup();
 
+    /// <summary>
+    /// Obtém ou define a coluna atualmente em avaliação durante parsing/execução.
+    /// </summary>
     string? CurrentColumn { get; set; }
 
+    /// <summary>
+    /// Resolve um token SQL para o valor correspondente no contexto da tabela.
+    /// </summary>
+    /// <param name="token">Token a resolver.</param>
+    /// <param name="dbType">Tipo esperado do token.</param>
+    /// <param name="isNullable">Indica se o valor pode ser nulo.</param>
+    /// <param name="pars">Parâmetros de consulta, quando aplicável.</param>
+    /// <param name="colDict">Dicionário de colunas opcional.</param>
+    /// <returns>Valor resolvido ou null.</returns>
     object? Resolve(
         string token,
         DbType dbType,
@@ -53,9 +138,32 @@ public interface ITableMock
         IDataParameterCollection? pars = null,
         IColumnDictionary? colDict = null);
 
+    /// <summary>
+    /// Cria a exceção apropriada para coluna inexistente.
+    /// </summary>
+    /// <param name="columnName">Nome da coluna inválida.</param>
     Exception UnknownColumn(string columnName);
+    /// <summary>
+    /// Cria a exceção apropriada para chave duplicada.
+    /// </summary>
+    /// <param name="tbl">Tabela afetada.</param>
+    /// <param name="key">Nome da chave.</param>
+    /// <param name="val">Valor duplicado.</param>
     Exception DuplicateKey(string tbl, string key, object? val);
+    /// <summary>
+    /// Cria a exceção apropriada para coluna que não aceita nulos.
+    /// </summary>
+    /// <param name="col">Nome da coluna.</param>
     Exception ColumnCannotBeNull(string col);
+    /// <summary>
+    /// Cria a exceção apropriada para violação de chave estrangeira.
+    /// </summary>
+    /// <param name="col">Coluna que referencia.</param>
+    /// <param name="refTbl">Tabela referenciada.</param>
     Exception ForeignKeyFails(string col, string refTbl);
+    /// <summary>
+    /// Cria a exceção apropriada para linha referenciada por outra tabela.
+    /// </summary>
+    /// <param name="tbl">Tabela referenciada.</param>
     Exception ReferencedRow(string tbl);
 }

--- a/src/DbSqlLikeMem/Models/ColumnDef.cs
+++ b/src/DbSqlLikeMem/Models/ColumnDef.cs
@@ -1,10 +1,24 @@
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Define os metadados de uma coluna, incluindo tipo, nulabilidade e identidade.
+/// </summary>
 public sealed class ColumnDef
 {
+    /// <summary>
+    /// Inicializa uma definição de coluna vazia.
+    /// </summary>
     public ColumnDef()
     { }
 
+    /// <summary>
+    /// Inicializa uma coluna com valores completos, incluindo padrão.
+    /// </summary>
+    /// <param name="index">Posição da coluna.</param>
+    /// <param name="dbType">Tipo de dados.</param>
+    /// <param name="nullable">Indica se aceita nulos.</param>
+    /// <param name="identity">Indica se é identidade.</param>
+    /// <param name="defaultValue">Valor padrão.</param>
     public ColumnDef(
         int index,
         DbType dbType,
@@ -16,6 +30,13 @@ public sealed class ColumnDef
         DefaultValue = defaultValue;
     }
 
+    /// <summary>
+    /// Inicializa uma coluna com identidade e configuração de nulabilidade.
+    /// </summary>
+    /// <param name="index">Posição da coluna.</param>
+    /// <param name="dbType">Tipo de dados.</param>
+    /// <param name="nullable">Indica se aceita nulos.</param>
+    /// <param name="identity">Indica se é identidade.</param>
     public ColumnDef(
         int index,
         DbType dbType,
@@ -26,12 +47,23 @@ public sealed class ColumnDef
         Identity = identity;
     }
 
+    /// <summary>
+    /// Inicializa uma coluna não nula com índice e tipo.
+    /// </summary>
+    /// <param name="index">Posição da coluna.</param>
+    /// <param name="dbType">Tipo de dados.</param>
     public ColumnDef(
         int index,
         DbType dbType
     ) : this(index, dbType, false) 
     { }
 
+    /// <summary>
+    /// Inicializa uma coluna com índice, tipo e nulabilidade.
+    /// </summary>
+    /// <param name="index">Posição da coluna.</param>
+    /// <param name="dbType">Tipo de dados.</param>
+    /// <param name="nullable">Indica se aceita nulos.</param>
     public ColumnDef(
         int index,
         DbType dbType,
@@ -42,14 +74,39 @@ public sealed class ColumnDef
         Nullable = nullable;
     }
 
+    /// <summary>
+    /// Obtém a posição da coluna na tabela.
+    /// </summary>
     public int Index { get; init; }
+    /// <summary>
+    /// Obtém o tipo de dados da coluna.
+    /// </summary>
     public DbType DbType { get; init; }
+    /// <summary>
+    /// Indica se a coluna aceita valores nulos.
+    /// </summary>
     public bool Nullable { get; init; }
+    /// <summary>
+    /// Indica se a coluna é auto incrementável.
+    /// </summary>
     public bool Identity { get; set; }
+    /// <summary>
+    /// Obtém ou define o valor padrão da coluna.
+    /// </summary>
     public object? DefaultValue { get; set; }
 
+    /// <summary>
+    /// Lista de valores permitidos quando a coluna é um enum.
+    /// </summary>
     public HashSet<string> EnumValues { get; internal set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    /// <summary>
+    /// Define os valores permitidos para a coluna enum.
+    /// </summary>
+    /// <param name="values">Valores permitidos.</param>
     public void SetEnumValues(params string[] values) => EnumValues = new(values, StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Função geradora de valor calculado para colunas derivadas.
+    /// </summary>
     public Func<Dictionary<int, object?>, ITableMock, object?>? GetGenValue { get; set; }
 }

--- a/src/DbSqlLikeMem/Models/ColumnDictionary.cs
+++ b/src/DbSqlLikeMem/Models/ColumnDictionary.cs
@@ -1,7 +1,13 @@
 namespace DbSqlLikeMem;
+/// <summary>
+/// Implementa um dicionário de colunas com comparação case-insensitive.
+/// </summary>
 public class ColumnDictionary
     : Dictionary<string, ColumnDef>,
         IColumnDictionary
 {
+    /// <summary>
+    /// Cria um dicionário de colunas ignorando maiúsculas/minúsculas.
+    /// </summary>
     public ColumnDictionary() : base(StringComparer.OrdinalIgnoreCase) { }
 }

--- a/src/DbSqlLikeMem/Models/DbMetrics.cs
+++ b/src/DbSqlLikeMem/Models/DbMetrics.cs
@@ -2,12 +2,30 @@ using System.Diagnostics;
 
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Acumula métricas de uso e tempo para operações no banco em memória.
+/// </summary>
 public sealed class DbMetrics
 {
+    /// <summary>
+    /// Quantidade de consultas SELECT executadas.
+    /// </summary>
     public int Selects { get; internal set; }
+    /// <summary>
+    /// Quantidade de operações INSERT executadas.
+    /// </summary>
     public int Inserts { get; internal set; }
+    /// <summary>
+    /// Quantidade de operações UPDATE executadas.
+    /// </summary>
     public int Updates { get; internal set; }
+    /// <summary>
+    /// Quantidade de operações DELETE executadas.
+    /// </summary>
     public int Deletes { get; internal set; }
+    /// <summary>
+    /// Tempo total decorrido desde o início da coleta.
+    /// </summary>
     public TimeSpan Elapsed => _sw.Elapsed;
 
     private readonly Stopwatch _sw = Stopwatch.StartNew();

--- a/src/DbSqlLikeMem/Models/DbMock.cs
+++ b/src/DbSqlLikeMem/Models/DbMock.cs
@@ -2,12 +2,21 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Base de um banco em memória com schemas, tabelas e procedimentos.
+/// </summary>
 public abstract class DbMock
     : Dictionary<string, SchemaMock>
     , ISchemaDictionary
 {
+    /// <summary>
+    /// Versão do banco simulada.
+    /// </summary>
     public int Version { get; }
 
+    /// <summary>
+    /// Indica se operações devem aplicar bloqueio para segurança de threads.
+    /// </summary>
     public bool ThreadSafe { get; set; }
 
     internal object SyncRoot { get; } = new();
@@ -20,6 +29,10 @@ public abstract class DbMock
 
     ISchemaMock IReadOnlyDictionary<string, ISchemaMock>.this[string key] => throw new NotImplementedException();
 
+    /// <summary>
+    /// Inicializa o banco com a versão informada e um schema padrão.
+    /// </summary>
+    /// <param name="version">Versão simulada do banco.</param>
     protected DbMock(
         int version)
         : base(StringComparer.OrdinalIgnoreCase)
@@ -43,6 +56,12 @@ public abstract class DbMock
         string schemaName,
         IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null);
 
+    /// <summary>
+    /// Cria um schema e o registra no banco.
+    /// </summary>
+    /// <param name="schemaName">Nome do schema.</param>
+    /// <param name="tables">Tabelas iniciais do schema.</param>
+    /// <returns>Schema criado.</returns>
     public ISchemaMock CreateSchema(
         string schemaName,
         IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null)
@@ -65,6 +84,12 @@ public abstract class DbMock
         return schemaName.NormalizeName();
     }
 
+    /// <summary>
+    /// Tenta obter um schema pelo nome.
+    /// </summary>
+    /// <param name="key">Nome do schema.</param>
+    /// <param name="value">Schema encontrado, se houver.</param>
+    /// <returns>True se o schema existir.</returns>
     public bool TryGetValue(
         string key,
         [MaybeNullWhen(false)] out ISchemaMock value
@@ -83,6 +108,14 @@ public abstract class DbMock
 
     #region Table
 
+    /// <summary>
+    /// Cria e adiciona uma tabela ao schema indicado.
+    /// </summary>
+    /// <param name="tableName">Nome da tabela.</param>
+    /// <param name="columns">Definição das colunas.</param>
+    /// <param name="rows">Linhas iniciais.</param>
+    /// <param name="schemaName">Schema alvo.</param>
+    /// <returns>Tabela criada.</returns>
     public ITableMock AddTable(
         string tableName,
         IColumnDictionary? columns = null,
@@ -95,6 +128,12 @@ public abstract class DbMock
         return s.CreateTable(tableName, columns ?? new ColumnDictionary(), rows);
     }
 
+    /// <summary>
+    /// Obtém uma tabela pelo nome, lançando erro se não existir.
+    /// </summary>
+    /// <param name="tableName">Nome da tabela.</param>
+    /// <param name="schemaName">Schema alvo.</param>
+    /// <returns>Tabela encontrada.</returns>
     public ITableMock GetTable(
         string tableName,
         string? schemaName = null)
@@ -107,6 +146,13 @@ public abstract class DbMock
         return tb;
     }
 
+    /// <summary>
+    /// Tenta obter uma tabela pelo nome.
+    /// </summary>
+    /// <param name="tableName">Nome da tabela.</param>
+    /// <param name="tb">Tabela encontrada, se houver.</param>
+    /// <param name="schemaName">Schema alvo.</param>
+    /// <returns>True se a tabela existir.</returns>
     public bool TryGetTable(
         string tableName,
         out ITableMock? tb,
@@ -118,6 +164,12 @@ public abstract class DbMock
             && tb != null;
     }
 
+    /// <summary>
+    /// Verifica se uma tabela existe no schema informado.
+    /// </summary>
+    /// <param name="tableName">Nome da tabela.</param>
+    /// <param name="schemaName">Schema alvo.</param>
+    /// <returns>True se existir.</returns>
     public bool ContainsTable(
         string tableName,
         string? schemaName = null)
@@ -196,6 +248,12 @@ public abstract class DbMock
 
     #region Procedures
 
+    /// <summary>
+    /// Registra um procedimento armazenado no schema informado.
+    /// </summary>
+    /// <param name="procName">Nome do procedimento.</param>
+    /// <param name="pr">Definição do procedimento.</param>
+    /// <param name="schemaName">Schema alvo.</param>
     public void AddProdecure(
         string procName,
         ProcedureDef pr,
@@ -208,6 +266,13 @@ public abstract class DbMock
         this[sc].Procedures[procName] = pr;
     }
 
+    /// <summary>
+    /// Tenta obter um procedimento armazenado pelo nome.
+    /// </summary>
+    /// <param name="procName">Nome do procedimento.</param>
+    /// <param name="pr">Procedimento encontrado, se houver.</param>
+    /// <param name="schemaName">Schema alvo.</param>
+    /// <returns>True se existir.</returns>
     public bool TryGetProcedure(
         string procName,
         out ProcedureDef? pr,

--- a/src/DbSqlLikeMem/Models/IndexDef.cs
+++ b/src/DbSqlLikeMem/Models/IndexDef.cs
@@ -1,13 +1,35 @@
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Representa a definição de um índice, incluindo colunas-chave e unicidade.
+/// </summary>
 public class IndexDef
 {
+    /// <summary>
+    /// Obtém o nome do índice.
+    /// </summary>
     public string Name { get; }
+    /// <summary>
+    /// Obtém as colunas que compõem a chave do índice.
+    /// </summary>
     public IReadOnlyList<string> KeyCols { get; }
+    /// <summary>
+    /// Indica se o índice é único.
+    /// </summary>
     public bool Unique { get; }
 
+    /// <summary>
+    /// Obtém colunas incluídas no índice, mas não fazem parte da chave.
+    /// </summary>
     public IReadOnlyList<string> Include { get; }
 
+    /// <summary>
+    /// Inicializa a definição do índice.
+    /// </summary>
+    /// <param name="name">Nome do índice.</param>
+    /// <param name="keyCols">Colunas chave do índice.</param>
+    /// <param name="include">Colunas incluídas adicionais.</param>
+    /// <param name="unique">Indica se o índice é único.</param>
     public IndexDef(
         string name,
         IEnumerable<string> keyCols,

--- a/src/DbSqlLikeMem/Models/IndexDictionary.cs
+++ b/src/DbSqlLikeMem/Models/IndexDictionary.cs
@@ -1,10 +1,20 @@
 namespace DbSqlLikeMem;
+/// <summary>
+/// Implementa um dicionário de índices com comparação case-insensitive.
+/// </summary>
 public class IndexDictionary : Dictionary<string, IndexDef>
 {
+    /// <summary>
+    /// Inicializa o dicionário de índices ignorando maiúsculas/minúsculas.
+    /// </summary>
     public IndexDictionary() : base(StringComparer.OrdinalIgnoreCase)
     {
     }
 
+    /// <summary>
+    /// Retorna apenas os índices marcados como únicos.
+    /// </summary>
+    /// <returns>Conjunto de índices únicos.</returns>
     public IEnumerable<IndexDef> GetUnique()
         => Values.Where(i => i.Unique);
 }

--- a/src/DbSqlLikeMem/Models/ProcedureDef.cs
+++ b/src/DbSqlLikeMem/Models/ProcedureDef.cs
@@ -1,8 +1,7 @@
 namespace DbSqlLikeMem;
 
 /// <summary>
-/// Signature-only stored procedure contract used by <see cref="MySqlConnectionMock"/>.
-/// No execution body is modeled yet; only parameter validation and OUT defaults.
+/// Representa um parâmetro de procedimento armazenado, com tipo e valor padrão.
 /// </summary>
 public sealed record ProcParam(
     string Name,
@@ -10,12 +9,20 @@ public sealed record ProcParam(
     bool Required = true,
     object? Value = null);
 
+/// <summary>
+/// Define a assinatura de um procedimento armazenado em memória.
+/// </summary>
 public sealed record ProcedureDef(
     IReadOnlyList<ProcParam> RequiredIn,
     IReadOnlyList<ProcParam> OptionalIn,
     IReadOnlyList<ProcParam> OutParams,
     ProcParam? ReturnParam = null)
 {
+    /// <summary>
+    /// Normaliza o nome do parâmetro removendo prefixos e espaços.
+    /// </summary>
+    /// <param name="name">Nome a normalizar.</param>
+    /// <returns>Nome normalizado.</returns>
     public static string NormalizeParamName(string name)
     {
         if (string.IsNullOrWhiteSpace(name)) return string.Empty;

--- a/src/DbSqlLikeMem/Models/SchemaDictionary.cs
+++ b/src/DbSqlLikeMem/Models/SchemaDictionary.cs
@@ -1,13 +1,23 @@
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Implementa um dicionário de schemas com comparação case-insensitive.
+/// </summary>
 public class SchemaDictionary 
     : Dictionary<string, ISchemaMock>
 {
+    /// <summary>
+    /// Cria um dicionário de schemas vazio.
+    /// </summary>
     public SchemaDictionary()
         : base(StringComparer.OrdinalIgnoreCase)
     {
     }
 
+    /// <summary>
+    /// Cria um dicionário de schemas a partir de outro conjunto.
+    /// </summary>
+    /// <param name="schemas">Schemas iniciais.</param>
     public SchemaDictionary(
         IDictionary<string, ISchemaMock>? schemas)
     : base(StringComparer.OrdinalIgnoreCase)

--- a/src/DbSqlLikeMem/Models/SchemaMock.cs
+++ b/src/DbSqlLikeMem/Models/SchemaMock.cs
@@ -2,10 +2,20 @@ using System.Collections;
 
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Base de um schema em memória, responsável por tabelas e procedimentos.
+/// </summary>
 public abstract class SchemaMock 
     : ISchemaMock
     , IEnumerable<KeyValuePair<string, ITableMock>>
 {
+    /// <summary>
+    /// Inicializa o schema com nome, banco e coleções opcionais.
+    /// </summary>
+    /// <param name="schemaName">Nome do schema.</param>
+    /// <param name="db">Instância do banco pai.</param>
+    /// <param name="tables">Configuração inicial de tabelas.</param>
+    /// <param name="procedures">Procedimentos iniciais.</param>
     protected SchemaMock(
         string schemaName,
         DbMock db,
@@ -27,19 +37,34 @@ public abstract class SchemaMock
         //        Views.AddTable(viewName, config);
     }
 
+    /// <summary>
+    /// Nome normalizado do schema.
+    /// </summary>
     public string SchemaName { get; }
 
+    /// <summary>
+    /// Banco ao qual o schema pertence.
+    /// </summary>
     public DbMock Db { get; }
 
-    /// <summary>Underlying table map. Names are normalized on access.</summary>
+    /// <summary>
+    /// Mapa interno de tabelas, com nomes normalizados no acesso.
+    /// </summary>
     public TableDictionary tables = new TableDictionary();
+    /// <summary>
+    /// Exposição das tabelas do schema.
+    /// </summary>
     public ITableDictionary Tables => tables;
 
-    // Stored procedure contracts (signature-only; no body execution yet)
+    /// <summary>
+    /// Contratos de procedimentos armazenados (apenas assinatura).
+    /// </summary>
     public IDictionary<string, ProcedureDef> Procedures { get; } =
         new Dictionary<string, ProcedureDef>(StringComparer.OrdinalIgnoreCase);
 
-    // Non-materialized views (definition only). Evaluated on demand at execution time.
+    /// <summary>
+    /// Views não materializadas (somente definição) avaliadas sob demanda.
+    /// </summary>
     internal IDictionary<string, SqlSelectQuery> Views { get; } =
         new Dictionary<string, SqlSelectQuery>(StringComparer.OrdinalIgnoreCase);
 
@@ -48,6 +73,13 @@ public abstract class SchemaMock
         IColumnDictionary columns,
         IEnumerable<Dictionary<int, object?>>? rows = null);
 
+    /// <summary>
+    /// Cria uma tabela e a registra no schema.
+    /// </summary>
+    /// <param name="tableName">Nome da tabela.</param>
+    /// <param name="columns">Colunas da tabela.</param>
+    /// <param name="rows">Linhas iniciais.</param>
+    /// <returns>Tabela criada.</returns>
     public TableMock CreateTable(
         string tableName,
         IColumnDictionary columns,
@@ -60,6 +92,11 @@ public abstract class SchemaMock
 
     #region Tables
 
+    /// <summary>
+    /// Adiciona uma tabela ao schema.
+    /// </summary>
+    /// <param name="key">Nome da tabela.</param>
+    /// <param name="table">Tabela a adicionar.</param>
     public void Add(string key, ITableMock table)
     {
         ArgumentNullException.ThrowIfNull(key);
@@ -87,19 +124,37 @@ public abstract class SchemaMock
         tables.Add(key, table);
     }
 
+    /// <summary>
+    /// Tenta obter uma tabela pelo nome.
+    /// </summary>
+    /// <param name="key">Nome da tabela.</param>
+    /// <param name="value">Tabela encontrada, se houver.</param>
+    /// <returns>True se a tabela existir.</returns>
     public bool TryGetTable(string key, out ITableMock? value)
         => tables.TryGetValue(key.NormalizeName(), out value);
 
+    /// <summary>
+    /// Obtém ou define uma tabela pelo nome.
+    /// </summary>
     public ITableMock this[string key]
     {
         get => tables[key.NormalizeName()];
         set => tables[key.NormalizeName()] = value;
     }
 
+    /// <summary>
+    /// Retorna os nomes das tabelas do schema.
+    /// </summary>
     public IEnumerable<string> Keys => tables.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Retorna as tabelas do schema.
+    /// </summary>
     public IEnumerable<ITableMock> Values => tables.Values;
 
+    /// <summary>
+    /// Retorna enumerador das tabelas do schema.
+    /// </summary>
     public IEnumerator<KeyValuePair<string, ITableMock>> GetEnumerator()
         => tables.GetEnumerator();
 
@@ -108,18 +163,27 @@ public abstract class SchemaMock
 
     #region Backup / Restore (best-effort)
 
+    /// <summary>
+    /// Faz backup de todas as tabelas do schema.
+    /// </summary>
     public virtual void BackupAllTablesBestEffort()
     {
         foreach (var table in tables.Values)
             table.Backup();
     }
 
+    /// <summary>
+    /// Restaura backup de todas as tabelas do schema.
+    /// </summary>
     public virtual void RestoreAllTablesBestEffort()
     {
         foreach (var table in tables.Values)
             table.Restore();
     }
 
+    /// <summary>
+    /// Limpa backup de todas as tabelas do schema.
+    /// </summary>
     public virtual void ClearBackupAllTablesBestEffort()
     {
         foreach (var table in tables.Values)

--- a/src/DbSqlLikeMem/Models/TableDictionary.cs
+++ b/src/DbSqlLikeMem/Models/TableDictionary.cs
@@ -1,14 +1,24 @@
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Implementa um dicionário de tabelas com comparação case-insensitive.
+/// </summary>
 public class TableDictionary
     : Dictionary<string, ITableMock>,
     ITableDictionary
 {
+    /// <summary>
+    /// Cria um dicionário de tabelas vazio.
+    /// </summary>
     public TableDictionary()
         : base(StringComparer.OrdinalIgnoreCase)
     {
     }
 
+    /// <summary>
+    /// Cria um dicionário de tabelas a partir de outro conjunto.
+    /// </summary>
+    /// <param name="tables">Tabelas iniciais.</param>
     public TableDictionary(
         IDictionary<string, ITableMock>? tables)
     : base(StringComparer.OrdinalIgnoreCase)

--- a/src/DbSqlLikeMem/Models/TableMock.cs
+++ b/src/DbSqlLikeMem/Models/TableMock.cs
@@ -2,11 +2,21 @@ using System.Collections.Concurrent;
 
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// Base de uma tabela em memória com dados, colunas e índices.
+/// </summary>
 public abstract class TableMock
     : List<Dictionary<int, object?>>,
     ITableMock
 {
 
+    /// <summary>
+    /// Inicializa a tabela com nome, schema e colunas, com linhas opcionais.
+    /// </summary>
+    /// <param name="tableName">Nome da tabela.</param>
+    /// <param name="schema">Schema pai.</param>
+    /// <param name="columns">Colunas da tabela.</param>
+    /// <param name="rows">Linhas iniciais.</param>
     protected TableMock(
         string tableName,
         SchemaMock schema,
@@ -19,21 +29,42 @@ public abstract class TableMock
         AddRange(rows ?? []);
     }
 
+    /// <summary>
+    /// Nome normalizado da tabela.
+    /// </summary>
     public string TableName { get; }
+    /// <summary>
+    /// Schema ao qual a tabela pertence.
+    /// </summary>
     public SchemaMock Schema { get; }
+    /// <summary>
+    /// Próximo valor de identidade para colunas auto incrementais.
+    /// </summary>
     public int NextIdentity { get; set; } = 1;
 
+    /// <summary>
+    /// Dicionário de colunas da tabela.
+    /// </summary>
     public IColumnDictionary Columns { get; }
 
     // ---------- Wave D : índices ---------------------------------
+    /// <summary>
+    /// Índices das colunas que formam a chave primária.
+    /// </summary>
     public HashSet<int> PrimaryKeyIndexes { get; } = [];
 
 #pragma warning disable CA1002 // Do not expose generic lists
     private readonly List<(string Col, string RefTable, string RefCol)> _foreignKeys = [];
+    /// <summary>
+    /// Lista de chaves estrangeiras definidas na tabela.
+    /// </summary>
     public IReadOnlyList<(string Col, string RefTable, string RefCol)> ForeignKeys => _foreignKeys;
 #pragma warning restore CA1002 // Do not expose generic lists
 
 #pragma warning disable CA1002 // Do not expose generic lists
+    /// <summary>
+    /// Índices declarados na tabela.
+    /// </summary>
     public IndexDictionary Indexes { get; } = [];
 #pragma warning restore CA1002 // Do not expose generic lists
 
@@ -53,6 +84,10 @@ public abstract class TableMock
         return info;
     }
 
+    /// <summary>
+    /// Cria e registra um índice na tabela.
+    /// </summary>
+    /// <param name="def">Definição do índice.</param>
     public void CreateIndex(IndexDef def)
     {
         ArgumentNullException.ThrowIfNull(def);
@@ -78,6 +113,12 @@ public abstract class TableMock
         _ix[name] = map;
     }
 
+    /// <summary>
+    /// Procura valores no índice usando a chave informada.
+    /// </summary>
+    /// <param name="def">Definição do índice.</param>
+    /// <param name="key">Chave a buscar.</param>
+    /// <returns>Lista de posições ou null.</returns>
     public IEnumerable<int>? Lookup(IndexDef def, string key)
     {
         ArgumentNullException.ThrowIfNull(def);
@@ -87,6 +128,10 @@ public abstract class TableMock
             : null;
     }
 
+    /// <summary>
+    /// Atualiza os índices após inserir ou alterar uma linha.
+    /// </summary>
+    /// <param name="rowIdx">Índice da linha alterada.</param>
     public void UpdateIndexesWithRow(int rowIdx)
     {
         foreach (var (name, def) in Indexes)
@@ -96,6 +141,9 @@ public abstract class TableMock
         }
     }
 
+    /// <summary>
+    /// Reconstrói todos os índices da tabela.
+    /// </summary>
     public void RebuildAllIndexes()
     {
         foreach (var ix in Indexes)
@@ -114,6 +162,11 @@ public abstract class TableMock
         _foreignKeys.Add((col, refTable, refCol));
     }
 
+    /// <summary>
+    /// Adiciona vários itens convertendo-os em linhas.
+    /// </summary>
+    /// <typeparam name="T">Tipo dos itens.</typeparam>
+    /// <param name="items">Itens a inserir.</param>
     public void AddRangeItems<T>(IEnumerable<T> items)
     {
         ArgumentNullException.ThrowIfNull(items);
@@ -121,6 +174,10 @@ public abstract class TableMock
             AddItem(item);
     }
 
+    /// <summary>
+    /// Adiciona linhas já materializadas.
+    /// </summary>
+    /// <param name="items">Linhas a inserir.</param>
     public new void AddRange(IEnumerable<Dictionary<int, object?>> items)
     {
         ArgumentNullException.ThrowIfNull(items);
@@ -128,6 +185,11 @@ public abstract class TableMock
             Add(item);
     }
 
+    /// <summary>
+    /// Adiciona um item convertendo-o em linha da tabela.
+    /// </summary>
+    /// <typeparam name="T">Tipo do item.</typeparam>
+    /// <param name="item">Item a inserir.</param>
     public void AddItem<T>(T item)
     {
         ArgumentNullException.ThrowIfNull(item);
@@ -164,6 +226,10 @@ public abstract class TableMock
         Add(row);
     }
 
+    /// <summary>
+    /// Adiciona uma linha garantindo valores padrão e unicidade.
+    /// </summary>
+    /// <param name="value">Linha a inserir.</param>
     public new void Add(Dictionary<int, object?> value)
     {
         ApplyDefaultValues(value);
@@ -198,8 +264,14 @@ public abstract class TableMock
 
     private List<Dictionary<int, object?>>? _backup;
 
+    /// <summary>
+    /// Faz backup das linhas atuais.
+    /// </summary>
     public void Backup() => _backup = [.. this.Select(row => new Dictionary<int, object?>(row))];
 
+    /// <summary>
+    /// Restaura o backup anterior, se existir.
+    /// </summary>
     public void Restore()
     {
         if (_backup == null)
@@ -212,9 +284,24 @@ public abstract class TableMock
             RebuildIndex(ix.Value);
     }
 
+    /// <summary>
+    /// Limpa o backup armazenado.
+    /// </summary>
     public void ClearBackup() => _backup = null;
 
+    /// <summary>
+    /// Obtém ou define a coluna atualmente em avaliação.
+    /// </summary>
     public abstract string? CurrentColumn { get; set; }
+    /// <summary>
+    /// Resolve um token para um valor no contexto da tabela.
+    /// </summary>
+    /// <param name="token">Token a resolver.</param>
+    /// <param name="dbType">Tipo esperado.</param>
+    /// <param name="isNullable">Se o valor pode ser nulo.</param>
+    /// <param name="pars">Parâmetros de consulta.</param>
+    /// <param name="colDict">Dicionário de colunas opcional.</param>
+    /// <returns>Valor resolvido.</returns>
     public abstract object? Resolve(
         string token,
         DbType dbType,
@@ -222,9 +309,32 @@ public abstract class TableMock
         IDataParameterCollection? pars = null,
         IColumnDictionary? colDict = null);
 
+    /// <summary>
+    /// Cria exceção para coluna inexistente.
+    /// </summary>
+    /// <param name="columnName">Nome da coluna.</param>
     public abstract Exception UnknownColumn(string columnName);
+    /// <summary>
+    /// Cria exceção para chave duplicada.
+    /// </summary>
+    /// <param name="tbl">Tabela afetada.</param>
+    /// <param name="key">Nome da chave.</param>
+    /// <param name="val">Valor duplicado.</param>
     public abstract Exception DuplicateKey(string tbl, string key, object? val);
+    /// <summary>
+    /// Cria exceção para coluna que não aceita nulos.
+    /// </summary>
+    /// <param name="col">Nome da coluna.</param>
     public abstract Exception ColumnCannotBeNull(string col);
+    /// <summary>
+    /// Cria exceção para violação de chave estrangeira.
+    /// </summary>
+    /// <param name="col">Coluna que referencia.</param>
+    /// <param name="refTbl">Tabela referenciada.</param>
     public abstract Exception ForeignKeyFails(string col, string refTbl);
+    /// <summary>
+    /// Cria exceção para tentativa de remover linha referenciada.
+    /// </summary>
+    /// <param name="tbl">Tabela referenciada.</param>
     public abstract Exception ReferencedRow(string tbl);
 }

--- a/src/DbSqlLikeMem/Query/TableResultMock.cs
+++ b/src/DbSqlLikeMem/Query/TableResultMock.cs
@@ -1,13 +1,28 @@
 using System.Diagnostics.CodeAnalysis;
 
 namespace DbSqlLikeMem;
+/// <summary>
+/// Representa o resultado de uma consulta como uma lista de linhas indexadas por coluna,
+/// usado para transportar dados retornados pela execução do SQL em memória.
+/// </summary>
 public class TableResultMock : List<Dictionary<int, object?>>
 {
+    /// <summary>
+    /// Define a lista de colunas presentes no resultado, com seus metadados.
+    /// </summary>
     public IList<TableResultColMock> Columns
     { get; internal set; } = [];
 
+    /// <summary>
+    /// Mantém os campos auxiliares usados em joins para compor resultados combinados.
+    /// </summary>
     public IList<Dictionary<string, object?>> JoinFields { get; internal set; } = [];
 
+    /// <summary>
+    /// Obtém o índice da coluna pelo alias ou nome e lança exceção se não encontrar.
+    /// </summary>
+    /// <param name="col">Nome ou alias da coluna a localizar.</param>
+    /// <returns>Índice da coluna no resultado.</returns>
     public int GetColumnIndexOrThrow(string col)
     {
         var found = Columns.FirstOrDefault(c =>
@@ -19,8 +34,20 @@ public class TableResultMock : List<Dictionary<int, object?>>
 }
 
 
+/// <summary>
+/// Describe metadados de uma coluna dentro de um resultado de consulta.
+/// </summary>
 public class TableResultColMock
 {
+    /// <summary>
+    /// Inicializa um metadado de coluna com alias, nome e tipo.
+    /// </summary>
+    /// <param name="tableAlias">Alias da tabela no resultado.</param>
+    /// <param name="columnAlias">Alias da coluna no resultado.</param>
+    /// <param name="columnName">Nome real da coluna.</param>
+    /// <param name="columIndex">Posição da coluna no resultado.</param>
+    /// <param name="dbType">Tipo do dado no resultado.</param>
+    /// <param name="isNullable">Indica se a coluna aceita valores nulos.</param>
     [SetsRequiredMembers]
     public TableResultColMock(
         string tableAlias,
@@ -39,10 +66,28 @@ public class TableResultColMock
         IsNullable = isNullable;
     }
 
+    /// <summary>
+    /// Alias da tabela associado à coluna.
+    /// </summary>
     public required string TableAlias { get; set; }
+    /// <summary>
+    /// Alias da coluna no resultado.
+    /// </summary>
     public required string ColumnAlias { get; set; }
+    /// <summary>
+    /// Nome real da coluna na tabela de origem.
+    /// </summary>
     public required string ColumnName { get; set; }
+    /// <summary>
+    /// Índice da coluna no conjunto de resultados.
+    /// </summary>
     public int ColumIndex { get; set; }
+    /// <summary>
+    /// Tipo do dado retornado pela coluna.
+    /// </summary>
     public DbType DbType { get; set; }
+    /// <summary>
+    /// Indica se o valor da coluna pode ser nulo.
+    /// </summary>
     public bool IsNullable { get; set; }
 }

--- a/src/DbSqlLikeMem/SqlMockException.cs
+++ b/src/DbSqlLikeMem/SqlMockException.cs
@@ -1,21 +1,44 @@
 namespace DbSqlLikeMem;
 
 #pragma warning disable CA1032 // Implement standard exception constructors
+/// <summary>
+/// Exceção base para erros simulados do banco em memória, com código de erro.
+/// </summary>
 public class SqlMockException : Exception
 #pragma warning restore CA1032 // Implement standard exception constructors
 {
+    /// <summary>
+    /// Obtém o código de erro associado à falha.
+    /// </summary>
     public int ErrorCode { get; }
+    /// <summary>
+    /// Inicializa a exceção com mensagem e código de erro.
+    /// </summary>
+    /// <param name="message">Mensagem do erro.</param>
+    /// <param name="code">Código do erro.</param>
     public SqlMockException(string message, int code)
         : base(message) => ErrorCode = code;
 
+    /// <summary>
+    /// Inicializa a exceção com valores padrão.
+    /// </summary>
     public SqlMockException() : base()
     {
     }
 
+    /// <summary>
+    /// Inicializa a exceção com mensagem opcional.
+    /// </summary>
+    /// <param name="message">Mensagem do erro.</param>
     public SqlMockException(string? message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Inicializa a exceção com mensagem e exceção interna.
+    /// </summary>
+    /// <param name="message">Mensagem do erro.</param>
+    /// <param name="innerException">Exceção interna.</param>
     public SqlMockException(string? message, Exception? innerException) : base(message, innerException)
     {
     }


### PR DESCRIPTION
### Motivation
- Provide clear XML documentation in Portuguese for public APIs so developers understand what each class, method and property is and what it is used for.
- Improve maintainability and discoverability of the in-memory DB mock by documenting contracts, metadata types and base behaviors.

### Description
- Added XML summaries to core public interfaces such as `ITableMock`, `ISchemaMock`, `ISchemaDictionary`, `ITableDictionary` and `IColumnDictionary` to explain their contracts, parameters and return expectations.
- Documented models and helpers including `ColumnDef`, `IndexDef`, `IndexDictionary`, `ColumnDictionary`, `TableMock`, `TableDictionary`, `SchemaMock`, `SchemaDictionary`, `DbMock`, `ProcedureDef`, `TableResultMock` and `TableResultColMock` to describe metadata shapes and common behaviors.
- Documented base classes and runtime helpers including `DbConnectionMockBase`, `DbDataReaderMockBase`, `DbMetrics` and `SqlMockException` to clarify transaction/connection semantics, reader behavior and exception semantics.
- Total of 20 source files modified to add concise Portuguese XML summaries and parameter/return explanations for public API members.

### Testing
- No automated tests were executed because this is a documentation-only change and does not alter runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a24225430832c8ccb49e60fadbbde)