### PR TITLE
Fix defaults for omitted insert columns

### DIFF
--- a/src/DbSqlLikeMem/Models/TableMock.cs
+++ b/src/DbSqlLikeMem/Models/TableMock.cs
@@ -276,10 +276,16 @@ public abstract class TableMock
     {
         foreach (var (key, col) in Columns)
         {
-            if (!value.ContainsKey(col.Index)) continue;
-            if (col.Identity) value[col.Index] = NextIdentity++;
-            else if (col.DefaultValue != null && value[col.Index] == null) value[col.Index] = col.DefaultValue;
-            if (!col.Nullable && value[col.Index] == null) throw ColumnCannotBeNull(key);
+            if (!value.ContainsKey(col.Index))
+                value[col.Index] = null;
+
+            if (col.Identity)
+                value[col.Index] = NextIdentity++;
+            else if (col.DefaultValue != null && value[col.Index] == null)
+                value[col.Index] = col.DefaultValue;
+
+            if (!col.Nullable && value[col.Index] == null)
+                throw ColumnCannotBeNull(key);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent `KeyNotFoundException` during `INSERT` operations that omit columns by ensuring inserted row dictionaries include all table column indexes and receive identity/default values before nullability checks.

### Description
- Update `ApplyDefaultValues` in `src/DbSqlLikeMem/Models/TableMock.cs` to populate missing `col.Index` entries with `null`, assign identity values via `NextIdentity++`, apply `DefaultValue` when appropriate, and enforce non-nullable constraints.
- This keeps row dictionaries aligned with the table schema so downstream code that accesses rows by column index no longer throws when columns were omitted from the `INSERT`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a73033e74832cb0d01893232233aa)