### PR TITLE
Support PostgreSQL casts, json operators, INTERVAL and OFFSET/FETCH in parser/executor

### DIFF
--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
@@ -25,6 +25,8 @@ internal sealed class NpgsqlDialect : SqlDialectBase
         operators:
         [
             "->>", "->",
+            "#>>", "#>",
+            "::",
             ">=", "<=", "<>", "!=", "==",
             "&&", "||"
         ])

--- a/src/DbSqlLikeMem.Npgsql/Query/NpgsqlAstQueryExecutor.cs
+++ b/src/DbSqlLikeMem.Npgsql/Query/NpgsqlAstQueryExecutor.cs
@@ -22,5 +22,36 @@ internal sealed class NpgsqlAstQueryExecutor(
     IDataParameterCollection pars
     ) : AstQueryExecutorBase(cnn, pars, cnn.Db.Dialect)
 {
+    protected override SqlExpr MapJsonAccess(JsonAccessExpr ja)
+    {
+        var pathExpr = ja.Path;
+        if (pathExpr is LiteralExpr lit && lit.Value is string s)
+        {
+            var converted = ConvertPostgresJsonPath(s);
+            if (converted is not null)
+                pathExpr = new LiteralExpr(converted);
+        }
 
+        var normalized = new JsonAccessExpr(ja.Target, pathExpr, ja.Unquote);
+        return base.MapJsonAccess(normalized);
+    }
+
+    private static string? ConvertPostgresJsonPath(string raw)
+    {
+        var trimmed = raw.Trim();
+        if (!trimmed.StartsWith("{", StringComparison.Ordinal) || !trimmed.EndsWith("}", StringComparison.Ordinal))
+            return null;
+
+        var inner = trimmed[1..^1];
+        if (string.IsNullOrWhiteSpace(inner))
+            return null;
+
+        var parts = inner
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(p => p.Trim('"'))
+            .Where(p => p.Length > 0)
+            .ToArray();
+
+        return parts.Length == 0 ? null : "$." + string.Join('.', parts);
+    }
 }

--- a/src/DbSqlLikeMem/Parser/SqlTokenizer.cs
+++ b/src/DbSqlLikeMem/Parser/SqlTokenizer.cs
@@ -27,9 +27,24 @@ internal sealed class SqlTokenizer
             if (TrySkipComment())
                 continue;
 
+            if (ch == '\\' && _dialect.IsStringQuote(Peek(1)))
+            {
+                Read(); // skip escape char before string literal
+                continue;
+            }
+
             if (_dialect.IsStringQuote(ch))
             {
                 tokens.Add(ReadString());
+                continue;
+            }
+
+            if (ch == ':' && Peek(1) == ':' && _dialect.Operators.Contains("::"))
+            {
+                var start = _pos;
+                Read();
+                Read();
+                tokens.Add(new SqlToken(SqlTokenKind.Operator, "::", start));
                 continue;
             }
 


### PR DESCRIPTION
### Motivation
- Fix PostgreSQL-related parser/executor gaps that caused Npgsql tests to fail by adding PostgreSQL-specific operators and interval handling. 
- Make JSON path/array syntax and Postgres-style casts (`::`) compatible with the existing MySQL-oriented execution model without breaking current behavior.

### Description
- Tokenizer: updated `SqlTokenizer` to recognize `::` as an operator and handle a backslash escape before string literals. (file: `SqlTokenizer.cs`).
- Parser: added support in `SqlExpressionParser` for PostgreSQL-style casts (`::`) by converting them to a `CAST`-style `CallExpr`, added parsing for `INTERVAL` literals, and extended JSON operator handling to accept `#>`/`#>>` alongside `->`/`->>` (file: `SqlExpressionParser.cs`).
- Executor: extended `ApplyLimit` in `AstQueryExecutorBase` to apply both `SqlLimitOffset` and `SqlFetch` (OFFSET/FETCH) semantics, added runtime support for `INTERVAL` values and `DateTime` +/- `INTERVAL` arithmetic, and wired `INTERVAL` `CallExpr` evaluation (file: `AstQueryExecutorBase.cs`).
- Dialect: expanded `NpgsqlDialect` operators list to include `#>`, `#>>` and `::` so they are tokenized/recognized (file: `NpgsqlDialect.cs`).
- Npgsql executor: added `NpgsqlAstQueryExecutor.MapJsonAccess` to normalize Postgres JSON path array syntax (e.g. `'{a,b}'`) into a `JSON_EXTRACT`-friendly path (file: `NpgsqlAstQueryExecutor.cs`).

### Testing
- No automated tests were executed in this change set; the patch focuses on parser/executor behavior and was validated via code inspection only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a770cf910832cb2b73d206eaf811d)