### PR TITLE
Add bilingual XML docs for protected members

### DIFF
--- a/src/DbSqlLikeMem.MySql.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/DapperTests.cs
@@ -206,6 +206,11 @@ UPDATE users
         Assert.Equal(dt2, emails[1].CreatedDate);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/src/DbSqlLikeMem.MySql.Test/MySqlAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlAdditionalBehaviorCoverageTests.cs
@@ -168,6 +168,11 @@ ORDER BY userid
         Assert.Equal(0, (int)counters[2].counter);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlAdvancedSqlGapTests.cs
@@ -105,6 +105,11 @@ ORDER BY id").ToList();
         Assert.Equal([1], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlAggregationTests.cs
@@ -72,6 +72,11 @@ public sealed class MySqlAggregationTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].userId);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlJoinTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlJoinTests.cs
@@ -88,6 +88,11 @@ public sealed class MySqlJoinTests : XUnitTestBase
         Assert.Equal(10, (int)rows[0].orderId);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs
@@ -147,6 +147,11 @@ public sealed class MySqlMockTests
         Assert.Empty(users);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _connection.Dispose();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlSelectAndWhereMoreCoverageTests.cs
@@ -84,6 +84,11 @@ ORDER BY id").ToList();
         Assert.Equal("(none)", (string)row.em);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlSqlCompatibilityGapTests.cs
@@ -209,6 +209,11 @@ ORDER BY id
         Assert.Equal(2, (int)rows2[0].id);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs
@@ -67,6 +67,11 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([123m, 456m, null], [.. rows.Select(r => (object?)r.v)]);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlWhereParserAndExecutorTests.cs
@@ -73,6 +73,11 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.MySql.Test/Views/MySqlCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Views/MySqlCreateViewEngineTests.cs
@@ -127,6 +127,11 @@ GROUP BY u.id;
         Assert.ThrowsAny<Exception>(() => _cnn.QueryRows("SELECT * FROM vdrop"));
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn.Dispose();

--- a/src/DbSqlLikeMem.MySql/Models/MySqlDbMock.cs
+++ b/src/DbSqlLikeMem.MySql/Models/MySqlDbMock.cs
@@ -12,6 +12,13 @@ public class MySqlDbMock
         Dialect = new MySqlDialect(Version);
     }
 
