### PR TITLE
Add missing XML summaries across project files

### DIFF
--- a/src/DbSqlLikeMem.MySql.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/DapperTests.cs
@@ -221,6 +221,10 @@ UPDATE users
     }
 }
 
+/// <summary>
+/// EN: Test DTO used by Dapper scenarios.
+/// PT: DTO de teste usado nos cenários do Dapper.
+/// </summary>
 public class UserObjectTest
 {
     public int Id { get; set; }

--- a/src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -1,6 +1,10 @@
 namespace DbSqlLikeMem.MySql.Test.Parser;
 
 
+/// <summary>
+/// EN: Expected casing results for SQL parser corpus tests.
+/// PT: Resultados esperados de capitalização nos testes de corpus do parser SQL.
+/// </summary>
 public enum SqlCaseExpectation
 {
     ParseOk,

--- a/src/DbSqlLikeMem.MySql.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Query/QueryExecutorExtrasTests.cs
@@ -92,6 +92,10 @@ SELECT * FROM t ORDER BY iddesc ASC LIMIT 2 OFFSET 1;";
     }
 }
 
+/// <summary>
+/// EN: Extra tests for SQL translation behavior.
+/// PT: Testes extras para o comportamento de tradução SQL.
+/// </summary>
 public class SqlTranslatorTests
 {
     [Fact]

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertOnDuplicateTests.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.MySql.Test.Strategy;
 
+/// <summary>
+/// EN: Tests for INSERT ... ON DUPLICATE behavior.
+/// PT: Testes para comportamento de INSERT ... ON DUPLICATE.
+/// </summary>
 public class MySqlInsertOnDuplicateTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyExtrasTests.cs
@@ -74,6 +74,10 @@ public sealed class MySqlInsertStrategyExtrasTests(
     }
 }
 
+/// <summary>
+/// EN: Tests delete strategy behavior with foreign keys.
+/// PT: Testes do comportamento da estratégia de delete com chaves estrangeiras.
+/// </summary>
 public class MySqlDeleteStrategyForeignKeyTests
 {
     [Fact]
@@ -105,6 +109,10 @@ public class MySqlDeleteStrategyForeignKeyTests
     }
 }
 
