### PR TITLE
Add GitHub Actions workflow for NuGet publishing and document release steps

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,33 @@
+name: Publish NuGet packages
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore
+        run: dotnet restore src/DbSqlLikeMem.slnx
+
+      - name: Pack
+        run: dotnet pack src/DbSqlLikeMem.slnx -c Release -o ./artifacts
+
+      - name: Publish to NuGet.org
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push "./artifacts/*.nupkg" --api-key "$NUGET_API_KEY" --source "https://api.nuget.org/v3/index.json" --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -163,6 +163,29 @@ var postgres = new NpgsqlConnectionMock(new NpgsqlDbMock());
 dotnet test src/DbSqlLikeMem.slnx
 ```
 
+## Publicando no NuGet (nuget.org)
+
+### Publicação via GitHub Actions (recomendado)
+
+1. Crie uma API key em https://www.nuget.org/ (Account settings → API Keys).
+2. No repositório do GitHub, adicione o segredo `NUGET_API_KEY` com essa chave.
+3. Atualize a versão em `src/Directory.Build.props` (propriedade `Version`).
+4. Crie e envie uma tag de release, por exemplo:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+O workflow `.github/workflows/nuget-publish.yml` empacota e publica todos os projetos do solution no nuget.org. 
+
+### Publicação manual (local)
+
+```bash
+dotnet pack src/DbSqlLikeMem.slnx -c Release -o ./artifacts
+dotnet nuget push "./artifacts/*.nupkg" --api-key "<SUA_API_KEY>" --source "https://api.nuget.org/v3/index.json"
+```
+
 ## Contributing
 
 Contributions are welcome! If you want to help improve DbSqlLikeMem, please open an issue to discuss your idea or submit a pull request. Areas where help is especially valuable:


### PR DESCRIPTION
### Motivation
- Provide an automated way to pack and publish the project's NuGet packages to nuget.org from the repository and to document the release/publish process.

### Description
- Add the CI workflow file `/.github/workflows/nuget-publish.yml` which triggers on `push` tags matching `v*` and on manual `workflow_dispatch`, and runs `dotnet restore`, `dotnet pack` and `dotnet nuget push` using the `NUGET_API_KEY` secret.
- Update `README.md` to add instructions (in Portuguese) for publishing via GitHub Actions and for manual local publishing using `dotnet pack` and `dotnet nuget push`, and note to update the `Version` in `src/Directory.Build.props` before release.
- The workflow packs the solution `src/DbSqlLikeMem.slnx` into `./artifacts` and pushes all generated `.nupkg` files to `https://api.nuget.org/v3/index.json` with `--skip-duplicate`.

### Testing
- No automated tests were executed because this change only adds a CI workflow and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a331d5d2c832ca1e44702ba1b1dc7)