### PR TITLE
Fix SQL Server DELETE ... JOIN handling and add DATEADD support in AST executor

### DIFF
--- a/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
@@ -83,8 +83,8 @@ public class SqlServerCommandMock(
         return query switch
         {
             SqlInsertQuery insertQ => connection.ExecuteInsert(insertQ, Parameters, connection.Db.Dialect),
-            SqlUpdateQuery updateQ => connection.ExecuteUpdate(updateQ, Parameters),
-            SqlDeleteQuery deleteQ => connection.ExecuteDelete(deleteQ, Parameters),
+            SqlUpdateQuery updateQ => connection.ExecuteUpdateSmart(updateQ, Parameters, connection.Db.Dialect),
+            SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
             _ => throw new NotSupportedException($"Tipo de query não suportado em ExecuteNonQuery: {query.GetType().Name}")
         };


### PR DESCRIPTION
### Motivation
- Fix an issue where SQL Server `DELETE ... FROM ... JOIN (SELECT ...)` and `UPDATE ... JOIN (SELECT ...)` patterns were not handled by the smart strategies, causing failures such as the `DeleteJoinDerivedSelect_ShouldDeleteRows` test.
- Add support for SQL Server `DATEADD` calls in the AST evaluator because some tests use `DATEADD(...)` and the executor previously only covered `DATE_ADD`/INTERVAL patterns.

### Description
- Route parsed `SqlUpdateQuery` and `SqlDeleteQuery` in `src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs` through `ExecuteUpdateSmart` and `ExecuteDeleteSmart` so join-from-select update/delete statements are executed by the smart strategies.
- Implement `DATEADD` evaluation in `src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs` to evaluate `DATEADD(unit, amount, date)` with common date parts (`YEAR`, `MONTH`, `DAY`, `HOUR`, `MINUTE`, `SECOND`) and add a helper `GetDateAddUnit` to normalize unit names.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a7779dd94832c9f1de3fcac9cc622)