+/// <summary>
+/// EN: Extra tests for update strategy behavior.
+/// PT: Testes extras do comportamento da estratégia de update.
+/// </summary>
 public class MySqlUpdateStrategyExtrasTests
 {
     [Fact]

--- a/src/DbSqlLikeMem.MySql/Models/MySqlDbMock.cs
+++ b/src/DbSqlLikeMem.MySql/Models/MySqlDbMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.MySql;
 
+/// <summary>
+/// EN: In-memory database mock configured for MySQL.
+/// PT: Mock de banco em memória configurado para MySQL.
+/// </summary>
 public class MySqlDbMock
     : DbMock
 {

--- a/src/DbSqlLikeMem.MySql/Models/MySqlSchemaMock.cs
+++ b/src/DbSqlLikeMem.MySql/Models/MySqlSchemaMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.MySql;
 
+/// <summary>
+/// EN: Schema mock for MySQL databases.
+/// PT: Mock de esquema para bancos MySQL.
+/// </summary>
 public class MySqlSchemaMock(
     string schemaName,
     MySqlDbMock db,

--- a/src/DbSqlLikeMem.MySql/Models/MySqlTableMock.cs
+++ b/src/DbSqlLikeMem.MySql/Models/MySqlTableMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.MySql;
 
+/// <summary>
+/// EN: Table mock specialized for MySQL schema operations.
+/// PT: Mock de tabela especializado para operações de esquema MySQL.
+/// </summary>
 internal class MySqlTableMock(
         string tableName,
         MySqlSchemaMock schema,

--- a/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
@@ -4,6 +4,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace DbSqlLikeMem.MySql;
 
+/// <summary>
+/// EN: Mock command for MySQL connections.
+/// PT: Comando mock para conexões MySQL.
+/// </summary>
 public class MySqlCommandMock(
     MySqlConnectionMock? connection = null,
     MySqlTransactionMock? transaction = null

--- a/src/DbSqlLikeMem.MySql/MySqlDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDataParameterCollectionMock.cs
@@ -3,6 +3,10 @@ using System.Collections;
 using System.Data.Common;
 
 namespace DbSqlLikeMem.MySql;
+/// <summary>
+/// EN: Mock parameter collection for MySQL commands.
+/// PT: Coleção de parâmetros mock para comandos MySQL.
+/// </summary>
 public class MySqlDataParameterCollectionMock
     : DbParameterCollection, IList<MySqlParameter>
 {

--- a/src/DbSqlLikeMem.MySql/MySqlDataReaderMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDataReaderMock.cs
@@ -1,6 +1,10 @@
 namespace DbSqlLikeMem.MySql;
 
 #pragma warning disable CA1010 // Generic interface should also be implemented
+/// <summary>
+/// EN: Mock data reader for MySQL query results.
+/// PT: Leitor de dados mock para resultados MySQL.
+/// </summary>
 public class MySqlDataReaderMock(
 #pragma warning restore CA1010 // Generic interface should also be implemented
     IList<TableResultMock> tables

--- a/src/DbSqlLikeMem.MySql/MySqlQueryable.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlQueryable.cs
@@ -2,6 +2,10 @@ using System.Collections;
 using System.Linq.Expressions;
 
 namespace DbSqlLikeMem.MySql;
+/// <summary>
+/// EN: IQueryable wrapper for MySQL LINQ translation.
+/// PT: Wrapper IQueryable para tradução LINQ do MySQL.
+/// </summary>
 public class MySqlQueryable<T> : IOrderedQueryable<T>
 {
     public string TableName { get; }

--- a/src/DbSqlLikeMem.MySql/MySqlTransactionMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlTransactionMock.cs
@@ -2,6 +2,10 @@ using System.Data.Common;
 using System.Diagnostics;
 
 namespace DbSqlLikeMem.MySql;
+/// <summary>
+/// EN: Mock transaction for MySQL connections.
+/// PT: Mock de transação para conexões MySQL.
+/// </summary>
 public class MySqlTransactionMock(
         MySqlConnectionMock cnn,
         IsolationLevel? isolationLevel = null

--- a/src/DbSqlLikeMem.Npgsql.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/DapperTests.cs
@@ -222,6 +222,10 @@ UPDATE users
     }
 }
 
+/// <summary>
+/// EN: Test DTO used by Dapper scenarios.
+/// PT: DTO de teste usado nos cenários do Dapper.
+/// </summary>
 public class UserObjectTest
 {
     public int Id { get; set; }

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -1,6 +1,10 @@
 namespace DbSqlLikeMem.Npgsql.Test.Parser;
 
 
+/// <summary>
+/// EN: Expected casing results for SQL parser corpus tests.
+/// PT: Resultados esperados de capitalização nos testes de corpus do parser SQL.
+/// </summary>
 public enum SqlCaseExpectation
 {
     ParseOk,

--- a/src/DbSqlLikeMem.Npgsql.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Query/QueryExecutorExtrasTests.cs
@@ -92,6 +92,10 @@ SELECT * FROM t ORDER BY iddesc ASC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY;";
     }
 }
 
+/// <summary>
+/// EN: Extra tests for SQL translation behavior.
+/// PT: Testes extras para o comportamento de tradução SQL.
+/// </summary>
 public class SqlTranslatorTests
 {
     [Fact]

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyExtrasTests.cs
@@ -74,6 +74,10 @@ public sealed class PostgreSqlInsertStrategyExtrasTests(
     }
 }
 
+/// <summary>
+/// EN: Tests delete strategy behavior with foreign keys.
+/// PT: Testes do comportamento da estratégia de delete com chaves estrangeiras.
+/// </summary>
 public class PostgreSqlDeleteStrategyForeignKeyTests
 {
     [Fact]
@@ -105,6 +109,10 @@ public class PostgreSqlDeleteStrategyForeignKeyTests
     }
 }
 
+/// <summary>
+/// EN: Extra tests for update strategy behavior.
+/// PT: Testes extras do comportamento da estratégia de update.
+/// </summary>
 public class PostgreSqlUpdateStrategyExtrasTests
 {
     [Fact]

--- a/src/DbSqlLikeMem.Npgsql/Models/NpgsqlDbMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/Models/NpgsqlDbMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.Npgsql;
 
+/// <summary>
+/// EN: In-memory database mock configured for Npgsql.
+/// PT: Mock de banco em memória configurado para Npgsql.
+/// </summary>
 public class NpgsqlDbMock : DbMock
 {
     internal override SqlDialectBase Dialect { get; set; }

--- a/src/DbSqlLikeMem.Npgsql/Models/NpgsqlSchemaMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/Models/NpgsqlSchemaMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.Npgsql;
 
+/// <summary>
+/// EN: Schema mock for Npgsql databases.
+/// PT: Mock de esquema para bancos Npgsql.
+/// </summary>
 public class NpgsqlSchemaMock(
     string schemaName,
     NpgsqlDbMock db,

--- a/src/DbSqlLikeMem.Npgsql/Models/NpgsqlTableMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/Models/NpgsqlTableMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.Npgsql;
 
+/// <summary>
+/// EN: Table mock specialized for Npgsql schema operations.
+/// PT: Mock de tabela especializado para operações de esquema Npgsql.
+/// </summary>
 internal class NpgsqlTableMock(
         string tableName,
         SchemaMock schema,

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDataParameterCollectionMock.cs
@@ -4,6 +4,10 @@ using Npgsql;
 using NpgsqlTypes;
 
 namespace DbSqlLikeMem.Npgsql;
+/// <summary>
+/// EN: Mock parameter collection for Npgsql commands.
+/// PT: Coleção de parâmetros mock para comandos Npgsql.
+/// </summary>
 public class NpgsqlDataParameterCollectionMock
     : DbParameterCollection, IList<NpgsqlParameter>
 {

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlQueryable.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlQueryable.cs
@@ -2,6 +2,10 @@ using System.Collections;
 using System.Linq.Expressions;
 
 namespace DbSqlLikeMem.Npgsql;
+/// <summary>
+/// EN: IQueryable wrapper for Npgsql LINQ translation.
+/// PT: Wrapper IQueryable para tradução LINQ do Npgsql.
+/// </summary>
 public class NpgsqlQueryable<T> : IOrderedQueryable<T>
 {
     public string TableName { get; }

--- a/src/DbSqlLikeMem.Oracle.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/DapperTests.cs
@@ -221,6 +221,10 @@ UPDATE users
     }
 }
 
+/// <summary>
+/// EN: Test DTO used by Dapper scenarios.
+/// PT: DTO de teste usado nos cenários do Dapper.
+/// </summary>
 public class UserObjectTest
 {
     public int Id { get; set; }

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -1,6 +1,10 @@
 namespace DbSqlLikeMem.Oracle.Test.Parser;
 
 
+/// <summary>
+/// EN: Expected casing results for SQL parser corpus tests.
+/// PT: Resultados esperados de capitalização nos testes de corpus do parser SQL.
+/// </summary>
 public enum SqlCaseExpectation
 {
     ParseOk,

--- a/src/DbSqlLikeMem.Oracle.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Query/QueryExecutorExtrasTests.cs
@@ -92,6 +92,10 @@ SELECT * FROM t ORDER BY iddesc ASC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY;";
     }
 }
 
+/// <summary>
+/// EN: Extra tests for SQL translation behavior.
+/// PT: Testes extras para o comportamento de tradução SQL.
+/// </summary>
 public class SqlTranslatorTests
 {
     [Fact]

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyExtrasTests.cs
@@ -74,6 +74,10 @@ public sealed class OracleInsertStrategyExtrasTests(
     }
 }
 
+/// <summary>
+/// EN: Tests delete strategy behavior with foreign keys.
+/// PT: Testes do comportamento da estratégia de delete com chaves estrangeiras.
+/// </summary>
 public class OracleDeleteStrategyForeignKeyTests
 {
     [Fact]
@@ -105,6 +109,10 @@ public class OracleDeleteStrategyForeignKeyTests
     }
 }
 
+/// <summary>
+/// EN: Extra tests for update strategy behavior.
+/// PT: Testes extras do comportamento da estratégia de update.
+/// </summary>
 public class OracleUpdateStrategyExtrasTests
 {
     [Fact]

--- a/src/DbSqlLikeMem.Oracle/Models/OracleDbMock.cs
+++ b/src/DbSqlLikeMem.Oracle/Models/OracleDbMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.Oracle;
 
+/// <summary>
+/// EN: In-memory database mock configured for Oracle.
+/// PT: Mock de banco em memória configurado para Oracle.
+/// </summary>
 public class OracleDbMock : DbMock
 {
     internal override SqlDialectBase Dialect { get; set; }

--- a/src/DbSqlLikeMem.Oracle/Models/OracleSchemaMock.cs
+++ b/src/DbSqlLikeMem.Oracle/Models/OracleSchemaMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.Oracle;
 
+/// <summary>
+/// EN: Schema mock for Oracle databases.
+/// PT: Mock de esquema para bancos Oracle.
+/// </summary>
 public class OracleSchemaMock(
     string schemaName,
     OracleDbMock db,

--- a/src/DbSqlLikeMem.Oracle/Models/OracleTableMock.cs
+++ b/src/DbSqlLikeMem.Oracle/Models/OracleTableMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.Oracle;
 
+/// <summary>
+/// EN: Table mock specialized for Oracle schema operations.
+/// PT: Mock de tabela especializado para operações de esquema Oracle.
+/// </summary>
 internal class OracleTableMock(
         string tableName,
         OracleSchemaMock schema,

--- a/src/DbSqlLikeMem.Oracle/OracleDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDataParameterCollectionMock.cs
@@ -3,6 +3,10 @@ using System.Data.Common;
 using Oracle.ManagedDataAccess.Client;
 
 namespace DbSqlLikeMem.Oracle;
+/// <summary>
+/// EN: Mock parameter collection for Oracle commands.
+/// PT: Coleção de parâmetros mock para comandos Oracle.
+/// </summary>
 public class OracleDataParameterCollectionMock
     : DbParameterCollection, IList<OracleParameter>
 {

--- a/src/DbSqlLikeMem.Oracle/OracleQueryable.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleQueryable.cs
@@ -2,6 +2,10 @@ using System.Collections;
 using System.Linq.Expressions;
 
 namespace DbSqlLikeMem.Oracle;
+/// <summary>
+/// EN: IQueryable wrapper for Oracle LINQ translation.
+/// PT: Wrapper IQueryable para tradução LINQ do Oracle.
+/// </summary>
 public class OracleQueryable<T> : IOrderedQueryable<T>
 {
     public string TableName { get; }

--- a/src/DbSqlLikeMem.SqlServer.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/DapperTests.cs
@@ -221,6 +221,10 @@ UPDATE users
     }
 }
 
+/// <summary>
+/// EN: Test DTO used by Dapper scenarios.
+/// PT: DTO de teste usado nos cenários do Dapper.
+/// </summary>
 public class UserObjectTest
 {
     public int Id { get; set; }

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -1,6 +1,10 @@
 namespace DbSqlLikeMem.SqlServer.Test.Parser;
 
 
+/// <summary>
+/// EN: Expected casing results for SQL parser corpus tests.
+/// PT: Resultados esperados de capitalização nos testes de corpus do parser SQL.
+/// </summary>
 public enum SqlCaseExpectation
 {
     ParseOk,

--- a/src/DbSqlLikeMem.SqlServer.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Query/QueryExecutorExtrasTests.cs
@@ -92,6 +92,10 @@ SELECT * FROM t ORDER BY iddesc ASC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY;";
     }
 }
 
+/// <summary>
+/// EN: Extra tests for SQL translation behavior.
+/// PT: Testes extras para o comportamento de tradução SQL.
+/// </summary>
 public class SqlTranslatorTests
 {
     [Fact]

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyExtrasTests.cs
@@ -74,6 +74,10 @@ public sealed class SqlServerInsertStrategyExtrasTests(
     }
 }
 
+/// <summary>
+/// EN: Tests delete strategy behavior with foreign keys.
+/// PT: Testes do comportamento da estratégia de delete com chaves estrangeiras.
+/// </summary>
 public class SqlServerDeleteStrategyForeignKeyTests
 {
     [Fact]
@@ -105,6 +109,10 @@ public class SqlServerDeleteStrategyForeignKeyTests
     }
 }
 
+/// <summary>
+/// EN: Extra tests for update strategy behavior.
+/// PT: Testes extras do comportamento da estratégia de update.
+/// </summary>
 public class SqlServerUpdateStrategyExtrasTests
 {
     [Fact]

--- a/src/DbSqlLikeMem.SqlServer/Models/SqlServerDbMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/Models/SqlServerDbMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.SqlServer;
 
+/// <summary>
+/// EN: In-memory database mock configured for SQL Server.
+/// PT: Mock de banco em memória configurado para SQL Server.
+/// </summary>
 public class SqlServerDbMock : DbMock
 {
     internal override SqlDialectBase Dialect { get; set; }

--- a/src/DbSqlLikeMem.SqlServer/Models/SqlServerSchemaMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/Models/SqlServerSchemaMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.SqlServer;
 
+/// <summary>
+/// EN: Schema mock for SQL Server databases.
+/// PT: Mock de esquema para bancos SQL Server.
+/// </summary>
 public class SqlServerSchemaMock(
     string schemaName,
     SqlServerDbMock db,

--- a/src/DbSqlLikeMem.SqlServer/Models/SqlServerTableMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/Models/SqlServerTableMock.cs
@@ -1,5 +1,9 @@
 namespace DbSqlLikeMem.SqlServer;
 
+/// <summary>
+/// EN: Table mock specialized for SQL Server schema operations.
+/// PT: Mock de tabela especializado para operações de esquema SQL Server.
+/// </summary>
 public class SqlServerTableMock(
         string tableName,
         SqlServerSchemaMock schema,

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDataParameterCollectionMock.cs
@@ -3,6 +3,10 @@ using System.Data.Common;
 using Microsoft.Data.SqlClient;
 
 namespace DbSqlLikeMem.SqlServer;
+/// <summary>
+/// EN: Mock parameter collection for SQL Server commands.
+/// PT: Coleção de parâmetros mock para comandos SQL Server.
+/// </summary>
 public class SqlServerDataParameterCollectionMock
     : DbParameterCollection, IList<SqlParameter>
 {

--- a/src/DbSqlLikeMem.SqlServer/SqlServerQueryable.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerQueryable.cs
@@ -2,6 +2,10 @@ using System.Collections;
 using System.Linq.Expressions;
 
 namespace DbSqlLikeMem.SqlServer;
+/// <summary>
+/// EN: IQueryable wrapper for SQL Server LINQ translation.
+/// PT: Wrapper IQueryable para tradução LINQ do SQL Server.
+/// </summary>
 public class SqlServerQueryable<T> : IOrderedQueryable<T>
 {
     public string TableName { get; }

--- a/src/DbSqlLikeMem.Test/ConsoleTestWriter.cs
+++ b/src/DbSqlLikeMem.Test/ConsoleTestWriter.cs
@@ -3,6 +3,10 @@ using Xunit.Abstractions;
 
 namespace DbSqlLikeMem.Test;
 
+/// <summary>
+/// EN: Redirects Console output to xUnit test output.
+/// PT: Redireciona a saída do Console para o output do xUnit.
+/// </summary>
 public class ConsoleTestWriter(
     ITestOutputHelper helper
     ) : StringWriter

--- a/src/DbSqlLikeMem/Parser/Dialects.cs
+++ b/src/DbSqlLikeMem/Parser/Dialects.cs
@@ -1,10 +1,22 @@
 namespace DbSqlLikeMem;
 
+/// <summary>
+/// EN: String escaping styles supported by the parser.
+/// PT: Estilos de escape de string suportados pelo parser.
+/// </summary>
 internal enum SqlStringEscapeStyle { backslash, doubled_quote }
+/// <summary>
+/// EN: Identifier escaping styles supported by the parser.
+/// PT: Estilos de escape de identificador suportados pelo parser.
+/// </summary>
 internal enum SqlIdentifierEscapeStyle { double_quote, backtick, bracket }
 
 internal readonly record struct SqlQuotePair(char Begin, char End);
 
+/// <summary>
+/// EN: Defines escape rules and behavior for a SQL dialect.
+/// PT: Define regras de escape e comportamento de um dialeto SQL.
+/// </summary>
 internal interface ISqlDialect
 {
     public int Version { get; }

--- a/src/DbSqlLikeMem/Parser/ExprAst.cs
+++ b/src/DbSqlLikeMem/Parser/ExprAst.cs
@@ -36,7 +36,15 @@ internal sealed record CaseExpr(
 internal sealed record CaseWhenThen(SqlExpr When, SqlExpr Then);
 
 internal sealed record StarExpr() : SqlExpr;
+/// <summary>
+/// EN: Unary operators represented in the SQL AST.
+/// PT: Operadores unários representados na AST SQL.
+/// </summary>
 internal enum SqlUnaryOp { Not }
+/// <summary>
+/// EN: Binary operators represented in the SQL AST.
+/// PT: Operadores binários representados na AST SQL.
+/// </summary>
 internal enum SqlBinaryOp
 {
     And, Or,

--- a/src/DbSqlLikeMem/Parser/SqlQueryAst.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryAst.cs
@@ -79,6 +79,10 @@ internal sealed record SqlTableSource(
     string? DerivedSql
 );
 
+/// <summary>
+/// EN: Join types represented in the SQL AST.
+/// PT: Tipos de join representados na AST SQL.
+/// </summary>
 internal enum SqlJoinType
 {
     Inner,

--- a/src/DbSqlLikeMem/Parser/SqlToken.cs
+++ b/src/DbSqlLikeMem/Parser/SqlToken.cs
@@ -1,4 +1,8 @@
 namespace DbSqlLikeMem;
+/// <summary>
+/// EN: Token kinds produced by the SQL tokenizer.
+/// PT: Tipos de tokens produzidos pelo tokenizador SQL.
+/// </summary>
 internal enum SqlTokenKind
 {
     Identifier,


### PR DESCRIPTION
### Motivation
- Improve code documentation and IDE/tooling experience by adding missing XML `<summary>` comments across provider-specific mocks, queryables, schema/db/table classes, parser types and test helpers.
- Provide consistent bilingual (EN/PT) summaries so public/internal types and tests are clearer to contributors and maintainers.

### Description
- Inserted XML `<summary>` blocks for many provider-specific types (MySql, Npgsql, Oracle, SqlServer) including `*DbMock`, `*SchemaMock`, `*TableMock`, `*CommandMock`, parameter collections and `Queryable` wrappers.
- Documented parser-facing enums and interfaces in `src/DbSqlLikeMem/Parser` (eg. token kinds, join/op enums and `ISqlDialect`) to clarify AST/tokenizer/dialect behavior.
- Added summaries to test fixtures, DTOs and test helper types (eg. `ConsoleTestWriter`, `UserObjectTest`, parser corpus enums and translator test classes).
- This is a documentation-only change across ~45 files (no runtime/logic changes).

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a5fc98da0832ca810809c933a077b)