+    /// <summary>
+    /// EN: Creates a MySQL schema mock instance.
+    /// PT: Cria uma instância de mock de schema MySQL.
+    /// </summary>
+    /// <param name="schemaName">EN: Schema name. PT: Nome do schema.</param>
+    /// <param name="tables">EN: Initial tables. PT: Tabelas iniciais.</param>
+    /// <returns>EN: Schema mock. PT: Mock de schema.</returns>
     protected override SchemaMock NewSchema(
         string schemaName,
         IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null

--- a/src/DbSqlLikeMem.MySql/Models/MySqlSchemaMock.cs
+++ b/src/DbSqlLikeMem.MySql/Models/MySqlSchemaMock.cs
@@ -6,6 +6,14 @@ public class MySqlSchemaMock(
     IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null
     ) : SchemaMock(schemaName, db, tables)
 {
+    /// <summary>
+    /// EN: Creates a MySQL table mock for this schema.
+    /// PT: Cria um mock de tabela MySQL para este schema.
+    /// </summary>
+    /// <param name="tableName">EN: Table name. PT: Nome da tabela.</param>
+    /// <param name="columns">EN: Table columns. PT: Colunas da tabela.</param>
+    /// <param name="rows">EN: Initial rows. PT: Linhas iniciais.</param>
+    /// <returns>EN: Table mock. PT: Mock de tabela.</returns>
     protected override TableMock NewTable(
         string tableName,
         IColumnDictionary columns,

--- a/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
@@ -16,6 +16,10 @@ public class MySqlCommandMock(
 
     public override int CommandTimeout { get; set; }
     public override CommandType CommandType { get; set; } = CommandType.Text;
+    /// <summary>
+    /// EN: Gets or sets the associated connection.
+    /// PT: Obtém ou define a conexão associada.
+    /// </summary>
     protected override DbConnection? DbConnection
     {
         get => connection;
@@ -23,8 +27,16 @@ public class MySqlCommandMock(
     }
 
     private readonly MySqlDataParameterCollectionMock collectionMock = [];
+    /// <summary>
+    /// EN: Gets the parameter collection for the command.
+    /// PT: Obtém a coleção de parâmetros do comando.
+    /// </summary>
     protected override DbParameterCollection DbParameterCollection => collectionMock;
 
+    /// <summary>
+    /// EN: Gets or sets the current transaction.
+    /// PT: Obtém ou define a transação atual.
+    /// </summary>
     protected override DbTransaction? DbTransaction
     {
         get => transaction!;
@@ -36,6 +48,11 @@ public class MySqlCommandMock(
 
     public override void Cancel() => DbTransaction?.Rollback();
 
+    /// <summary>
+    /// EN: Creates a new MySQL parameter.
+    /// PT: Cria um novo parâmetro MySQL.
+    /// </summary>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter CreateDbParameter()
         => new MySqlParameter();
 
@@ -95,6 +112,12 @@ public class MySqlCommandMock(
         };
     }
 
+    /// <summary>
+    /// EN: Executes the command and returns a data reader.
+    /// PT: Executa o comando e retorna um data reader.
+    /// </summary>
+    /// <param name="behavior">EN: Command behavior. PT: Comportamento do comando.</param>
+    /// <returns>EN: Data reader. PT: Data reader.</returns>
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
     {
         ArgumentNullException.ThrowIfNull(connection);
@@ -186,6 +209,11 @@ public class MySqlCommandMock(
 
     public override void Prepare() { }
 
+    /// <summary>
+    /// EN: Disposes the command and resources.
+    /// PT: Descarta o comando e os recursos.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (!disposedValue)

--- a/src/DbSqlLikeMem.MySql/MySqlConnectionMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlConnectionMock.cs
@@ -13,9 +13,20 @@ public sealed class MySqlConnectionMock
         _serverVersion = $"MySQL {Db.Version}";
     }
 
+    /// <summary>
+    /// EN: Creates a MySQL transaction mock.
+    /// PT: Cria um mock de transação MySQL.
+    /// </summary>
+    /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
     protected override DbTransaction CreateTransaction()
         => new MySqlTransactionMock(this);
 
+    /// <summary>
+    /// EN: Creates a MySQL command mock for the transaction.
+    /// PT: Cria um mock de comando MySQL para a transação.
+    /// </summary>
+    /// <param name="transaction">EN: Current transaction. PT: Transação atual.</param>
+    /// <returns>EN: Command instance. PT: Instância do comando.</returns>
     protected override DbCommand CreateDbCommandCore(DbTransaction? transaction)
         => new MySqlCommandMock(this, transaction as MySqlTransactionMock);
 

--- a/src/DbSqlLikeMem.MySql/MySqlDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDataParameterCollectionMock.cs
@@ -43,8 +43,20 @@ public class MySqlDataParameterCollectionMock
         { } other => other,
     };
 
+    /// <summary>
+    /// EN: Gets a parameter by index.
+    /// PT: Obtém um parâmetro pelo índice.
+    /// </summary>
+    /// <param name="index">EN: Parameter index. PT: Índice do parâmetro.</param>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter GetParameter(int index) => Items[index];
 
+    /// <summary>
+    /// EN: Gets a parameter by name.
+    /// PT: Obtém um parâmetro pelo nome.
+    /// </summary>
+    /// <param name="parameterName">EN: Parameter name. PT: Nome do parâmetro.</param>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter GetParameter(string parameterName)
     {
         var index = IndexOf(parameterName);
@@ -53,6 +65,12 @@ public class MySqlDataParameterCollectionMock
         return Items[index];
     }
 
+    /// <summary>
+    /// EN: Sets a parameter by index.
+    /// PT: Define um parâmetro pelo índice.
+    /// </summary>
+    /// <param name="index">EN: Parameter index. PT: Índice do parâmetro.</param>
+    /// <param name="value">EN: Parameter value. PT: Valor do parâmetro.</param>
     protected override void SetParameter(int index, DbParameter value)
     {
         ArgumentNullException.ThrowIfNull(value);
@@ -67,6 +85,12 @@ public class MySqlDataParameterCollectionMock
             DicItems.Add(newNormalizedParameterName, index);
     }
 
+    /// <summary>
+    /// EN: Sets a parameter by name.
+    /// PT: Define um parâmetro pelo nome.
+    /// </summary>
+    /// <param name="parameterName">EN: Parameter name. PT: Nome do parâmetro.</param>
+    /// <param name="value">EN: Parameter value. PT: Valor do parâmetro.</param>
     protected override void SetParameter(string parameterName, DbParameter value)
         => SetParameter(IndexOf(parameterName), value);
 

--- a/src/DbSqlLikeMem.MySql/MySqlTransactionMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlTransactionMock.cs
@@ -9,6 +9,10 @@ public class MySqlTransactionMock(
 {
     private bool disposedValue;
 
+    /// <summary>
+    /// EN: Gets the connection associated with this transaction.
+    /// PT: Obtém a conexão associada a esta transação.
+    /// </summary>
     protected override DbConnection? DbConnection => cnn;
 
     public override IsolationLevel IsolationLevel
@@ -32,6 +36,11 @@ public class MySqlTransactionMock(
         }
     }
 
+    /// <summary>
+    /// EN: Disposes the transaction resources.
+    /// PT: Descarta os recursos da transação.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (!disposedValue)

--- a/src/DbSqlLikeMem.MySql/MySqlTranslator.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlTranslator.cs
@@ -58,6 +58,12 @@ public class MySqlTranslator : ExpressionVisitor
     }
 
 #pragma warning disable CS8605 // Unboxing a possibly null value.
+    /// <summary>
+    /// EN: Translates method calls into MySQL expressions.
+    /// PT: Traduz chamadas de método em expressões MySQL.
+    /// </summary>
+    /// <param name="node">EN: Method call expression. PT: Expressão de chamada de método.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitMethodCall(MethodCallExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -124,6 +130,12 @@ public class MySqlTranslator : ExpressionVisitor
     }
 #pragma warning restore CS8605 // Unboxing a possibly null value.
 
+    /// <summary>
+    /// EN: Translates constants into MySQL literals.
+    /// PT: Traduz constantes em literais MySQL.
+    /// </summary>
+    /// <param name="node">EN: Constant expression. PT: Expressão constante.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitConstant(ConstantExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -161,6 +173,12 @@ public class MySqlTranslator : ExpressionVisitor
         return node;
     }
 
+    /// <summary>
+    /// EN: Translates binary expressions into MySQL syntax.
+    /// PT: Traduz expressões binárias para a sintaxe MySQL.
+    /// </summary>
+    /// <param name="node">EN: Binary expression. PT: Expressão binária.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitBinary(BinaryExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -180,6 +198,12 @@ public class MySqlTranslator : ExpressionVisitor
         return node;
     }
 
+    /// <summary>
+    /// EN: Translates member access into MySQL expressions.
+    /// PT: Traduz acesso a membros em expressões MySQL.
+    /// </summary>
+    /// <param name="node">EN: Member expression. PT: Expressão de membro.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitMember(MemberExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);

--- a/src/DbSqlLikeMem.Npgsql.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/DapperTests.cs
@@ -207,6 +207,11 @@ UPDATE users
         Assert.Equal(dt2, emails[1].CreatedDate);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdditionalBehaviorCoverageTests.cs
@@ -168,6 +168,11 @@ ORDER BY userid
         Assert.Equal(0, (int)counters[2].counter);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdvancedSqlGapTests.cs
@@ -105,6 +105,11 @@ ORDER BY id").ToList();
         Assert.Equal([1], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAggregationTests.cs
@@ -72,6 +72,11 @@ public sealed class PostgreSqlAggregationTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].userId);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlJoinTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlJoinTests.cs
@@ -88,6 +88,11 @@ public sealed class PostgreSqlJoinTests : XUnitTestBase
         Assert.Equal(10, (int)rows[0].orderId);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlMockTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlMockTests.cs
@@ -146,6 +146,11 @@ public sealed class PostgreSqlMockTests
         Assert.Empty(users);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _connection.Dispose();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSelectAndWhereMoreCoverageTests.cs
@@ -84,6 +84,11 @@ ORDER BY id").ToList();
         Assert.Equal("(none)", (string)row.em);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSqlCompatibilityGapTests.cs
@@ -209,6 +209,11 @@ ORDER BY id
         Assert.Equal(2, (int)rows2[0].id);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs
@@ -59,6 +59,11 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([123m, 456m, null], [.. rows.Select(r => (object?)r.v)]);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlWhereParserAndExecutorTests.cs
@@ -73,6 +73,11 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewEngineTests.cs
@@ -127,6 +127,11 @@ GROUP BY u.id;
         Assert.ThrowsAny<Exception>(() => _cnn.QueryRows("SELECT * FROM vdrop"));
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn.Dispose();

--- a/src/DbSqlLikeMem.Npgsql/Models/NpgsqlDbMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/Models/NpgsqlDbMock.cs
@@ -11,6 +11,13 @@ public class NpgsqlDbMock : DbMock
         Dialect = new NpgsqlDialect(Version);
     }
 
+    /// <summary>
+    /// EN: Creates a PostgreSQL schema mock instance.
+    /// PT: Cria uma instância de mock de schema PostgreSQL.
+    /// </summary>
+    /// <param name="schemaName">EN: Schema name. PT: Nome do schema.</param>
+    /// <param name="tables">EN: Initial tables. PT: Tabelas iniciais.</param>
+    /// <returns>EN: Schema mock. PT: Mock de schema.</returns>
     protected override SchemaMock NewSchema(
         string schemaName,
         IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null

--- a/src/DbSqlLikeMem.Npgsql/Models/NpgsqlSchemaMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/Models/NpgsqlSchemaMock.cs
@@ -6,6 +6,14 @@ public class NpgsqlSchemaMock(
     IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null
     ) : SchemaMock(schemaName, db, tables)
 {
+    /// <summary>
+    /// EN: Creates a PostgreSQL table mock for this schema.
+    /// PT: Cria um mock de tabela PostgreSQL para este schema.
+    /// </summary>
+    /// <param name="tableName">EN: Table name. PT: Nome da tabela.</param>
+    /// <param name="columns">EN: Table columns. PT: Colunas da tabela.</param>
+    /// <param name="rows">EN: Initial rows. PT: Linhas iniciais.</param>
+    /// <returns>EN: Table mock. PT: Mock de tabela.</returns>
     protected override TableMock NewTable(
         string tableName,
         IColumnDictionary columns,

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
@@ -20,6 +20,10 @@ public class NpgsqlCommandMock(
     public override int CommandTimeout { get; set; }
     public override CommandType CommandType { get; set; } = CommandType.Text;
 
+    /// <summary>
+    /// EN: Gets or sets the associated connection.
+    /// PT: Obtém ou define a conexão associada.
+    /// </summary>
     protected override DbConnection? DbConnection
     {
         get => connection;
@@ -27,8 +31,16 @@ public class NpgsqlCommandMock(
     }
 
     private readonly NpgsqlDataParameterCollectionMock collectionMock = [];
+    /// <summary>
+    /// EN: Gets the parameter collection for the command.
+    /// PT: Obtém a coleção de parâmetros do comando.
+    /// </summary>
     protected override DbParameterCollection DbParameterCollection => collectionMock;
 
+    /// <summary>
+    /// EN: Gets or sets the current transaction.
+    /// PT: Obtém ou define a transação atual.
+    /// </summary>
     protected override DbTransaction? DbTransaction
     {
         get => transaction!;
@@ -40,6 +52,11 @@ public class NpgsqlCommandMock(
 
     public override void Cancel() => DbTransaction?.Rollback();
 
+    /// <summary>
+    /// EN: Creates a new PostgreSQL parameter.
+    /// PT: Cria um novo parâmetro PostgreSQL.
+    /// </summary>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter CreateDbParameter()
         // Por enquanto reusa NpgsqlParameter (NpgsqlConnector) para não puxar pacote de SqlClient.
         => new NpgsqlParameter();
@@ -73,6 +90,12 @@ public class NpgsqlCommandMock(
         };
     }
 
+    /// <summary>
+    /// EN: Executes the command and returns a data reader.
+    /// PT: Executa o comando e retorna um data reader.
+    /// </summary>
+    /// <param name="behavior">EN: Command behavior. PT: Comportamento do comando.</param>
+    /// <returns>EN: Data reader. PT: Data reader.</returns>
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
     {
         ArgumentNullException.ThrowIfNull(connection);
@@ -124,6 +147,11 @@ public class NpgsqlCommandMock(
 
     public override void Prepare() { }
 
+    /// <summary>
+    /// EN: Disposes the command and resources.
+    /// PT: Descarta o comando e os recursos.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (!disposedValue)

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlConnectionMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlConnectionMock.cs
@@ -18,9 +18,20 @@ public sealed class NpgsqlConnectionMock
         _serverVersion = $"PostgreSQL {Db.Version}";
     }
 
+    /// <summary>
+    /// EN: Creates a PostgreSQL transaction mock.
+    /// PT: Cria um mock de transação PostgreSQL.
+    /// </summary>
+    /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
     protected override DbTransaction CreateTransaction()
         => new NpgsqlTransactionMock(this);
 
+    /// <summary>
+    /// EN: Creates a PostgreSQL command mock for the transaction.
+    /// PT: Cria um mock de comando PostgreSQL para a transação.
+    /// </summary>
+    /// <param name="transaction">EN: Current transaction. PT: Transação atual.</param>
+    /// <returns>EN: Command instance. PT: Instância do comando.</returns>
     protected override DbCommand CreateDbCommandCore(DbTransaction? transaction)
         => new NpgsqlCommandMock(this, transaction as NpgsqlTransactionMock);
 

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDataParameterCollectionMock.cs
@@ -45,8 +45,20 @@ public class NpgsqlDataParameterCollectionMock
         { } other => other,
     };
 
+    /// <summary>
+    /// EN: Gets a parameter by index.
+    /// PT: Obtém um parâmetro pelo índice.
+    /// </summary>
+    /// <param name="index">EN: Parameter index. PT: Índice do parâmetro.</param>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter GetParameter(int index) => Items[index];
 
+    /// <summary>
+    /// EN: Gets a parameter by name.
+    /// PT: Obtém um parâmetro pelo nome.
+    /// </summary>
+    /// <param name="parameterName">EN: Parameter name. PT: Nome do parâmetro.</param>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter GetParameter(string parameterName)
     {
         var index = IndexOf(parameterName);
@@ -55,6 +67,12 @@ public class NpgsqlDataParameterCollectionMock
         return Items[index];
     }
 
+    /// <summary>
+    /// EN: Sets a parameter by index.
+    /// PT: Define um parâmetro pelo índice.
+    /// </summary>
+    /// <param name="index">EN: Parameter index. PT: Índice do parâmetro.</param>
+    /// <param name="value">EN: Parameter value. PT: Valor do parâmetro.</param>
     protected override void SetParameter(int index, DbParameter value)
     {
         ArgumentNullException.ThrowIfNull(value);
@@ -71,6 +89,12 @@ public class NpgsqlDataParameterCollectionMock
         //newParameter.ParameterCollection = this;
     }
 
+    /// <summary>
+    /// EN: Sets a parameter by name.
+    /// PT: Define um parâmetro pelo nome.
+    /// </summary>
+    /// <param name="parameterName">EN: Parameter name. PT: Nome do parâmetro.</param>
+    /// <param name="value">EN: Parameter value. PT: Valor do parâmetro.</param>
     protected override void SetParameter(string parameterName, DbParameter value)
         => SetParameter(IndexOf(parameterName), value);
 

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlTransactionMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlTransactionMock.cs
@@ -10,6 +10,10 @@ public sealed class NpgsqlTransactionMock(
 {
     private bool disposedValue;
 
+    /// <summary>
+    /// EN: Gets the connection associated with this transaction.
+    /// PT: Obtém a conexão associada a esta transação.
+    /// </summary>
     protected override DbConnection? DbConnection => cnn;
 
     public override IsolationLevel IsolationLevel
@@ -33,6 +37,11 @@ public sealed class NpgsqlTransactionMock(
         }
     }
 
+    /// <summary>
+    /// EN: Disposes the transaction resources.
+    /// PT: Descarta os recursos da transação.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (!disposedValue)

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlTranslator.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlTranslator.cs
@@ -58,6 +58,12 @@ public class NpgsqlTranslator : ExpressionVisitor
     }
 
 #pragma warning disable CS8605 // Unboxing a possibly null value.
+    /// <summary>
+    /// EN: Translates method calls into PostgreSQL expressions.
+    /// PT: Traduz chamadas de método em expressões PostgreSQL.
+    /// </summary>
+    /// <param name="node">EN: Method call expression. PT: Expressão de chamada de método.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitMethodCall(MethodCallExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -124,6 +130,12 @@ public class NpgsqlTranslator : ExpressionVisitor
     }
 #pragma warning restore CS8605 // Unboxing a possibly null value.
 
+    /// <summary>
+    /// EN: Translates constants into PostgreSQL literals.
+    /// PT: Traduz constantes em literais PostgreSQL.
+    /// </summary>
+    /// <param name="node">EN: Constant expression. PT: Expressão constante.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitConstant(ConstantExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -161,6 +173,12 @@ public class NpgsqlTranslator : ExpressionVisitor
         return node;
     }
 
+    /// <summary>
+    /// EN: Translates binary expressions into PostgreSQL syntax.
+    /// PT: Traduz expressões binárias para a sintaxe PostgreSQL.
+    /// </summary>
+    /// <param name="node">EN: Binary expression. PT: Expressão binária.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitBinary(BinaryExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -180,6 +198,12 @@ public class NpgsqlTranslator : ExpressionVisitor
         return node;
     }
 
+    /// <summary>
+    /// EN: Translates member access into PostgreSQL expressions.
+    /// PT: Traduz acesso a membros em expressões PostgreSQL.
+    /// </summary>
+    /// <param name="node">EN: Member expression. PT: Expressão de membro.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitMember(MemberExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);

--- a/src/DbSqlLikeMem.Oracle.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/DapperTests.cs
@@ -206,6 +206,11 @@ UPDATE users
         Assert.Equal(dt2, emails[1].CreatedDate);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAdditionalBehaviorCoverageTests.cs
@@ -168,6 +168,11 @@ ORDER BY userid
         Assert.Equal(0, (int)counters[2].counter);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAdvancedSqlGapTests.cs
@@ -105,6 +105,11 @@ ORDER BY id").ToList();
         Assert.Equal([1], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAggregationTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAggregationTests.cs
@@ -72,6 +72,11 @@ public sealed class OracleAggregationTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].userId);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleJoinTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleJoinTests.cs
@@ -88,6 +88,11 @@ public sealed class OracleJoinTests : XUnitTestBase
         Assert.Equal(10, (int)rows[0].orderId);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleMockTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleMockTests.cs
@@ -147,6 +147,11 @@ public sealed class OracleMockTests
         Assert.Empty(users);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _connection.Dispose();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleSelectAndWhereMoreCoverageTests.cs
@@ -84,6 +84,11 @@ ORDER BY id").ToList();
         Assert.Equal("(none)", (string)row.em);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleSqlCompatibilityGapTests.cs
@@ -209,6 +209,11 @@ ORDER BY id
         Assert.Equal(2, (int)rows2[0].id);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs
@@ -59,6 +59,11 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([123m, 456m, null], [.. rows.Select(r => (object?)r.v)]);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleWhereParserAndExecutorTests.cs
@@ -73,6 +73,11 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewEngineTests.cs
@@ -126,6 +126,11 @@ GROUP BY u.id;
         Assert.ThrowsAny<Exception>(() => _cnn.QueryRows("SELECT * FROM vdrop"));
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn.Dispose();

--- a/src/DbSqlLikeMem.Oracle/Models/OracleDbMock.cs
+++ b/src/DbSqlLikeMem.Oracle/Models/OracleDbMock.cs
@@ -11,6 +11,13 @@ public class OracleDbMock : DbMock
         Dialect = new OracleDialect(Version);
     }
 
+    /// <summary>
+    /// EN: Creates an Oracle schema mock instance.
+    /// PT: Cria uma instância de mock de schema Oracle.
+    /// </summary>
+    /// <param name="schemaName">EN: Schema name. PT: Nome do schema.</param>
+    /// <param name="tables">EN: Initial tables. PT: Tabelas iniciais.</param>
+    /// <returns>EN: Schema mock. PT: Mock de schema.</returns>
     protected override SchemaMock NewSchema(
         string schemaName,
         IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null

--- a/src/DbSqlLikeMem.Oracle/Models/OracleSchemaMock.cs
+++ b/src/DbSqlLikeMem.Oracle/Models/OracleSchemaMock.cs
@@ -6,6 +6,14 @@ public class OracleSchemaMock(
     IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null
     ) : SchemaMock(schemaName, db, tables)
 {
+    /// <summary>
+    /// EN: Creates an Oracle table mock for this schema.
+    /// PT: Cria um mock de tabela Oracle para este schema.
+    /// </summary>
+    /// <param name="tableName">EN: Table name. PT: Nome da tabela.</param>
+    /// <param name="columns">EN: Table columns. PT: Colunas da tabela.</param>
+    /// <param name="rows">EN: Initial rows. PT: Linhas iniciais.</param>
+    /// <returns>EN: Table mock. PT: Mock de tabela.</returns>
     protected override TableMock NewTable(
         string tableName,
         IColumnDictionary columns,

--- a/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
@@ -20,6 +20,10 @@ public class OracleCommandMock(
     public override int CommandTimeout { get; set; }
     public override CommandType CommandType { get; set; } = CommandType.Text;
 
+    /// <summary>
+    /// EN: Gets or sets the associated connection.
+    /// PT: Obtém ou define a conexão associada.
+    /// </summary>
     protected override DbConnection? DbConnection
     {
         get => connection;
@@ -27,8 +31,16 @@ public class OracleCommandMock(
     }
 
     private readonly OracleDataParameterCollectionMock collectionMock = [];
+    /// <summary>
+    /// EN: Gets the parameter collection for the command.
+    /// PT: Obtém a coleção de parâmetros do comando.
+    /// </summary>
     protected override DbParameterCollection DbParameterCollection => collectionMock;
 
+    /// <summary>
+    /// EN: Gets or sets the current transaction.
+    /// PT: Obtém ou define a transação atual.
+    /// </summary>
     protected override DbTransaction? DbTransaction
     {
         get => transaction!;
@@ -40,6 +52,11 @@ public class OracleCommandMock(
 
     public override void Cancel() => DbTransaction?.Rollback();
 
+    /// <summary>
+    /// EN: Creates a new Oracle parameter.
+    /// PT: Cria um novo parâmetro Oracle.
+    /// </summary>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter CreateDbParameter()
         // Por enquanto reusa OracleParameter (OracleConnector) para não puxar pacote de SqlClient.
         => new OracleParameter();
@@ -73,6 +90,12 @@ public class OracleCommandMock(
         };
     }
 
+    /// <summary>
+    /// EN: Executes the command and returns a data reader.
+    /// PT: Executa o comando e retorna um data reader.
+    /// </summary>
+    /// <param name="behavior">EN: Command behavior. PT: Comportamento do comando.</param>
+    /// <returns>EN: Data reader. PT: Data reader.</returns>
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
     {
         ArgumentNullException.ThrowIfNull(connection);
@@ -124,6 +147,11 @@ public class OracleCommandMock(
 
     public override void Prepare() { }
 
+    /// <summary>
+    /// EN: Disposes the command and resources.
+    /// PT: Descarta o comando e os recursos.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (!disposedValue)

--- a/src/DbSqlLikeMem.Oracle/OracleConnectionMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleConnectionMock.cs
@@ -18,9 +18,20 @@ public class OracleConnectionMock
         _serverVersion = $"Oracle {Db.Version}";
     }
 
+    /// <summary>
+    /// EN: Creates an Oracle transaction mock.
+    /// PT: Cria um mock de transação Oracle.
+    /// </summary>
+    /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
     protected override DbTransaction CreateTransaction()
         => new OracleTransactionMock(this);
 
+    /// <summary>
+    /// EN: Creates an Oracle command mock for the transaction.
+    /// PT: Cria um mock de comando Oracle para a transação.
+    /// </summary>
+    /// <param name="transaction">EN: Current transaction. PT: Transação atual.</param>
+    /// <returns>EN: Command instance. PT: Instância do comando.</returns>
     protected override DbCommand CreateDbCommandCore(DbTransaction? transaction)
         => new OracleCommandMock(this, transaction as OracleTransactionMock);
 

--- a/src/DbSqlLikeMem.Oracle/OracleDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDataParameterCollectionMock.cs
@@ -44,8 +44,20 @@ public class OracleDataParameterCollectionMock
         { } other => other,
     };
 
+    /// <summary>
+    /// EN: Gets a parameter by index.
+    /// PT: Obtém um parâmetro pelo índice.
+    /// </summary>
+    /// <param name="index">EN: Parameter index. PT: Índice do parâmetro.</param>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter GetParameter(int index) => Items[index];
 
+    /// <summary>
+    /// EN: Gets a parameter by name.
+    /// PT: Obtém um parâmetro pelo nome.
+    /// </summary>
+    /// <param name="parameterName">EN: Parameter name. PT: Nome do parâmetro.</param>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter GetParameter(string parameterName)
     {
         var index = IndexOf(parameterName);
@@ -54,6 +66,12 @@ public class OracleDataParameterCollectionMock
         return Items[index];
     }
 
+    /// <summary>
+    /// EN: Sets a parameter by index.
+    /// PT: Define um parâmetro pelo índice.
+    /// </summary>
+    /// <param name="index">EN: Parameter index. PT: Índice do parâmetro.</param>
+    /// <param name="value">EN: Parameter value. PT: Valor do parâmetro.</param>
     protected override void SetParameter(int index, DbParameter value)
     {
         ArgumentNullException.ThrowIfNull(value);
@@ -70,6 +88,12 @@ public class OracleDataParameterCollectionMock
         //newParameter.ParameterCollection = this;
     }
 
+    /// <summary>
+    /// EN: Sets a parameter by name.
+    /// PT: Define um parâmetro pelo nome.
+    /// </summary>
+    /// <param name="parameterName">EN: Parameter name. PT: Nome do parâmetro.</param>
+    /// <param name="value">EN: Parameter value. PT: Valor do parâmetro.</param>
     protected override void SetParameter(string parameterName, DbParameter value)
         => SetParameter(IndexOf(parameterName), value);
 

--- a/src/DbSqlLikeMem.Oracle/OracleTransactionMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleTransactionMock.cs
@@ -10,6 +10,10 @@ public sealed class OracleTransactionMock(
 {
     private bool disposedValue;
 
+    /// <summary>
+    /// EN: Gets the connection associated with this transaction.
+    /// PT: Obtém a conexão associada a esta transação.
+    /// </summary>
     protected override DbConnection? DbConnection => cnn;
 
     public override IsolationLevel IsolationLevel
@@ -33,6 +37,11 @@ public sealed class OracleTransactionMock(
         }
     }
 
+    /// <summary>
+    /// EN: Disposes the transaction resources.
+    /// PT: Descarta os recursos da transação.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (!disposedValue)

--- a/src/DbSqlLikeMem.Oracle/OracleTranslator.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleTranslator.cs
@@ -58,6 +58,12 @@ public class OracleTranslator : ExpressionVisitor
     }
 
 #pragma warning disable CS8605 // Unboxing a possibly null value.
+    /// <summary>
+    /// EN: Translates method calls into Oracle expressions.
+    /// PT: Traduz chamadas de método em expressões Oracle.
+    /// </summary>
+    /// <param name="node">EN: Method call expression. PT: Expressão de chamada de método.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitMethodCall(MethodCallExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -124,6 +130,12 @@ public class OracleTranslator : ExpressionVisitor
     }
 #pragma warning restore CS8605 // Unboxing a possibly null value.
 
+    /// <summary>
+    /// EN: Translates constants into Oracle literals.
+    /// PT: Traduz constantes em literais Oracle.
+    /// </summary>
+    /// <param name="node">EN: Constant expression. PT: Expressão constante.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitConstant(ConstantExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -161,6 +173,12 @@ public class OracleTranslator : ExpressionVisitor
         return node;
     }
 
+    /// <summary>
+    /// EN: Translates binary expressions into Oracle syntax.
+    /// PT: Traduz expressões binárias para a sintaxe Oracle.
+    /// </summary>
+    /// <param name="node">EN: Binary expression. PT: Expressão binária.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitBinary(BinaryExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -180,6 +198,12 @@ public class OracleTranslator : ExpressionVisitor
         return node;
     }
 
+    /// <summary>
+    /// EN: Translates member access into Oracle expressions.
+    /// PT: Traduz acesso a membros em expressões Oracle.
+    /// </summary>
+    /// <param name="node">EN: Member expression. PT: Expressão de membro.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitMember(MemberExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);

--- a/src/DbSqlLikeMem.SqlServer.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/DapperTests.cs
@@ -206,6 +206,11 @@ UPDATE users
         Assert.Equal(dt2, emails[1].CreatedDate);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdditionalBehaviorCoverageTests.cs
@@ -168,6 +168,11 @@ ORDER BY userid
         Assert.Equal(0, (int)counters[2].counter);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdvancedSqlGapTests.cs
@@ -105,6 +105,11 @@ ORDER BY id").ToList();
         Assert.Equal([1], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerAggregationTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerAggregationTests.cs
@@ -72,6 +72,11 @@ public sealed class SqlServerAggregationTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].userId);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerJoinTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerJoinTests.cs
@@ -88,6 +88,11 @@ public sealed class SqlServerJoinTests : XUnitTestBase
         Assert.Equal(10, (int)rows[0].orderId);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerMockTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerMockTests.cs
@@ -146,6 +146,11 @@ public sealed class SqlServerMockTests
         Assert.Empty(users);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _connection.Dispose();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerSelectAndWhereMoreCoverageTests.cs
@@ -84,6 +84,11 @@ ORDER BY id").ToList();
         Assert.Equal("(none)", (string)row.em);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerSqlCompatibilityGapTests.cs
@@ -209,6 +209,11 @@ ORDER BY id
         Assert.Equal(2, (int)rows2[0].id);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs
@@ -59,6 +59,11 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([123m, 456m, null], [.. rows.Select(r => (object?)r.v)]);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerWhereParserAndExecutorTests.cs
@@ -73,6 +73,11 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn?.Dispose();

--- a/src/DbSqlLikeMem.SqlServer.Test/Views/SqlServerCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Views/SqlServerCreateViewEngineTests.cs
@@ -127,6 +127,11 @@ GROUP BY u.id;
         Assert.ThrowsAny<Exception>(() => _cnn.QueryRows("SELECT * FROM vdrop"));
     }
 
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         _cnn.Dispose();

--- a/src/DbSqlLikeMem.SqlServer/Models/SqlServerDbMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/Models/SqlServerDbMock.cs
@@ -10,6 +10,13 @@ public class SqlServerDbMock : DbMock
     {
         Dialect = new SqlServerDialect(Version);
     }
+    /// <summary>
+    /// EN: Creates a SQL Server schema mock instance.
+    /// PT: Cria uma instância de mock de schema do SQL Server.
+    /// </summary>
+    /// <param name="schemaName">EN: Schema name. PT: Nome do schema.</param>
+    /// <param name="tables">EN: Initial tables. PT: Tabelas iniciais.</param>
+    /// <returns>EN: Schema mock. PT: Mock de schema.</returns>
     protected override SchemaMock NewSchema(
         string schemaName,
         IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null

--- a/src/DbSqlLikeMem.SqlServer/Models/SqlServerSchemaMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/Models/SqlServerSchemaMock.cs
@@ -6,6 +6,14 @@ public class SqlServerSchemaMock(
     IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null
     ) : SchemaMock(schemaName, db, tables)
 {
+    /// <summary>
+    /// EN: Creates a SQL Server table mock for this schema.
+    /// PT: Cria um mock de tabela SQL Server para este schema.
+    /// </summary>
+    /// <param name="tableName">EN: Table name. PT: Nome da tabela.</param>
+    /// <param name="columns">EN: Table columns. PT: Colunas da tabela.</param>
+    /// <param name="rows">EN: Initial rows. PT: Linhas iniciais.</param>
+    /// <returns>EN: Table mock. PT: Mock de tabela.</returns>
     protected override TableMock NewTable(
         string tableName,
         IColumnDictionary columns,

--- a/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
@@ -21,6 +21,10 @@ public class SqlServerCommandMock(
     public override int CommandTimeout { get; set; }
     public override CommandType CommandType { get; set; } = CommandType.Text;
 
+    /// <summary>
+    /// EN: Gets or sets the associated connection.
+    /// PT: Obtém ou define a conexão associada.
+    /// </summary>
     protected override DbConnection? DbConnection
     {
         get => connection;
@@ -28,8 +32,16 @@ public class SqlServerCommandMock(
     }
 
     private readonly SqlServerDataParameterCollectionMock collectionMock = [];
+    /// <summary>
+    /// EN: Gets the parameter collection for the command.
+    /// PT: Obtém a coleção de parâmetros do comando.
+    /// </summary>
     protected override DbParameterCollection DbParameterCollection => collectionMock;
 
+    /// <summary>
+    /// EN: Gets or sets the current transaction.
+    /// PT: Obtém ou define a transação atual.
+    /// </summary>
     protected override DbTransaction? DbTransaction
     {
         get => transaction!;
@@ -41,6 +53,11 @@ public class SqlServerCommandMock(
 
     public override void Cancel() => DbTransaction?.Rollback();
 
+    /// <summary>
+    /// EN: Creates a new SQL Server parameter.
+    /// PT: Cria um novo parâmetro do SQL Server.
+    /// </summary>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter CreateDbParameter()
         => new SqlParameter();
 
@@ -73,6 +90,12 @@ public class SqlServerCommandMock(
         };
     }
 
+    /// <summary>
+    /// EN: Executes the command and returns a data reader.
+    /// PT: Executa o comando e retorna um data reader.
+    /// </summary>
+    /// <param name="behavior">EN: Command behavior. PT: Comportamento do comando.</param>
+    /// <returns>EN: Data reader. PT: Data reader.</returns>
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
     {
         ArgumentNullException.ThrowIfNull(connection);
@@ -124,6 +147,11 @@ public class SqlServerCommandMock(
 
     public override void Prepare() { }
 
+    /// <summary>
+    /// EN: Disposes the command and resources.
+    /// PT: Descarta o comando e os recursos.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (!disposedValue)

--- a/src/DbSqlLikeMem.SqlServer/SqlServerConnectionMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerConnectionMock.cs
@@ -19,9 +19,20 @@ public sealed class SqlServerConnectionMock
         _serverVersion = $"SQL Server {Db.Version}";
     }
 
+    /// <summary>
+    /// EN: Creates a SQL Server transaction mock.
+    /// PT: Cria um mock de transação SQL Server.
+    /// </summary>
+    /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
     protected override DbTransaction CreateTransaction()
         => new SqlServerTransactionMock(this);
 
+    /// <summary>
+    /// EN: Creates a SQL Server command mock for the transaction.
+    /// PT: Cria um mock de comando SQL Server para a transação.
+    /// </summary>
+    /// <param name="transaction">EN: Current transaction. PT: Transação atual.</param>
+    /// <returns>EN: Command instance. PT: Instância do comando.</returns>
     protected override DbCommand CreateDbCommandCore(DbTransaction? transaction)
         => new SqlServerCommandMock(this, transaction as SqlServerTransactionMock);
 

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDataParameterCollectionMock.cs
@@ -43,8 +43,20 @@ public class SqlServerDataParameterCollectionMock
         { } other => other,
     };
 
+    /// <summary>
+    /// EN: Gets a parameter by index.
+    /// PT: Obtém um parâmetro pelo índice.
+    /// </summary>
+    /// <param name="index">EN: Parameter index. PT: Índice do parâmetro.</param>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter GetParameter(int index) => Items[index];
 
+    /// <summary>
+    /// EN: Gets a parameter by name.
+    /// PT: Obtém um parâmetro pelo nome.
+    /// </summary>
+    /// <param name="parameterName">EN: Parameter name. PT: Nome do parâmetro.</param>
+    /// <returns>EN: Parameter instance. PT: Instância do parâmetro.</returns>
     protected override DbParameter GetParameter(string parameterName)
     {
         var index = IndexOf(parameterName);
@@ -53,6 +65,12 @@ public class SqlServerDataParameterCollectionMock
         return Items[index];
     }
 
+    /// <summary>
+    /// EN: Sets a parameter by index.
+    /// PT: Define um parâmetro pelo índice.
+    /// </summary>
+    /// <param name="index">EN: Parameter index. PT: Índice do parâmetro.</param>
+    /// <param name="value">EN: Parameter value. PT: Valor do parâmetro.</param>
     protected override void SetParameter(int index, DbParameter value)
     {
         ArgumentNullException.ThrowIfNull(value);
@@ -67,6 +85,12 @@ public class SqlServerDataParameterCollectionMock
             DicItems.Add(newNormalizedParameterName, index);
     }
 
+    /// <summary>
+    /// EN: Sets a parameter by name.
+    /// PT: Define um parâmetro pelo nome.
+    /// </summary>
+    /// <param name="parameterName">EN: Parameter name. PT: Nome do parâmetro.</param>
+    /// <param name="value">EN: Parameter value. PT: Valor do parâmetro.</param>
     protected override void SetParameter(string parameterName, DbParameter value)
         => SetParameter(IndexOf(parameterName), value);
 

--- a/src/DbSqlLikeMem.SqlServer/SqlServerTransactionMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerTransactionMock.cs
@@ -10,6 +10,10 @@ public sealed class SqlServerTransactionMock(
 {
     private bool disposedValue;
 
+    /// <summary>
+    /// EN: Gets the connection associated with this transaction.
+    /// PT: Obtém a conexão associada a esta transação.
+    /// </summary>
     protected override DbConnection? DbConnection => cnn;
 
     public override IsolationLevel IsolationLevel
@@ -33,6 +37,11 @@ public sealed class SqlServerTransactionMock(
         }
     }
 
+    /// <summary>
+    /// EN: Disposes the transaction resources.
+    /// PT: Descarta os recursos da transação.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (!disposedValue)

--- a/src/DbSqlLikeMem.SqlServer/SqlServerTranslator.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerTranslator.cs
@@ -58,6 +58,12 @@ public class SqlServerTranslator : ExpressionVisitor
     }
 
 #pragma warning disable CS8605 // Unboxing a possibly null value.
+    /// <summary>
+    /// EN: Translates method calls into SQL Server expressions.
+    /// PT: Traduz chamadas de método em expressões do SQL Server.
+    /// </summary>
+    /// <param name="node">EN: Method call expression. PT: Expressão de chamada de método.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitMethodCall(MethodCallExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -124,6 +130,12 @@ public class SqlServerTranslator : ExpressionVisitor
     }
 #pragma warning restore CS8605 // Unboxing a possibly null value.
 
+    /// <summary>
+    /// EN: Translates constants into SQL Server literals.
+    /// PT: Traduz constantes em literais do SQL Server.
+    /// </summary>
+    /// <param name="node">EN: Constant expression. PT: Expressão constante.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitConstant(ConstantExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -161,6 +173,12 @@ public class SqlServerTranslator : ExpressionVisitor
         return node;
     }
 
+    /// <summary>
+    /// EN: Translates binary expressions into SQL Server syntax.
+    /// PT: Traduz expressões binárias para a sintaxe do SQL Server.
+    /// </summary>
+    /// <param name="node">EN: Binary expression. PT: Expressão binária.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitBinary(BinaryExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);
@@ -180,6 +198,12 @@ public class SqlServerTranslator : ExpressionVisitor
         return node;
     }
 
+    /// <summary>
+    /// EN: Translates member access into SQL Server expressions.
+    /// PT: Traduz acesso a membros em expressões do SQL Server.
+    /// </summary>
+    /// <param name="node">EN: Member expression. PT: Expressão de membro.</param>
+    /// <returns>EN: Translated expression. PT: Expressão traduzida.</returns>
     protected override Expression VisitMember(MemberExpression node)
     {
         ArgumentNullException.ThrowIfNull(node);

--- a/src/DbSqlLikeMem.Test/XUnitTestBase.cs
+++ b/src/DbSqlLikeMem.Test/XUnitTestBase.cs
@@ -5,9 +5,18 @@ namespace DbSqlLikeMem.Test;
 
 public abstract class XUnitTestBase : IDisposable
 {
+    /// <summary>
+    /// EN: Test output writer used to redirect console output.
+    /// PT: Escritor de saída de teste usado para redirecionar a saída do console.
+    /// </summary>
     protected ConsoleTestWriter ConsoleWriter { get; }
     private bool disposedValue;
 
+    /// <summary>
+    /// EN: Initializes the base test with the output helper.
+    /// PT: Inicializa o teste base com o helper de saída.
+    /// </summary>
+    /// <param name="helper">EN: Output helper. PT: Helper de saída.</param>
     protected XUnitTestBase(
         ITestOutputHelper helper)
     {
@@ -15,6 +24,13 @@ public abstract class XUnitTestBase : IDisposable
         Console.SetOut(ConsoleWriter);
     }
 
+    /// <summary>
+    /// EN: Copies writable public instance properties from one object to another.
+    /// PT: Copia propriedades públicas graváveis de instância de um objeto para outro.
+    /// </summary>
+    /// <param name="src">EN: Source instance. PT: Instância de origem.</param>
+    /// <param name="dst">EN: Destination instance. PT: Instância de destino.</param>
+    /// <typeparam name="T">EN: Instance type. PT: Tipo da instância.</typeparam>
     protected static void CopyWritableProps<T>(
         T src,
         T dst)
@@ -30,6 +46,11 @@ public abstract class XUnitTestBase : IDisposable
             p.SetValue(dst, p.GetValue(src));
     }
 
+    /// <summary>
+    /// EN: Resolves the current test method name.
+    /// PT: Resolve o nome do método de teste atual.
+    /// </summary>
+    /// <returns>EN: Test name. PT: Nome do teste.</returns>
     protected static string GetTestName()
     {
         var stack = new StackTrace();
@@ -39,6 +60,11 @@ public abstract class XUnitTestBase : IDisposable
         return testMethod?.Name ?? "UnknownTest";
     }
 
+    /// <summary>
+    /// EN: Disposes managed resources when requested.
+    /// PT: Descarta recursos gerenciados quando solicitado.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected virtual void Dispose(bool disposing)
     {
         ConsoleWriter?.Flush();

--- a/src/DbSqlLikeMem/Base/DbConnectionMockBase.cs
+++ b/src/DbSqlLikeMem/Base/DbConnectionMockBase.cs
@@ -71,6 +71,10 @@ public abstract class DbConnectionMockBase(
     /// </summary>
     public override string DataSource => _dataSource;
 
+    /// <summary>
+    /// EN: Backing field for the simulated server version.
+    /// PT: Campo de suporte para a versão simulada do servidor.
+    /// </summary>
     protected string _serverVersion = "";
     /// <summary>
     /// EN: Simulated server version.
@@ -78,6 +82,10 @@ public abstract class DbConnectionMockBase(
     /// </summary>
     public override string ServerVersion => _serverVersion;
 
+    /// <summary>
+    /// EN: Current active transaction, if any.
+    /// PT: Transação ativa atual, se houver.
+    /// </summary>
     protected DbTransaction? CurrentTransaction { get; private set; }
 
     #region Table
@@ -208,6 +216,12 @@ public abstract class DbConnectionMockBase(
 
     #endregion
 
+    /// <summary>
+    /// EN: Begins a database transaction with the specified isolation level.
+    /// PT: Inicia uma transação com o nível de isolamento especificado.
+    /// </summary>
+    /// <param name="isolationLevel">EN: Isolation level. PT: Nível de isolamento.</param>
+    /// <returns>EN: Created transaction. PT: Transação criada.</returns>
     protected override DbTransaction BeginDbTransaction(
         IsolationLevel isolationLevel)
     {
@@ -225,6 +239,11 @@ public abstract class DbConnectionMockBase(
         return CurrentTransaction;
     }
 
+    /// <summary>
+    /// EN: Creates a provider-specific transaction instance.
+    /// PT: Cria uma instância de transação específica do provedor.
+    /// </summary>
+    /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
     protected abstract DbTransaction CreateTransaction();
 
     /// <summary>
@@ -242,9 +261,20 @@ public abstract class DbConnectionMockBase(
     public override void Close()
         => _state = ConnectionState.Closed;
 
+    /// <summary>
+    /// EN: Creates a command associated with the current transaction.
+    /// PT: Cria um comando associado à transação atual.
+    /// </summary>
+    /// <returns>EN: Command instance. PT: Instância do comando.</returns>
     protected override DbCommand CreateDbCommand()
         => CreateDbCommandCore(CurrentTransaction);
 
+    /// <summary>
+    /// EN: Creates a provider-specific command tied to a transaction.
+    /// PT: Cria um comando específico do provedor atrelado a uma transação.
+    /// </summary>
+    /// <param name="transaction">EN: Current transaction. PT: Transação atual.</param>
+    /// <returns>EN: Command instance. PT: Instância do comando.</returns>
     protected abstract DbCommand CreateDbCommandCore(
         DbTransaction? transaction);
 
@@ -317,6 +347,11 @@ public abstract class DbConnectionMockBase(
 
     internal abstract Exception NewException(string message, int code);
 
+    /// <summary>
+    /// EN: Disposes the connection and associated resources.
+    /// PT: Descarta a conexão e os recursos associados.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (_disposed)

--- a/src/DbSqlLikeMem/Base/DbDataReaderMockBase.cs
+++ b/src/DbSqlLikeMem/Base/DbDataReaderMockBase.cs
@@ -92,6 +92,12 @@ public abstract class DbDataReaderMockBase(
     /// </summary>
     public override char GetChar(int ordinal) => (char)this[ordinal];
     public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Gets a nested data reader for the specified ordinal.
+    /// PT: Obtém um data reader aninhado para o ordinal especificado.
+    /// </summary>
+    /// <param name="ordinal">EN: Column ordinal. PT: Ordinal da coluna.</param>
+    /// <returns>EN: Nested data reader. PT: Data reader aninhado.</returns>
     protected override DbDataReader GetDbDataReader(int ordinal) => throw new NotImplementedException();
     /// <summary>
     /// EN: Gets the data type name of the column.
@@ -282,6 +288,11 @@ public abstract class DbDataReaderMockBase(
     /// PT: Retorna um enumerador dos conjuntos de resultados.
     /// </summary>
     public override IEnumerator GetEnumerator() => _resultSets.GetEnumerator();
+    /// <summary>
+    /// EN: Disposes the data reader and associated resources.
+    /// PT: Descarta o data reader e recursos associados.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
     protected override void Dispose(bool disposing)
     {
         if (!disposedValue)

--- a/src/DbSqlLikeMem/Models/DbMock.cs
+++ b/src/DbSqlLikeMem/Models/DbMock.cs
@@ -56,6 +56,13 @@ public abstract class DbMock
 
     #region Schema
 
+    /// <summary>
+    /// EN: Creates a new schema instance for the database.
+    /// PT: Cria uma nova instância de schema para o banco.
+    /// </summary>
+    /// <param name="schemaName">EN: Schema name. PT: Nome do schema.</param>
+    /// <param name="tables">EN: Initial tables. PT: Tabelas iniciais.</param>
+    /// <returns>EN: New schema instance. PT: Nova instância de schema.</returns>
     protected abstract SchemaMock NewSchema(
         string schemaName,
         IDictionary<string, (IColumnDictionary columns, IEnumerable<Dictionary<int, object?>>? rows)>? tables = null);

--- a/src/DbSqlLikeMem/Models/SchemaMock.cs
+++ b/src/DbSqlLikeMem/Models/SchemaMock.cs
@@ -76,6 +76,14 @@ public abstract class SchemaMock
     internal IDictionary<string, SqlSelectQuery> Views { get; } =
         new Dictionary<string, SqlSelectQuery>(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// EN: Creates a new table instance for this schema.
+    /// PT: Cria uma nova instância de tabela para este schema.
+    /// </summary>
+    /// <param name="tableName">EN: Table name. PT: Nome da tabela.</param>
+    /// <param name="columns">EN: Table columns. PT: Colunas da tabela.</param>
+    /// <param name="rows">EN: Initial rows. PT: Linhas iniciais.</param>
+    /// <returns>EN: New table instance. PT: Nova instância de tabela.</returns>
     protected abstract TableMock NewTable(
         string tableName,
         IColumnDictionary columns,

--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -1198,9 +1198,12 @@ internal abstract class AstQueryExecutorBase(
     // ---------------- DIALECT HOOKS ----------------
 
     /// <summary>
-    /// Dialect mapping for JSON access operators (-> / ->> etc).
+    /// EN: Dialect mapping for JSON access operators (-> / ->> etc).
     /// Default implementation matches current MySQL best-effort behavior.
     /// SqlServer/Postgre/Oracle should override.
+    /// PT: Mapeamento de dialeto para operadores de acesso JSON (-> / ->> etc).
+    /// A implementação padrão segue o comportamento best-effort do MySQL.
+    /// SqlServer/Postgre/Oracle devem sobrescrever.
     /// </summary>
     protected virtual SqlExpr MapJsonAccess(JsonAccessExpr ja)
     {
@@ -1214,8 +1217,10 @@ internal abstract class AstQueryExecutorBase(
     }
 
     /// <summary>
-    /// Dialect mapping for scalar subquery evaluation.
+    /// EN: Dialect mapping for scalar subquery evaluation.
     /// Default is MySQL-like: first cell of first row.
+    /// PT: Mapeamento de dialeto para avaliação de subconsulta escalar.
+    /// O padrão é semelhante ao MySQL: primeira célula da primeira linha.
     /// </summary>
     protected virtual object? EvalScalarSubquery(
         SubqueryExpr sq,
@@ -2481,4 +2486,3 @@ internal abstract class AstQueryExecutorBase(
         }
     }
 }
-


### PR DESCRIPTION
### Motivation
- Harmonize code documentation by adding English-first then Portuguese XML comments to `protected` fields, properties and methods across the public API surface so consumers and maintainers see bilingual docs consistently.
- Ensure provider-specific implementations (MySQL, Npgsql, Oracle, SqlServer) and core abstractions expose brief summaries for protected overrides and members to improve discoverability and maintenance.
- Add consistent documentation to test fixtures' `Dispose` overrides to make the cleanup contract explicit in both languages.

### Description
- Added EN/PT XML `/// <summary>` documentation to core abstractions such as `DbMock`, `SchemaMock`, `DbConnectionMockBase`, `DbDataReaderMockBase` and executor hooks like `AstQueryExecutorBase` for protected members and virtual hooks (e.g. `MapJsonAccess`, `EvalScalarSubquery`).
- Documented protected members in provider-specific modules (`MySql`, `Npgsql`, `Oracle`, `SqlServer`) including command/connection/transaction mocks, parameter collection overrides (`GetParameter`, `SetParameter`), translator visitor overrides (`VisitMethodCall`, `VisitConstant`, `VisitBinary`, `VisitMember`), and `CreateTransaction`/`CreateDbCommandCore` implementations using bilingual summaries and parameter/return info where applicable.
- Added bilingual XML comments for protected `Dispose` overrides and added protected `Dispose` overrides (with docs) in many test fixtures to explicitly document resource cleanup patterns.

### Testing
- Automated tests: none executed as this is a documentation-only change; no behavior changes expected. 
- Result: no tests run (docs-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a2bd41928832caff86e4f9bc74969)