### PR TITLE
Add XML summary comments to test methods across suites

### DIFF
--- a/src/DbSqlLikeMem.MySql.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/CsvLoaderAndIndexTests.cs
@@ -4,6 +4,10 @@ public sealed class CsvLoaderAndIndexTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests CsvLoader_ShouldLoadRows_ByColumnName behavior.
+    /// PT: Testa o comportamento de CsvLoader_ShouldLoadRows_ByColumnName.
+    /// </summary>
     [Fact]
     public void CsvLoader_ShouldLoadRows_ByColumnName()
     {
@@ -26,6 +30,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal("John", tb[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests GetColumn_ShouldThrow_UnknownColumn behavior.
+    /// PT: Testa o comportamento de GetColumn_ShouldThrow_UnknownColumn.
+    /// </summary>
     [Fact]
     public void GetColumn_ShouldThrow_UnknownColumn()
     {
@@ -37,6 +45,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal(1054, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests Index_Lookup_ShouldReturnRowPositions behavior.
+    /// PT: Testa o comportamento de Index_Lookup_ShouldReturnRowPositions.
+    /// </summary>
     [Fact]
     public void Index_Lookup_ShouldReturnRowPositions()
     {
@@ -56,6 +68,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal([0, 1], [.. ix!.Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests BackupRestore_ShouldRollbackData behavior.
+    /// PT: Testa o comportamento de BackupRestore_ShouldRollbackData.
+    /// </summary>
     [Fact]
     public void BackupRestore_ShouldRollbackData()
     {

--- a/src/DbSqlLikeMem.MySql.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/DapperTests.cs
@@ -21,6 +21,10 @@ public sealed class DapperTests : XUnitTestBase
         _connection.Open();
     }
 
+    /// <summary>
+    /// EN: Tests TestSelectQuery behavior.
+    /// PT: Testa o comportamento de TestSelectQuery.
+    /// </summary>
     [Fact]
     public void TestSelectQuery()
     {
@@ -28,6 +32,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.NotNull(users);
     }
 
+    /// <summary>
+    /// EN: Tests QueryShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryShouldReturnCorrectData()
     {
@@ -61,6 +69,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.Equal(dt, result.First().CreatedDate);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldInsertData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldInsertData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldInsertData()
     {
@@ -87,6 +99,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.Equal(dt, table[0][2]);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldUpdateData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldUpdateData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldUpdateData()
     {
@@ -126,6 +142,10 @@ UPDATE users
         Assert.Equal(dtUpdate, table[0][3]);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldDeleteData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldDeleteData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldDeleteData()
     {
@@ -148,6 +168,10 @@ UPDATE users
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleResultSets()
     {

--- a/src/DbSqlLikeMem.MySql.Test/DapperUserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/DapperUserTests.cs
@@ -14,6 +14,10 @@ public sealed class DapperUserTests(
         public Guid? TestGuidNull { get; set; }
     }
 
+    /// <summary>
+    /// EN: Tests InsertUserShouldAddUserToTable behavior.
+    /// PT: Testa o comportamento de InsertUserShouldAddUserToTable.
+    /// </summary>
     [Fact]
     public void InsertUserShouldAddUserToTable()
     {
@@ -58,6 +62,10 @@ public sealed class DapperUserTests(
         Assert.Equal(user.TestGuidNull, insertedRow[6]);
     }
 
+    /// <summary>
+    /// EN: Tests QueryUserShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryUserShouldReturnCorrectData()
     {
@@ -110,6 +118,10 @@ public sealed class DapperUserTests(
         Assert.Equal(user.TestGuidNull, result.TestGuidNull);
     }
 
+    /// <summary>
+    /// EN: Tests UpdateUserShouldModifyUserInTable behavior.
+    /// PT: Testa o comportamento de UpdateUserShouldModifyUserInTable.
+    /// </summary>
     [Fact]
     public void UpdateUserShouldModifyUserInTable()
     {
@@ -176,6 +188,10 @@ public sealed class DapperUserTests(
         Assert.Equal(updatedUser.TestGuidNull, updatedRow[6]);
     }
 
+    /// <summary>
+    /// EN: Tests DeleteUserShouldRemoveUserFromTable behavior.
+    /// PT: Testa o comportamento de DeleteUserShouldRemoveUserFromTable.
+    /// </summary>
     [Fact]
     public void DeleteUserShouldRemoveUserFromTable()
     {
@@ -223,6 +239,10 @@ public sealed class DapperUserTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleUserResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {

--- a/src/DbSqlLikeMem.MySql.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.MySql.Test/DapperUserTests2.cs
@@ -16,6 +16,10 @@ public sealed class DapperUserTests2(
         public List<int> Tenants { get; set; } = [];
     }
 
+    /// <summary>
+    /// EN: Tests QueryUserShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryUserShouldReturnCorrectData()
     {
@@ -68,6 +72,10 @@ public sealed class DapperUserTests2(
         Assert.Equal(user.TestGuidNull, result.TestGuidNull);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleUserResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
@@ -127,6 +135,10 @@ public sealed class DapperUserTests2(
         Assert.Equal("jane.doe@example.com", users2[0].Email);
     }
 
+    /// <summary>
+    /// EN: Tests QueryWithJoinShouldReturnJoinedData behavior.
+    /// PT: Testa o comportamento de QueryWithJoinShouldReturnJoinedData.
+    /// </summary>
     [Fact]
     public void QueryWithJoinShouldReturnJoinedData()
     {

--- a/src/DbSqlLikeMem.MySql.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/ExistsTests.cs
@@ -4,6 +4,10 @@ public sealed class ExistsTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Exists_ShouldFilterUsersWithOrders behavior.
+    /// PT: Testa o comportamento de Exists_ShouldFilterUsersWithOrders.
+    /// </summary>
     [Fact]
     public void Exists_ShouldFilterUsersWithOrders()
     {
@@ -43,6 +47,10 @@ ORDER BY u.Id";
         ids.Should().Equal(1, 3);
     }
 
+    /// <summary>
+    /// EN: Tests NotExists_ShouldFilterUsersWithoutOrders behavior.
+    /// PT: Testa o comportamento de NotExists_ShouldFilterUsersWithoutOrders.
+    /// </summary>
     [Fact]
     public void NotExists_ShouldFilterUsersWithoutOrders()
     {
@@ -81,6 +89,10 @@ ORDER BY u.Id";
         ids.Should().Equal(2);
     }
 
+    /// <summary>
+    /// EN: Tests Exists_WithExtraPredicate_ShouldWork behavior.
+    /// PT: Testa o comportamento de Exists_WithExtraPredicate_ShouldWork.
+    /// </summary>
     [Fact]
     public void Exists_WithExtraPredicate_ShouldWork()
     {

--- a/src/DbSqlLikeMem.MySql.Test/ExtendedMySqlMockTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/ExtendedMySqlMockTests.cs
@@ -4,6 +4,10 @@ public sealed class ExtendedMySqlMockTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests InsertAutoIncrementShouldAssignIdentityWhenNotSpecified behavior.
+    /// PT: Testa o comportamento de InsertAutoIncrementShouldAssignIdentityWhenNotSpecified.
+    /// </summary>
     [Fact]
     public void InsertAutoIncrementShouldAssignIdentityWhenNotSpecified()
     {
@@ -26,6 +30,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal("Bob", table[1][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertNullIntoNullableColumnShouldSucceed behavior.
+    /// PT: Testa o comportamento de InsertNullIntoNullableColumnShouldSucceed.
+    /// </summary>
     [Fact]
     public void InsertNullIntoNullableColumnShouldSucceed()
     {
@@ -41,6 +49,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Null(table[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertNullIntoNonNullableColumnShouldThrow behavior.
+    /// PT: Testa o comportamento de InsertNullIntoNonNullableColumnShouldThrow.
+    /// </summary>
     [Fact]
     public void InsertNullIntoNonNullableColumnShouldThrow()
     {
@@ -57,6 +69,10 @@ public sealed class ExtendedMySqlMockTests(
 
     private static readonly string[] item = ["first", "second"];
 
+    /// <summary>
+    /// EN: Tests CompositeIndexFilterShouldReturnCorrectRows behavior.
+    /// PT: Testa o comportamento de CompositeIndexFilterShouldReturnCorrectRows.
+    /// </summary>
     [Fact]
     public void CompositeIndexFilterShouldReturnCorrectRows()
     {
@@ -78,6 +94,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(1, (int)result[0].value);
     }
 
+    /// <summary>
+    /// EN: Tests LikeFilterShouldReturnMatchingRows behavior.
+    /// PT: Testa o comportamento de LikeFilterShouldReturnMatchingRows.
+    /// </summary>
     [Fact]
     public void LikeFilterShouldReturnMatchingRows()
     {
@@ -94,6 +114,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal("alice", res[0].name);
     }
 
+    /// <summary>
+    /// EN: Tests InFilterShouldReturnMatchingRows behavior.
+    /// PT: Testa o comportamento de InFilterShouldReturnMatchingRows.
+    /// </summary>
     [Fact]
     public void InFilterShouldReturnMatchingRows()
     {
@@ -111,6 +135,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal([1, 3], ids);
     }
 
+    /// <summary>
+    /// EN: Tests OrderByLimitOffsetDistinctShouldReturnExpectedRows behavior.
+    /// PT: Testa o comportamento de OrderByLimitOffsetDistinctShouldReturnExpectedRows.
+    /// </summary>
     [Fact]
     public void OrderByLimitOffsetDistinctShouldReturnExpectedRows()
     {
@@ -128,6 +156,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(1, (int)res[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests HavingFilterShouldApplyAfterAggregation behavior.
+    /// PT: Testa o comportamento de HavingFilterShouldApplyAfterAggregation.
+    /// </summary>
     [Fact]
     public void HavingFilterShouldApplyAfterAggregation()
     {
@@ -148,6 +180,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(2L, result[0].C);
     }
 
+    /// <summary>
+    /// EN: Tests ForeignKeyDeleteShouldThrowOnReferencedParentDeletion behavior.
+    /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletion.
+    /// </summary>
     [Fact]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletion()
     {
@@ -171,6 +207,10 @@ public sealed class ExtendedMySqlMockTests(
             cnn.Execute("DELETE FROM parent WHERE id = 1"));
     }
 
+    /// <summary>
+    /// EN: Tests ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK behavior.
+    /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK.
+    /// </summary>
     [Fact]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK()
     {
@@ -193,6 +233,10 @@ public sealed class ExtendedMySqlMockTests(
             cnn.Execute("DELETE FROM parent WHERE id = 1"));
     }
 
+    /// <summary>
+    /// EN: Tests MultipleParameterSetsInsertShouldInsertAllRows behavior.
+    /// PT: Testa o comportamento de MultipleParameterSetsInsertShouldInsertAllRows.
+    /// </summary>
     [Fact]
     public void MultipleParameterSetsInsertShouldInsertAllRows()
     {

--- a/src/DbSqlLikeMem.MySql.Test/FluentTest.cs
+++ b/src/DbSqlLikeMem.MySql.Test/FluentTest.cs
@@ -19,6 +19,10 @@ public sealed class FluentTest(
         return cnn;
     }
 
+    /// <summary>
+    /// EN: Tests InsertUpdateDeleteFluentScenario behavior.
+    /// PT: Testa o comportamento de InsertUpdateDeleteFluentScenario.
+    /// </summary>
     [Fact]
     public void InsertUpdateDeleteFluentScenario()
     {
@@ -58,6 +62,10 @@ public sealed class FluentTest(
         Assert.True(cnn.Metrics.Elapsed > TimeSpan.Zero);
     }
 
+    /// <summary>
+    /// EN: Tests TestFluent behavior.
+    /// PT: Testa o comportamento de TestFluent.
+    /// </summary>
     [Fact]
     public void TestFluent()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlAdditionalBehaviorCoverageTests.cs
@@ -36,6 +36,10 @@ public sealed class MySqlAdditionalBehaviorCoverageTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_IsNull_And_IsNotNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_IsNull_And_IsNotNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_IsNull_And_IsNotNull_ShouldWork()
     {
@@ -46,6 +50,10 @@ public sealed class MySqlAdditionalBehaviorCoverageTests : XUnitTestBase
         Assert.Equal([1, 3], notNullIds);
     }
 
+    /// <summary>
+    /// EN: Tests Where_EqualNull_ShouldReturnNoRows behavior.
+    /// PT: Testa o comportamento de Where_EqualNull_ShouldReturnNoRows.
+    /// </summary>
     [Fact]
     public void Where_EqualNull_ShouldReturnNoRows()
     {
@@ -57,6 +65,10 @@ public sealed class MySqlAdditionalBehaviorCoverageTests : XUnitTestBase
         Assert.Empty(ids);
     }
 
+    /// <summary>
+    /// EN: Tests LeftJoin_ShouldPreserveLeftRows_WhenNoMatch behavior.
+    /// PT: Testa o comportamento de LeftJoin_ShouldPreserveLeftRows_WhenNoMatch.
+    /// </summary>
     [Fact]
     public void LeftJoin_ShouldPreserveLeftRows_WhenNoMatch()
     {
@@ -79,6 +91,10 @@ ORDER BY u.id
         Assert.Null((object?)rows[2].amount);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_Desc_ThenAsc_ShouldBeDeterministic behavior.
+    /// PT: Testa o comportamento de OrderBy_Desc_ThenAsc_ShouldBeDeterministic.
+    /// </summary>
     [Fact]
     public void OrderBy_Desc_ThenAsc_ShouldBeDeterministic()
     {
@@ -92,6 +108,10 @@ ORDER BY amount DESC, id ASC
         Assert.Equal([200m, 50m, 10m], [.. rows.Select(r => (decimal)r.amount)]);
     }
 
+    /// <summary>
+    /// EN: Tests Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls behavior.
+    /// PT: Testa o comportamento de Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls.
+    /// </summary>
     [Fact]
     public void Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls()
     {
@@ -101,6 +121,10 @@ ORDER BY amount DESC, id ASC
         Assert.Equal(2L, (long)r.c2);
     }
 
+    /// <summary>
+    /// EN: Tests Having_ShouldFilterGroups behavior.
+    /// PT: Testa o comportamento de Having_ShouldFilterGroups.
+    /// </summary>
     [Fact]
     public void Having_ShouldFilterGroups()
     {
@@ -115,6 +139,10 @@ ORDER BY userid
         Assert.Equal([2], userIds);
     }
 
+    /// <summary>
+    /// EN: Tests Where_In_WithParameterList_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_In_WithParameterList_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_In_WithParameterList_ShouldWork()
     {
@@ -122,6 +150,10 @@ ORDER BY userid
         Assert.Equal([1, 3], ids);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_WithColumnsOutOfOrder_ShouldMapCorrectly behavior.
+    /// PT: Testa o comportamento de Insert_WithColumnsOutOfOrder_ShouldMapCorrectly.
+    /// </summary>
     [Fact]
     public void Insert_WithColumnsOutOfOrder_ShouldMapCorrectly()
     {
@@ -133,6 +165,10 @@ ORDER BY userid
         Assert.Equal("zed@x.com", (string)row.email);
     }
 
+    /// <summary>
+    /// EN: Tests Delete_WithInParameterList_ShouldDeleteMatchingRows behavior.
+    /// PT: Testa o comportamento de Delete_WithInParameterList_ShouldDeleteMatchingRows.
+    /// </summary>
     [Fact]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
@@ -143,6 +179,10 @@ ORDER BY userid
         Assert.Equal([2], remaining);
     }
 
+    /// <summary>
+    /// EN: Tests Update_SetExpression_ShouldUpdateRows behavior.
+    /// PT: Testa o comportamento de Update_SetExpression_ShouldUpdateRows.
+    /// </summary>
     [Fact]
     public void Update_SetExpression_ShouldUpdateRows()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlAdvancedSqlGapTests.cs
@@ -35,6 +35,10 @@ public sealed class MySqlAdvancedSqlGapTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Window_RowNumber_PartitionBy_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
+    /// </summary>
     [Fact]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
@@ -47,6 +51,10 @@ ORDER BY tenantid, id").ToList();
         Assert.Equal([1, 2, 1], [.. rows.Select(r => (int)r.rn)]);
     }
 
+    /// <summary>
+    /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
+    /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
+    /// </summary>
     [Fact]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
@@ -59,6 +67,10 @@ ORDER BY u.id").ToList();
         Assert.Equal([15m, 7m, 0m], [.. rows.Select(r => (decimal)(r.total ?? 0m))]);
     }
 
+    /// <summary>
+    /// EN: Tests DateAdd_IntervalDay_ShouldWork behavior.
+    /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
+    /// </summary>
     [Fact]
     public void DateAdd_IntervalDay_ShouldWork()
     {
@@ -74,6 +86,10 @@ ORDER BY id").ToList();
             [.. rows.Select(r => (DateTime)r.d)]);
     }
 
+    /// <summary>
+    /// EN: Tests Cast_StringToInt_ShouldWork behavior.
+    /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
+    /// </summary>
     [Fact]
     public void Cast_StringToInt_ShouldWork()
     {
@@ -82,6 +98,10 @@ ORDER BY id").ToList();
         Assert.Equal(42, (int)rows[0].v);
     }
 
+    /// <summary>
+    /// EN: Tests Regexp_Operator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
+    /// </summary>
     [Fact]
     public void Regexp_Operator_ShouldWork()
     {
@@ -89,6 +109,10 @@ ORDER BY id").ToList();
         Assert.Equal([1, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_Field_Function_ShouldWork behavior.
+    /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
+    /// </summary>
     [Fact]
     public void OrderBy_Field_Function_ShouldWork()
     {
@@ -96,6 +120,10 @@ ORDER BY id").ToList();
         Assert.Equal([3, 1, 2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Collation_CaseSensitivity_ShouldFollowColumnCollation behavior.
+    /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
+    /// </summary>
     [Fact]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlAggregationTests.cs
@@ -20,6 +20,10 @@ public sealed class MySqlAggregationTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
+    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
+    /// </summary>
     [Fact]
     public void GroupBy_WithCountAndSum_ShouldWork()
     {
@@ -42,6 +46,10 @@ public sealed class MySqlAggregationTests : XUnitTestBase
         Assert.Equal(5m, (decimal)rows[1].sumAmount);
     }
 
+    /// <summary>
+    /// EN: Tests Having_ShouldFilterAggregates behavior.
+    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
+    /// </summary>
     [Fact]
     public void Having_ShouldFilterAggregates()
     {
@@ -57,6 +65,10 @@ public sealed class MySqlAggregationTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].userId);
     }
 
+    /// <summary>
+    /// EN: Tests Distinct_Order_Limit_Offset_ShouldWork behavior.
+    /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
+    /// </summary>
     [Fact]
     public void Distinct_Order_Limit_Offset_ShouldWork()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlDataParameterCollectionMockTest.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlDataParameterCollectionMockTest.cs
@@ -3,6 +3,10 @@ public sealed class MySqlDataParameterCollectionMockTest(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames behavior.
+    /// PT: Testa o comportamento de ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames.
+    /// </summary>
     [Fact]
     public void ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames()
     {
@@ -13,6 +17,10 @@ public sealed class MySqlDataParameterCollectionMockTest(
         Assert.Equal("id", MySqlDataParameterCollectionMock.NormalizeParameterName("@'id'"));
     }
 
+    /// <summary>
+    /// EN: Tests ParameterCollection_Add_DuplicateName_ShouldThrow behavior.
+    /// PT: Testa o comportamento de ParameterCollection_Add_DuplicateName_ShouldThrow.
+    /// </summary>
     [Fact]
     public void ParameterCollection_Add_DuplicateName_ShouldThrow()
     {
@@ -22,6 +30,10 @@ public sealed class MySqlDataParameterCollectionMockTest(
         Assert.Throws<ArgumentException>(() => pars.AddWithValue("@id", 2)); // case-insensitive
     }
 
+    /// <summary>
+    /// EN: Tests ParameterCollection_RemoveAt_ShouldReindexDictionary behavior.
+    /// PT: Testa o comportamento de ParameterCollection_RemoveAt_ShouldReindexDictionary.
+    /// </summary>
     [Fact]
     public void ParameterCollection_RemoveAt_ShouldReindexDictionary()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlJoinTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlJoinTests.cs
@@ -28,6 +28,10 @@ public sealed class MySqlJoinTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests LeftJoin_ShouldKeepAllLeftRows behavior.
+    /// PT: Testa o comportamento de LeftJoin_ShouldKeepAllLeftRows.
+    /// </summary>
     [Fact]
     public void LeftJoin_ShouldKeepAllLeftRows()
     {
@@ -44,6 +48,10 @@ public sealed class MySqlJoinTests : XUnitTestBase
         Assert.Contains(rows, r => (int)r.id == 2);
     }
 
+    /// <summary>
+    /// EN: Tests RightJoin_ShouldKeepAllRightRows behavior.
+    /// PT: Testa o comportamento de RightJoin_ShouldKeepAllRightRows.
+    /// </summary>
     [Fact]
     public void RightJoin_ShouldKeepAllRightRows()
     {
@@ -74,6 +82,10 @@ public sealed class MySqlJoinTests : XUnitTestBase
     //    Assert.Contains(rows, r => r.id is null && (int)r.orderId == 12); // órfão
     //}
 
+    /// <summary>
+    /// EN: Tests Join_ON_WithMultipleConditions_AND_ShouldWork behavior.
+    /// PT: Testa o comportamento de Join_ON_WithMultipleConditions_AND_ShouldWork.
+    /// </summary>
     [Fact]
     public void Join_ON_WithMultipleConditions_AND_ShouldWork()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlLinqProviderTest.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlLinqProviderTest.cs
@@ -9,6 +9,10 @@ public sealed class MySqlLinqProviderTest
     }
 #pragma warning restore CA1812
 
+    /// <summary>
+    /// EN: Tests LinqProvider_ShouldQueryWhereAndReturnRows behavior.
+    /// PT: Testa o comportamento de LinqProvider_ShouldQueryWhereAndReturnRows.
+    /// </summary>
     [Fact]
     public void LinqProvider_ShouldQueryWhereAndReturnRows()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs
@@ -25,6 +25,10 @@ public sealed class MySqlMockTests
         _connection.Open();
     }
 
+    /// <summary>
+    /// EN: Tests TestInsert behavior.
+    /// PT: Testa o comportamento de TestInsert.
+    /// </summary>
     [Fact]
     public void TestInsert()
     {
@@ -37,6 +41,10 @@ public sealed class MySqlMockTests
         Assert.Equal("John Doe", _connection.GetTable("users")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TestUpdate behavior.
+    /// PT: Testa o comportamento de TestUpdate.
+    /// </summary>
     [Fact]
     public void TestUpdate()
     {
@@ -52,6 +60,10 @@ public sealed class MySqlMockTests
         Assert.Equal("Jane Doe", _connection.GetTable("users")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TestDelete behavior.
+    /// PT: Testa o comportamento de TestDelete.
+    /// </summary>
     [Fact]
     public void TestDelete()
     {
@@ -67,6 +79,10 @@ public sealed class MySqlMockTests
         Assert.Empty(_connection.GetTable("users"));
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionCommit behavior.
+    /// PT: Testa o comportamento de TestTransactionCommit.
+    /// </summary>
     [Fact]
     public void TestTransactionCommit()
     {
@@ -98,6 +114,10 @@ public sealed class MySqlMockTests
         Assert.Single(users);
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionCommitInsertUpdate behavior.
+    /// PT: Testa o comportamento de TestTransactionCommitInsertUpdate.
+    /// </summary>
     [Fact]
     public void TestTransactionCommitInsertUpdate()
     {
@@ -116,6 +136,10 @@ public sealed class MySqlMockTests
         Assert.Equal("Bob", name);
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionRollback behavior.
+    /// PT: Testa o comportamento de TestTransactionRollback.
+    /// </summary>
     [Fact]
     public void TestTransactionRollback()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlSelectAndWhereMoreCoverageTests.cs
@@ -30,6 +30,10 @@ public sealed class MySqlSelectAndWhereMoreCoverageTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_Between_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Between_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Between_ShouldWork()
     {
@@ -37,6 +41,10 @@ public sealed class MySqlSelectAndWhereMoreCoverageTests : XUnitTestBase
         Assert.Equal([2, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_NotIn_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_NotIn_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_NotIn_ShouldWork()
     {
@@ -45,6 +53,10 @@ public sealed class MySqlSelectAndWhereMoreCoverageTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Where_ExistsSubquery_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_ExistsSubquery_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_ExistsSubquery_ShouldWork()
     {
@@ -62,6 +74,10 @@ ORDER BY u.id").ToList();
         Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_CaseWhen_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_CaseWhen_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_CaseWhen_ShouldWork()
     {
@@ -77,6 +93,10 @@ ORDER BY id").ToList();
         Assert.Equal("Y", (string)rows[2].hasEmail);
     }
 
+    /// <summary>
+    /// EN: Tests Select_IfNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_IfNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_IfNull_ShouldWork()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlSqlCompatibilityGapTests.cs
@@ -36,6 +36,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_Precedence_AND_ShouldBindStrongerThan_OR behavior.
+    /// PT: Testa o comportamento de Where_Precedence_AND_ShouldBindStrongerThan_OR.
+    /// </summary>
     [Fact]
     public void Where_Precedence_AND_ShouldBindStrongerThan_OR()
     {
@@ -45,6 +49,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_OR_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_OR_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_OR_ShouldWork()
     {
@@ -52,6 +60,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 3], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_ParenthesesGrouping_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_ParenthesesGrouping_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_ParenthesesGrouping_ShouldWork()
     {
@@ -61,6 +73,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_Arithmetic_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_Arithmetic_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_Arithmetic_ShouldWork()
     {
@@ -68,6 +84,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([2, 3, 4], [.. rows.Select(r => (int)r.nextId)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_CASE_WHEN_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_CASE_WHEN_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_CASE_WHEN_ShouldWork()
     {
@@ -75,6 +95,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 0, 1], [.. rows.Select(r => (int)r.hasEmail)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_IF_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_IF_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_IF_ShouldWork()
     {
@@ -83,6 +107,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["yes", "no", "yes"], [.. rows.Select(r => (string)r.flag)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_IIF_ShouldWork_AsAliasForIF behavior.
+    /// PT: Testa o comportamento de Select_Expressions_IIF_ShouldWork_AsAliasForIF.
+    /// </summary>
     [Fact]
     public void Select_Expressions_IIF_ShouldWork_AsAliasForIF()
     {
@@ -91,6 +119,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 0, 1], [.. rows.Select(r => (int)r.hasEmail)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_COALESCE_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_COALESCE_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_COALESCE_ShouldWork()
     {
@@ -98,6 +130,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["john@x.com", "none", "jane@x.com"], [.. rows.Select(r => (string)r.em)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_IFNULL_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_IFNULL_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_IFNULL_ShouldWork()
     {
@@ -105,6 +141,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["john@x.com", "none", "jane@x.com"], [.. rows.Select(r => (string)r.em)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_CONCAT_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_CONCAT_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_CONCAT_ShouldWork()
     {
@@ -112,6 +152,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["John#1", "Bob#2", "Jane#3"], [.. rows.Select(r => (string)r.tag)]);
     }
 
+    /// <summary>
+    /// EN: Tests Distinct_ShouldBeConsistent behavior.
+    /// PT: Testa o comportamento de Distinct_ShouldBeConsistent.
+    /// </summary>
     [Fact]
     public void Distinct_ShouldBeConsistent()
     {
@@ -121,6 +165,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["Bob", "Jane", "John"], [.. rows.Select(r => (string)r.name)]);
     }
 
+    /// <summary>
+    /// EN: Tests Join_ComplexOn_WithOr_ShouldWork behavior.
+    /// PT: Testa o comportamento de Join_ComplexOn_WithOr_ShouldWork.
+    /// </summary>
     [Fact]
     public void Join_ComplexOn_WithOr_ShouldWork()
     {
@@ -137,6 +185,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
             [.. rows.Select(r => ((int)r.uid,(int)r.oid))]);
     }
 
+    /// <summary>
+    /// EN: Tests GroupBy_Having_ShouldSupportAggregates behavior.
+    /// PT: Testa o comportamento de GroupBy_Having_ShouldSupportAggregates.
+    /// </summary>
     [Fact]
     public void GroupBy_Having_ShouldSupportAggregates()
     {
@@ -150,6 +202,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(210m, (decimal)rows[0].total);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_ShouldSupportAlias_And_Ordinal behavior.
+    /// PT: Testa o comportamento de OrderBy_ShouldSupportAlias_And_Ordinal.
+    /// </summary>
     [Fact]
     public void OrderBy_ShouldSupportAlias_And_Ordinal()
     {
@@ -161,6 +217,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([(2,"Bob"),(3,"Jane"),(1,"John")], [.. rows2.Select(r => ((int)r.id,(string)r.name))]);
     }
 
+    /// <summary>
+    /// EN: Tests Union_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_ShouldWork.
+    /// </summary>
     [Fact]
     public void Union_ShouldWork()
     {
@@ -172,6 +232,10 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1,2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Union_Inside_SubSelect_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
+    /// </summary>
     [Fact]
     public void Union_Inside_SubSelect_ShouldWork()
     {
@@ -186,6 +250,10 @@ ORDER BY id
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Cte_With_ShouldWork behavior.
+    /// PT: Testa o comportamento de Cte_With_ShouldWork.
+    /// </summary>
     [Fact]
     public void Cte_With_ShouldWork()
     {
@@ -195,6 +263,10 @@ ORDER BY id
         Assert.Equal([2,1], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault behavior.
+    /// PT: Testa o comportamento de Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault.
+    /// </summary>
     [Fact]
     public void Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlTransactionTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlTransactionTests.cs
@@ -10,6 +10,10 @@ public sealed class MySqlTransactionTests(
         public string? Email { get; set; }
     }
 
+    /// <summary>
+    /// EN: Tests TransactionCommitShouldPersistData behavior.
+    /// PT: Testa o comportamento de TransactionCommitShouldPersistData.
+    /// </summary>
     [Fact]
     public void TransactionCommitShouldPersistData()
     {
@@ -38,6 +42,10 @@ public sealed class MySqlTransactionTests(
         Assert.Equal(user.Email, insertedRow[2]);
     }
 
+    /// <summary>
+    /// EN: Tests TransactionRollbackShouldNotPersistData behavior.
+    /// PT: Testa o comportamento de TransactionRollbackShouldNotPersistData.
+    /// </summary>
     [Fact]
     public void TransactionRollbackShouldNotPersistData()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs
@@ -22,6 +22,10 @@ public sealed class MySqlUnionLimitAndJsonCompatibilityTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates behavior.
+    /// PT: Testa o comportamento de UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates.
+    /// </summary>
     [Fact]
     public void UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates()
     {
@@ -42,6 +46,10 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([1], [.. distinct.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Limit_OffsetCommaSyntax_ShouldWork behavior.
+    /// PT: Testa o comportamento de Limit_OffsetCommaSyntax_ShouldWork.
+    /// </summary>
     [Fact]
     public void Limit_OffsetCommaSyntax_ShouldWork()
     {
@@ -50,6 +58,10 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([2, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Limit_OffsetKeywordSyntax_ShouldWork behavior.
+    /// PT: Testa o comportamento de Limit_OffsetKeywordSyntax_ShouldWork.
+    /// </summary>
     [Fact]
     public void Limit_OffsetKeywordSyntax_ShouldWork()
     {
@@ -58,6 +70,10 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([2, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests JsonExtract_SimpleObjectPath_ShouldWork behavior.
+    /// PT: Testa o comportamento de JsonExtract_SimpleObjectPath_ShouldWork.
+    /// </summary>
     [Fact]
     public void JsonExtract_SimpleObjectPath_ShouldWork()
     {

--- a/src/DbSqlLikeMem.MySql.Test/MySqlWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlWhereParserAndExecutorTests.cs
@@ -21,6 +21,10 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_IN_ShouldFilter behavior.
+    /// PT: Testa o comportamento de Where_IN_ShouldFilter.
+    /// </summary>
     [Fact]
     public void Where_IN_ShouldFilter()
     {
@@ -30,6 +34,10 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Contains(rows, r => (int)r.id == 3);
     }
 
+    /// <summary>
+    /// EN: Tests Where_IsNotNull_ShouldFilter behavior.
+    /// PT: Testa o comportamento de Where_IsNotNull_ShouldFilter.
+    /// </summary>
     [Fact]
     public void Where_IsNotNull_ShouldFilter()
     {
@@ -37,6 +45,10 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(2, rows.Count);
     }
 
+    /// <summary>
+    /// EN: Tests Where_Operators_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Operators_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Operators_ShouldWork()
     {
@@ -47,6 +59,10 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal([1, 3], [.. rows2.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_Like_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Like_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Like_ShouldWork()
     {
@@ -55,6 +71,10 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Where_FindInSet_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_FindInSet_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_FindInSet_ShouldWork()
     {
@@ -63,6 +83,10 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_AND_ShouldBeCaseInsensitive_InRealLife behavior.
+    /// PT: Testa o comportamento de Where_AND_ShouldBeCaseInsensitive_InRealLife.
+    /// </summary>
     [Fact]
     public void Where_AND_ShouldBeCaseInsensitive_InRealLife()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Parser/SqlExprPrinterTest.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/SqlExprPrinterTest.cs
@@ -4,6 +4,10 @@ public sealed class SqlExprPrinterTest(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse behavior.
+    /// PT: Testa o comportamento de ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse.
+    /// </summary>
     [Theory]
     [MemberDataByMySqlVersion(nameof(Expressions))]
     public void ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse(string expr, int version)

--- a/src/DbSqlLikeMem.MySql.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/SqlExpressionParserTests.cs
@@ -7,6 +7,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Smoke tests: todas as expressões reais encontradas no zip (suportadas) -----------
 
+    /// <summary>
+    /// EN: Tests ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions behavior.
+    /// PT: Testa o comportamento de ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions.
+    /// </summary>
     [Theory]
     [MemberDataByMySqlVersion(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
@@ -75,6 +79,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Negative tests: coisas que aparecem nos testes atuais mas NÃO fazem parte do subset -----------
 
+    /// <summary>
+    /// EN: Tests ParseWhere_ShouldThrow_ForUnsupportedExpressions behavior.
+    /// PT: Testa o comportamento de ParseWhere_ShouldThrow_ForUnsupportedExpressions.
+    /// </summary>
     [Theory]
     [MemberDataByMySqlVersion(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
@@ -101,6 +109,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Regras (cenários extra) -----------
 
+    /// <summary>
+    /// EN: Tests Precedence_OR_ShouldBindLooserThan_AND behavior.
+    /// PT: Testa o comportamento de Precedence_OR_ShouldBindLooserThan_AND.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
@@ -125,6 +137,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(SqlBinaryOp.Eq, andRight.Op);
     }
 
+    /// <summary>
+    /// EN: Tests Parentheses_ShouldOverridePrecedence behavior.
+    /// PT: Testa o comportamento de Parentheses_ShouldOverridePrecedence.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Parentheses_ShouldOverridePrecedence(int version)
@@ -142,6 +158,10 @@ public sealed class SqlExpressionParserTests(
         Assert.False(isNull.Negated);
     }
 
+    /// <summary>
+    /// EN: Tests Not_ShouldWork behavior.
+    /// PT: Testa o comportamento de Not_ShouldWork.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Not_ShouldWork(int version)
@@ -155,6 +175,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(SqlBinaryOp.Or, or.Op);
     }
 
+    /// <summary>
+    /// EN: Tests IsNotNull_ShouldProduce_IsNullExpr_Negated behavior.
+    /// PT: Testa o comportamento de IsNotNull_ShouldProduce_IsNullExpr_Negated.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
@@ -164,6 +188,10 @@ public sealed class SqlExpressionParserTests(
         Assert.True(n.Negated);
     }
 
+    /// <summary>
+    /// EN: Tests In_ShouldParse_List behavior.
+    /// PT: Testa o comportamento de In_ShouldParse_List.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void In_ShouldParse_List(int version)
@@ -173,6 +201,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(3, ins.Items.Count);
     }
 
+    /// <summary>
+    /// EN: Tests Like_ShouldParse behavior.
+    /// PT: Testa o comportamento de Like_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Like_ShouldParse(int version)
@@ -182,6 +214,10 @@ public sealed class SqlExpressionParserTests(
         Assert.NotNull(like.Pattern);
     }
 
+    /// <summary>
+    /// EN: Tests Identifier_WithAliasDotColumn_ShouldParse behavior.
+    /// PT: Testa o comportamento de Identifier_WithAliasDotColumn_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
@@ -200,6 +236,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("userId", r.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parameter_Tokens_ShouldParse behavior.
+    /// PT: Testa o comportamento de Parameter_Tokens_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Parameter_Tokens_ShouldParse(int version)
@@ -210,6 +250,10 @@ public sealed class SqlExpressionParserTests(
         Assert.NotNull(SqlExpressionParser.ParseWhere("a = ?", d));
     }
 
+    /// <summary>
+    /// EN: Tests Backtick_Identifier_ShouldParse behavior.
+    /// PT: Testa o comportamento de Backtick_Identifier_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Backtick_Identifier_ShouldParse(int version)
@@ -220,6 +264,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("DeletedDtt", id.Name);
     }
 
+    /// <summary>
+    /// EN: Tests DoubleQuoted_String_ShouldParse behavior.
+    /// PT: Testa o comportamento de DoubleQuoted_String_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void DoubleQuoted_String_ShouldParse(int version)
@@ -230,6 +278,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("John", lit.Value);
     }
 
+    /// <summary>
+    /// EN: Tests Printer_ShouldBeStable_ForSimpleExpression behavior.
+    /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)

--- a/src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -604,6 +604,10 @@ select id
 };
     }
 
+    /// <summary>
+    /// EN: Tests Parse_ShouldHandle_MultiStatementStrings_BySplitting behavior.
+    /// PT: Testa o comportamento de Parse_ShouldHandle_MultiStatementStrings_BySplitting.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Parse_ShouldHandle_MultiStatementStrings_BySplitting(int version)
@@ -623,6 +627,10 @@ select id
         Assert.True(q3 is SqlInsertQuery);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_Corpus behavior.
+    /// PT: Testa o comportamento de Parse_Corpus.
+    /// </summary>
     [Theory]
     [MemberDataByMySqlVersion(nameof(Statements))]
     public void Parse_Corpus(string sql, string why, SqlCaseExpectation expectation, int minVersion, int version)

--- a/src/DbSqlLikeMem.MySql.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Query/QueryExecutorExtrasTests.cs
@@ -20,6 +20,10 @@ public sealed class QueryExecutorExtrasTests(
         return db;
     }
 
+    /// <summary>
+    /// EN: Tests GroupByAndAggregationsShouldComputeCorrectly behavior.
+    /// PT: Testa o comportamento de GroupByAndAggregationsShouldComputeCorrectly.
+    /// </summary>
     [Fact]
     public void GroupByAndAggregationsShouldComputeCorrectly()
     {
@@ -53,6 +57,10 @@ GROUP BY grp";
 
     private static readonly int[] expected = [4, 3];
 
+    /// <summary>
+    /// EN: Tests OrderByLimitOffsetShouldPageCorrectly behavior.
+    /// PT: Testa o comportamento de OrderByLimitOffsetShouldPageCorrectly.
+    /// </summary>
     [Fact]
     public void OrderByLimitOffsetShouldPageCorrectly()
     {
@@ -92,12 +100,16 @@ SELECT * FROM t ORDER BY iddesc ASC LIMIT 2 OFFSET 1;";
     }
 }
 
-/// <summary>
-/// EN: Extra tests for SQL translation behavior.
-/// PT: Testes extras para o comportamento de tradução SQL.
-/// </summary>
+    /// <summary>
+    /// EN: Extra tests for SQL translation behavior.
+    /// PT: Testes extras para o comportamento de tradução SQL.
+    /// </summary>
 public class SqlTranslatorTests
 {
+    /// <summary>
+    /// EN: Tests TranslateBasicWhereAndOrderBySqlCorrect behavior.
+    /// PT: Testa o comportamento de TranslateBasicWhereAndOrderBySqlCorrect.
+    /// </summary>
     [Fact]
     public void TranslateBasicWhereAndOrderBySqlCorrect()
     {

--- a/src/DbSqlLikeMem.MySql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -4,6 +4,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests CreateTableAsSelect_ShouldCreateNewTableWithRows behavior.
+    /// PT: Testa o comportamento de CreateTableAsSelect_ShouldCreateNewTableWithRows.
+    /// </summary>
     [Fact]
     public void CreateTableAsSelect_ShouldCreateNewTableWithRows()
     {
@@ -32,6 +36,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         Assert.Equal("A", active[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertIntoSelect_ShouldInsertRowsFromQuery behavior.
+    /// PT: Testa o comportamento de InsertIntoSelect_ShouldInsertRowsFromQuery.
+    /// </summary>
     [Fact]
     public void InsertIntoSelect_ShouldInsertRowsFromQuery()
     {
@@ -59,6 +67,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         Assert.Equal("A", audit[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests UpdateJoinDerivedSelect_ShouldUpdateRows behavior.
+    /// PT: Testa o comportamento de UpdateJoinDerivedSelect_ShouldUpdateRows.
+    /// </summary>
     [Fact]
     public void UpdateJoinDerivedSelect_ShouldUpdateRows()
     {
@@ -94,6 +106,10 @@ WHERE u.tenantid = 10";
         Assert.Null(users[2][2]);
     }
 
+    /// <summary>
+    /// EN: Tests DeleteJoinDerivedSelect_ShouldDeleteRows behavior.
+    /// PT: Testa o comportamento de DeleteJoinDerivedSelect_ShouldDeleteRows.
+    /// </summary>
     [Fact]
     public void DeleteJoinDerivedSelect_ShouldDeleteRows()
     {

--- a/src/DbSqlLikeMem.MySql.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.MySql.Test/SqlValueHelperTests .cs
@@ -6,6 +6,10 @@ public sealed class SqlValueHelperTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Resolve_ShouldReadDapperParameter_ByName behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_ByName.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldReadDapperParameter_ByName()
     {
@@ -22,6 +26,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(123, v);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_ShouldThrow_WhenParameterMissing behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldThrow_WhenParameterMissing()
     {
@@ -29,6 +37,10 @@ public sealed class SqlValueHelperTests(
             MySqlValueHelper.Resolve("@p404", DbType.Int32, isNullable: false, pars: null, colDict: null));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_ShouldParseInList_ToListOfResolvedValues behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldParseInList_ToListOfResolvedValues.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldParseInList_ToListOfResolvedValues()
     {
@@ -38,6 +50,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal([1, 2, 3], [.. list.Cast<int>()]);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_NullOnNonNullable_ShouldThrow behavior.
+    /// PT: Testa o comportamento de Resolve_NullOnNonNullable_ShouldThrow.
+    /// </summary>
     [Fact]
     public void Resolve_NullOnNonNullable_ShouldThrow()
     {
@@ -45,6 +61,10 @@ public sealed class SqlValueHelperTests(
             MySqlValueHelper.Resolve("null", DbType.Int32, isNullable: false, pars: null, colDict: null));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Json_ShouldReturnJsonDocument_WhenValid behavior.
+    /// PT: Testa o comportamento de Resolve_Json_ShouldReturnJsonDocument_WhenValid.
+    /// </summary>
     [Fact]
     public void Resolve_Json_ShouldReturnJsonDocument_WhenValid()
     {
@@ -54,6 +74,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(1, doc.RootElement.GetProperty("a").GetInt32());
     }
 
+    /// <summary>
+    /// EN: Tests Like_ShouldMatch_MySqlStyle behavior.
+    /// PT: Testa o comportamento de Like_ShouldMatch_MySqlStyle.
+    /// </summary>
     [Theory]
     [InlineData("John", "%oh%", true)]
     [InlineData("John", "J_hn", true)]
@@ -65,6 +89,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(expected, MySqlValueHelper.Like(value, pattern));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Enum_ShouldValidateAgainstColumnDef behavior.
+    /// PT: Testa o comportamento de Resolve_Enum_ShouldValidateAgainstColumnDef.
+    /// </summary>
     [Fact]
     public void Resolve_Enum_ShouldValidateAgainstColumnDef()
     {
@@ -84,6 +112,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(1265, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Set_ShouldReturnHashSet_AndValidate behavior.
+    /// PT: Testa o comportamento de Resolve_Set_ShouldReturnHashSet_AndValidate.
+    /// </summary>
     [Fact]
     public void Resolve_Set_ShouldReturnHashSet_AndValidate()
     {

--- a/src/DbSqlLikeMem.MySql.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/StoredProcedureExecutionTests.cs
@@ -16,6 +16,10 @@ public sealed class StoredProcedureExecutionTests(
             Direction = dir
         };
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs()
     {
@@ -52,6 +56,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, affected);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput()
     {
@@ -86,6 +94,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(1318, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull()
     {
@@ -120,6 +132,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(1048, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue()
     {
@@ -163,6 +179,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, ((MySqlParameter)cmd.Parameters["@o_status"]).Value);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset behavior.
+    /// PT: Testa o comportamento de ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset.
+    /// </summary>
     [Fact]
     public void ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset()
     {
@@ -192,6 +212,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.False(r.Read());
     }
 
+    /// <summary>
+    /// EN: Tests DapperExecute_CommandTypeStoredProcedure_ShouldWork behavior.
+    /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldWork.
+    /// </summary>
     [Fact]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldWork()
     {
@@ -221,6 +245,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, affected);
     }
 
+    /// <summary>
+    /// EN: Tests DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam behavior.
+    /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam.
+    /// </summary>
     [Fact]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam()
     {

--- a/src/DbSqlLikeMem.MySql.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/StoredProcedureSignatureTests.cs
@@ -4,6 +4,10 @@ public sealed class StoredProcedureSignatureTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests StoredProcedure_ShouldValidateRequiredInAndOutParams behavior.
+    /// PT: Testa o comportamento de StoredProcedure_ShouldValidateRequiredInAndOutParams.
+    /// </summary>
     [Fact]
     public void StoredProcedure_ShouldValidateRequiredInAndOutParams()
     {
@@ -31,6 +35,10 @@ public sealed class StoredProcedureSignatureTests(
             CultureInfo.InvariantCulture));
     }
 
+    /// <summary>
+    /// EN: Tests StoredProcedure_ShouldThrowWhenMissingRequiredParam behavior.
+    /// PT: Testa o comportamento de StoredProcedure_ShouldThrowWhenMissingRequiredParam.
+    /// </summary>
     [Fact]
     public void StoredProcedure_ShouldThrowWhenMissingRequiredParam()
     {
@@ -50,6 +58,10 @@ public sealed class StoredProcedureSignatureTests(
         Assert.Equal(1318, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests CallStatement_ShouldValidateAgainstRegisteredProcedure behavior.
+    /// PT: Testa o comportamento de CallStatement_ShouldValidateAgainstRegisteredProcedure.
+    /// </summary>
     [Fact]
     public void CallStatement_ShouldValidateAgainstRegisteredProcedure()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlDeleteStrategyTests.cs
@@ -4,6 +4,10 @@ public sealed class MySqlCommandDeleteTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_remove_1_linha behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_1_linha.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_remove_1_linha()
     {
@@ -23,6 +27,10 @@ public sealed class MySqlCommandDeleteTests(
         Assert.Equal(1, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_remove_varias_linhas behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_varias_linhas.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_remove_varias_linhas()
     {
@@ -43,6 +51,10 @@ public sealed class MySqlCommandDeleteTests(
         Assert.Equal(2, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0 behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0()
     {
@@ -60,6 +72,10 @@ public sealed class MySqlCommandDeleteTests(
         Assert.Equal(0, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_tabela_inexistente_dispara behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_tabela_inexistente_dispara.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_tabela_inexistente_dispara()
     {
@@ -71,6 +87,10 @@ public sealed class MySqlCommandDeleteTests(
         Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara.
+    /// </summary>
     [Fact(Skip = "Isso é valido no MySql")]
     public void ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara()
     {
@@ -86,6 +106,10 @@ public sealed class MySqlCommandDeleteTests(
         Assert.Contains("delete", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia()
     {
@@ -108,6 +132,10 @@ public sealed class MySqlCommandDeleteTests(
         Assert.Equal(0, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false.
+    /// </summary>
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -126,6 +154,10 @@ public sealed class MySqlCommandDeleteTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_case_insensitive behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_case_insensitive.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_case_insensitive()
     {
@@ -142,6 +174,10 @@ public sealed class MySqlCommandDeleteTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_com_parametro_se_suportado behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_com_parametro_se_suportado.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_com_parametro_se_suportado()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertOnDuplicateTests.cs
@@ -8,6 +8,10 @@ public class MySqlInsertOnDuplicateTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Insert_OnDuplicate_ShouldInsertWhenNoConflict behavior.
+    /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldInsertWhenNoConflict.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Insert_OnDuplicate_ShouldInsertWhenNoConflict(int version)
@@ -29,6 +33,10 @@ public class MySqlInsertOnDuplicateTests(
         Assert.Equal("A", t[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_OnDuplicate_ShouldUpdateExistingRow_ByPrimaryKey_UsingValues behavior.
+    /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateExistingRow_ByPrimaryKey_UsingValues.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Insert_OnDuplicate_ShouldUpdateExistingRow_ByPrimaryKey_UsingValues(int version)
@@ -52,6 +60,10 @@ public class MySqlInsertOnDuplicateTests(
         Assert.Single(t);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_OnDuplicate_ShouldUpdateExistingRow_ByUniqueIndex behavior.
+    /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateExistingRow_ByUniqueIndex.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Insert_OnDuplicate_ShouldUpdateExistingRow_ByUniqueIndex(int version)
@@ -78,6 +90,10 @@ public class MySqlInsertOnDuplicateTests(
         Assert.Equal("B", t[0][2]);        // atualizado
     }
 
+    /// <summary>
+    /// EN: Tests Insert_OnDuplicate_ShouldUpdateUsingLiteralAndParam behavior.
+    /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateUsingLiteralAndParam.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Insert_OnDuplicate_ShouldUpdateUsingLiteralAndParam(int version)
@@ -106,6 +122,10 @@ public class MySqlInsertOnDuplicateTests(
         Assert.Equal("FORCED", t[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_OnDuplicate_ShouldUpdateAggragating behavior.
+    /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateAggragating.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Insert_OnDuplicate_ShouldUpdateAggragating(int version)

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyCoverageTests.cs
@@ -4,6 +4,10 @@ public sealed class MySqlInsertStrategyCoverageTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Insert_MultiRowValues_ShouldInsertAllRows behavior.
+    /// PT: Testa o comportamento de Insert_MultiRowValues_ShouldInsertAllRows.
+    /// </summary>
     [Fact]
     public void Insert_MultiRowValues_ShouldInsertAllRows()
     {
@@ -28,6 +32,10 @@ public sealed class MySqlInsertStrategyCoverageTests(
         Assert.Equal("B", (string)t[1][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_WithIdentityColumnOmitted_ShouldAutoIncrement behavior.
+    /// PT: Testa o comportamento de Insert_WithIdentityColumnOmitted_ShouldAutoIncrement.
+    /// </summary>
     [Fact]
     public void Insert_WithIdentityColumnOmitted_ShouldAutoIncrement()
     {
@@ -54,6 +62,10 @@ public sealed class MySqlInsertStrategyCoverageTests(
         Assert.Equal("B", (string)t[1][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests InsertSelect_ShouldInsertRowsFromSelect behavior.
+    /// PT: Testa o comportamento de InsertSelect_ShouldInsertRowsFromSelect.
+    /// </summary>
     [Fact]
     public void InsertSelect_ShouldInsertRowsFromSelect()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyExtrasTests.cs
@@ -3,6 +3,10 @@ public sealed class MySqlInsertStrategyExtrasTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests MultiRowInsertShouldAddAllRows behavior.
+    /// PT: Testa o comportamento de MultiRowInsertShouldAddAllRows.
+    /// </summary>
     [Fact]
     public void MultiRowInsertShouldAddAllRows()
     {
@@ -26,6 +30,10 @@ public sealed class MySqlInsertStrategyExtrasTests(
         Assert.Equal("B", table[1][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertWithDefaultValueAndIdentityShouldApplyDefaults behavior.
+    /// PT: Testa o comportamento de InsertWithDefaultValueAndIdentityShouldApplyDefaults.
+    /// </summary>
     [Fact]
     public void InsertWithDefaultValueAndIdentityShouldApplyDefaults()
     {
@@ -53,6 +61,10 @@ public sealed class MySqlInsertStrategyExtrasTests(
         Assert.Equal(2, table[1][0]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertDuplicatePrimaryKeyShouldThrow behavior.
+    /// PT: Testa o comportamento de InsertDuplicatePrimaryKeyShouldThrow.
+    /// </summary>
     [Fact]
     public void InsertDuplicatePrimaryKeyShouldThrow()
     {
@@ -74,12 +86,16 @@ public sealed class MySqlInsertStrategyExtrasTests(
     }
 }
 
-/// <summary>
-/// EN: Tests delete strategy behavior with foreign keys.
-/// PT: Testes do comportamento da estratégia de delete com chaves estrangeiras.
-/// </summary>
+    /// <summary>
+    /// EN: Tests delete strategy behavior with foreign keys.
+    /// PT: Testes do comportamento da estratégia de delete com chaves estrangeiras.
+    /// </summary>
 public class MySqlDeleteStrategyForeignKeyTests
 {
+    /// <summary>
+    /// EN: Tests DeleteReferencedRowShouldThrow behavior.
+    /// PT: Testa o comportamento de DeleteReferencedRowShouldThrow.
+    /// </summary>
     [Fact]
     public void DeleteReferencedRowShouldThrow()
     {
@@ -109,12 +125,16 @@ public class MySqlDeleteStrategyForeignKeyTests
     }
 }
 
-/// <summary>
-/// EN: Extra tests for update strategy behavior.
-/// PT: Testes extras do comportamento da estratégia de update.
-/// </summary>
+    /// <summary>
+    /// EN: Extra tests for update strategy behavior.
+    /// PT: Testes extras do comportamento da estratégia de update.
+    /// </summary>
 public class MySqlUpdateStrategyExtrasTests
 {
+    /// <summary>
+    /// EN: Tests UpdateMultipleConditionsShouldOnlyAffectMatchingRows behavior.
+    /// PT: Testa o comportamento de UpdateMultipleConditionsShouldOnlyAffectMatchingRows.
+    /// </summary>
     [Fact]
     public void UpdateMultipleConditionsShouldOnlyAffectMatchingRows()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyTests.cs
@@ -3,6 +3,10 @@ public sealed class MySqlInsertStrategyTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests InsertIntoTableShouldAddNewRow behavior.
+    /// PT: Testa o comportamento de InsertIntoTableShouldAddNewRow.
+    /// </summary>
     [Fact]
     public void InsertIntoTableShouldAddNewRow()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTransactionTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTransactionTests.cs
@@ -3,6 +3,10 @@ public sealed class MySqlTransactionTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests TransactionShouldCommit behavior.
+    /// PT: Testa o comportamento de TransactionShouldCommit.
+    /// </summary>
     [Fact]
     public void TransactionShouldCommit()
     {
@@ -33,6 +37,10 @@ public sealed class MySqlTransactionTests(
         Assert.Equal("John Doe", table[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TransactionShouldRollback behavior.
+    /// PT: Testa o comportamento de TransactionShouldRollback.
+    /// </summary>
     [Fact]
     public void TransactionShouldRollback()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyCoverageTests.cs
@@ -4,6 +4,10 @@ public sealed class MySqlUpdateStrategyCoverageTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Update_SetNullableColumnToNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Update_SetNullableColumnToNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Update_SetNullableColumnToNull_ShouldWork()
     {
@@ -25,6 +29,10 @@ public sealed class MySqlUpdateStrategyCoverageTests(
         Assert.Null(users[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests Update_SetNotNullableColumnToNull_ShouldThrow behavior.
+    /// PT: Testa o comportamento de Update_SetNotNullableColumnToNull_ShouldThrow.
+    /// </summary>
     [Fact]
     public void Update_SetNotNullableColumnToNull_ShouldThrow()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs
@@ -4,6 +4,10 @@ public sealed class MySqlUpdateStrategyTests(
     ITestOutputHelper helper
 ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests UpdateTableShouldModifyExistingRow behavior.
+    /// PT: Testa o comportamento de UpdateTableShouldModifyExistingRow.
+    /// </summary>
     [Fact]
     public void UpdateTableShouldModifyExistingRow()
     {
@@ -28,6 +32,10 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldReturnZero_WhenNoRowsMatchWhere behavior.
+    /// PT: Testa o comportamento de Update_ShouldReturnZero_WhenNoRowsMatchWhere.
+    /// </summary>
     [Fact]
     public void Update_ShouldReturnZero_WhenNoRowsMatchWhere()
     {
@@ -49,6 +57,10 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Equal(0, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple behavior.
+    /// PT: Testa o comportamento de Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple.
+    /// </summary>
     [Fact]
     public void Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple()
     {
@@ -73,6 +85,10 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Equal(2, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldHandleWhereWithAnd_CaseInsensitive behavior.
+    /// PT: Testa o comportamento de Update_ShouldHandleWhereWithAnd_CaseInsensitive.
+    /// </summary>
     [Fact]
     public void Update_ShouldHandleWhereWithAnd_CaseInsensitive()
     {
@@ -97,6 +113,10 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldUpdateMultipleSetPairs behavior.
+    /// PT: Testa o comportamento de Update_ShouldUpdateMultipleSetPairs.
+    /// </summary>
     [Fact]
     public void Update_ShouldUpdateMultipleSetPairs()
     {
@@ -118,6 +138,10 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords behavior.
+    /// PT: Testa o comportamento de Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords.
+    /// </summary>
     [Fact]
     public void Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords()
     {
@@ -138,6 +162,10 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldWork_WithThreadSafeTrueOrFalse behavior.
+    /// PT: Testa o comportamento de Update_ShouldWork_WithThreadSafeTrueOrFalse.
+    /// </summary>
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -160,6 +188,10 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldThrow_WhenTableDoesNotExist behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrow_WhenTableDoesNotExist.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrow_WhenTableDoesNotExist()
     {
@@ -174,6 +206,10 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken()
     {
@@ -191,6 +227,10 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Contains("upd", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull behavior.
+    /// PT: Testa o comportamento de Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull.
+    /// </summary>
     [Fact]
     public void Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull()
     {
@@ -212,6 +252,10 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldSupportParameter_IfSqlValueHelperSupports behavior.
+    /// PT: Testa o comportamento de Update_ShouldSupportParameter_IfSqlValueHelperSupports.
+    /// </summary>
     [Fact]
     public void Update_ShouldSupportParameter_IfSqlValueHelperSupports()
     {
@@ -242,6 +286,10 @@ public sealed class MySqlUpdateStrategyTests(
     // Opcional: testar ValidateUnique (preciso do IndexDef real)
     // ============================================================
     //
+    /// <summary>
+    /// EN: Tests Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides()
     {

--- a/src/DbSqlLikeMem.MySql.Test/SubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/SubqueryFromAndJoinsTests.cs
@@ -4,6 +4,10 @@ public sealed class SubqueryFromAndJoinsTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests FromSubquery_ShouldReturnFilteredRows behavior.
+    /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
+    /// </summary>
     [Fact]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
@@ -32,6 +36,10 @@ public sealed class SubqueryFromAndJoinsTests(
         ids.Should().Equal(1, 3);
     }
 
+    /// <summary>
+    /// EN: Tests JoinSubquery_ShouldJoinCorrectly behavior.
+    /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
+    /// </summary>
     [Fact]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
@@ -72,6 +80,10 @@ ORDER BY u.Id, o.Amount";
         rows.Should().Equal([(1, 60m), (2, 80m)]);
     }
 
+    /// <summary>
+    /// EN: Tests NestedSubquery_ShouldWork behavior.
+    /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
+    /// </summary>
     [Fact]
     public void NestedSubquery_ShouldWork()
     {

--- a/src/DbSqlLikeMem.MySql.Test/TemporaryTable/MySqlTemporaryTableEngineTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/TemporaryTable/MySqlTemporaryTableEngineTests.cs
@@ -4,6 +4,10 @@ public sealed class MySqlTemporaryTableEngineTests
 {
     private static readonly int[] expected = [1, 2];
 
+    /// <summary>
+    /// EN: Tests CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows behavior.
+    /// PT: Testa o comportamento de CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows.
+    /// </summary>
     [Fact]
     public void CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows()
     {

--- a/src/DbSqlLikeMem.MySql.Test/TemporaryTable/MySqlTemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/TemporaryTable/MySqlTemporaryTableParserTests.cs
@@ -2,6 +2,10 @@ namespace DbSqlLikeMem.MySql.Test.TemporaryTable;
 
 public sealed class MySqlTemporaryTableParserTests
 {
+    /// <summary>
+    /// EN: Tests ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect behavior.
+    /// PT: Testa o comportamento de ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect(int version)
@@ -49,6 +53,10 @@ WHERE `tenantid` = 10",
         };
     }
 
+    /// <summary>
+    /// EN: Tests Parse_ShouldAccept_CreateTemporaryTable_Variants behavior.
+    /// PT: Testa o comportamento de Parse_ShouldAccept_CreateTemporaryTable_Variants.
+    /// </summary>
     [Theory]
     [MemberDataByMySqlVersion(nameof(CreateTempTableStatements))]
     public void Parse_ShouldAccept_CreateTemporaryTable_Variants(string sql, int version)

--- a/src/DbSqlLikeMem.MySql.Test/Views/MySqlCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Views/MySqlCreateViewEngineTests.cs
@@ -28,6 +28,10 @@ public sealed class MySqlCreateViewEngineTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests CreateView_ThenSelectFromView_ShouldReturnExpectedRows behavior.
+    /// PT: Testa o comportamento de CreateView_ThenSelectFromView_ShouldReturnExpectedRows.
+    /// </summary>
     [Fact]
     public void CreateView_ThenSelectFromView_ShouldReturnExpectedRows()
     {
@@ -41,6 +45,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal(["John", "Bob" ], rows.Select(r => (string)r["name"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_IsNotMaterialized_ShouldReflectBaseTableChanges behavior.
+    /// PT: Testa o comportamento de View_IsNotMaterialized_ShouldReflectBaseTableChanges.
+    /// </summary>
     [Fact]
     public void View_IsNotMaterialized_ShouldReflectBaseTableChanges()
     {
@@ -53,6 +61,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([1, 2, 3, 4], rows.Select(r => (int)r["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests CreateOrReplaceView_ShouldChangeDefinition behavior.
+    /// PT: Testa o comportamento de CreateOrReplaceView_ShouldChangeDefinition.
+    /// </summary>
     [Fact]
     public void CreateOrReplaceView_ShouldChangeDefinition()
     {
@@ -65,6 +77,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([3], r2.Select(x => (int)x["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_NameShouldShadowTable_WhenSameName behavior.
+    /// PT: Testa o comportamento de View_NameShouldShadowTable_WhenSameName.
+    /// </summary>
     [Fact]
     public void View_NameShouldShadowTable_WhenSameName()
     {
@@ -82,6 +98,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal(1, (int)rows[0]["id"]!);
     }
 
+    /// <summary>
+    /// EN: Tests View_CanReferenceAnotherView behavior.
+    /// PT: Testa o comportamento de View_CanReferenceAnotherView.
+    /// </summary>
     [Fact]
     public void View_CanReferenceAnotherView()
     {
@@ -92,6 +112,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([2], rows.Select(r => (int)r["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_WithJoinAndAggregation_ShouldWork behavior.
+    /// PT: Testa o comportamento de View_WithJoinAndAggregation_ShouldWork.
+    /// </summary>
     [Fact]
     public void View_WithJoinAndAggregation_ShouldWork()
     {
@@ -112,6 +136,10 @@ GROUP BY u.id;
         Assert.True(rows[2]["total"] is null);
     }
 
+    /// <summary>
+    /// EN: Tests CreateView_ExistingNameWithoutOrReplace_ShouldThrow behavior.
+    /// PT: Testa o comportamento de CreateView_ExistingNameWithoutOrReplace_ShouldThrow.
+    /// </summary>
     [Fact]
     public void CreateView_ExistingNameWithoutOrReplace_ShouldThrow()
     {
@@ -119,6 +147,10 @@ GROUP BY u.id;
         Assert.ThrowsAny<Exception>(() => _cnn.ExecNonQuery("CREATE VIEW vdup AS SELECT 2 AS x FROM DUAL;"));
     }
 
+    /// <summary>
+    /// EN: Tests DropView_ShouldRemoveDefinition behavior.
+    /// PT: Testa o comportamento de DropView_ShouldRemoveDefinition.
+    /// </summary>
     [Fact(Skip = "MySQL: DROP VIEW faz parte do ciclo de vida. Implementar depois.")]
     public void DropView_ShouldRemoveDefinition()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Views/MySqlCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Views/MySqlCreateViewParserTests.cs
@@ -4,6 +4,10 @@ public sealed class MySqlCreateViewParserTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements behavior.
+    /// PT: Testa o comportamento de ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements(int version)
@@ -27,6 +31,10 @@ SELECT * FROM v_users;
         Assert.Contains("users", cv.Select.Table?.Name, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateOrReplaceView_ShouldSetFlag behavior.
+    /// PT: Testa o comportamento de Parse_CreateOrReplaceView_ShouldSetFlag.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Parse_CreateOrReplaceView_ShouldSetFlag(int version)
@@ -38,6 +46,10 @@ SELECT * FROM v_users;
         Assert.Equal("v", cv.Table?.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames(int version)
@@ -48,6 +60,10 @@ SELECT * FROM v_users;
         Assert.Equal(["a", "b"], cv.ColumnNames);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_WithBackticks_ShouldWork behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_WithBackticks_ShouldWork.
+    /// </summary>
     [Theory]
     [MemberDataMySqlVersion]
     public void Parse_CreateView_WithBackticks_ShouldWork(int version)
@@ -58,6 +74,10 @@ SELECT * FROM v_users;
         Assert.Equal("v", cv.Table?.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec.
+    /// </summary>
     [Theory(Skip = "MySQL não suporta IF NOT EXISTS em CREATE VIEW. O mock aceita por conveniência; habilite se quiser comportamento estrito.")]
     [MemberDataMySqlVersion]
     public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec(int version)

--- a/src/DbSqlLikeMem.Npgsql.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/CsvLoaderAndIndexTests.cs
@@ -4,6 +4,10 @@ public sealed class CsvLoaderAndIndexTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests CsvLoader_ShouldLoadRows_ByColumnName behavior.
+    /// PT: Testa o comportamento de CsvLoader_ShouldLoadRows_ByColumnName.
+    /// </summary>
     [Fact]
     public void CsvLoader_ShouldLoadRows_ByColumnName()
     {
@@ -26,6 +30,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal("John", cnn.GetTable("users")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests GetColumn_ShouldThrow_UnknownColumn behavior.
+    /// PT: Testa o comportamento de GetColumn_ShouldThrow_UnknownColumn.
+    /// </summary>
     [Fact]
     public void GetColumn_ShouldThrow_UnknownColumn()
     {
@@ -37,6 +45,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal(1054, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests Index_Lookup_ShouldReturnRowPositions behavior.
+    /// PT: Testa o comportamento de Index_Lookup_ShouldReturnRowPositions.
+    /// </summary>
     [Fact]
     public void Index_Lookup_ShouldReturnRowPositions()
     {
@@ -56,6 +68,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal([0, 1], [.. ix!.Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests BackupRestore_ShouldRollbackData behavior.
+    /// PT: Testa o comportamento de BackupRestore_ShouldRollbackData.
+    /// </summary>
     [Fact]
     public void BackupRestore_ShouldRollbackData()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/DapperTests.cs
@@ -21,6 +21,10 @@ public sealed class DapperTests : XUnitTestBase
         _connection.Open();
     }
 
+    /// <summary>
+    /// EN: Tests TestSelectQuery behavior.
+    /// PT: Testa o comportamento de TestSelectQuery.
+    /// </summary>
     [Fact]
     public void TestSelectQuery()
     {
@@ -28,6 +32,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.NotNull(users);
     }
 
+    /// <summary>
+    /// EN: Tests QueryShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryShouldReturnCorrectData()
     {
@@ -61,6 +69,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.Equal(dt, result.First().CreatedDate);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldInsertData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldInsertData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldInsertData()
     {
@@ -87,6 +99,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.Equal(dt, table[0][2]);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldUpdateData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldUpdateData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldUpdateData()
     {
@@ -126,6 +142,10 @@ UPDATE users
         Assert.Equal(dtUpdate, table[0][3]);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldDeleteData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldDeleteData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldDeleteData()
     {
@@ -148,6 +168,10 @@ UPDATE users
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleResultSets()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/DapperUserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/DapperUserTests.cs
@@ -14,6 +14,10 @@ public sealed class DapperUserTests(
         public Guid? TestGuidNull { get; set; }
     }
 
+    /// <summary>
+    /// EN: Tests InsertUserShouldAddUserToTable behavior.
+    /// PT: Testa o comportamento de InsertUserShouldAddUserToTable.
+    /// </summary>
     [Fact]
     public void InsertUserShouldAddUserToTable()
     {
@@ -58,6 +62,10 @@ public sealed class DapperUserTests(
         Assert.Equal(user.TestGuidNull, insertedRow[6]);
     }
 
+    /// <summary>
+    /// EN: Tests QueryUserShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryUserShouldReturnCorrectData()
     {
@@ -110,6 +118,10 @@ public sealed class DapperUserTests(
         Assert.Equal(user.TestGuidNull, result.TestGuidNull);
     }
 
+    /// <summary>
+    /// EN: Tests UpdateUserShouldModifyUserInTable behavior.
+    /// PT: Testa o comportamento de UpdateUserShouldModifyUserInTable.
+    /// </summary>
     [Fact]
     public void UpdateUserShouldModifyUserInTable()
     {
@@ -176,6 +188,10 @@ public sealed class DapperUserTests(
         Assert.Equal(updatedUser.TestGuidNull, updatedRow[6]);
     }
 
+    /// <summary>
+    /// EN: Tests DeleteUserShouldRemoveUserFromTable behavior.
+    /// PT: Testa o comportamento de DeleteUserShouldRemoveUserFromTable.
+    /// </summary>
     [Fact]
     public void DeleteUserShouldRemoveUserFromTable()
     {
@@ -223,6 +239,10 @@ public sealed class DapperUserTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleUserResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/DapperUserTests2.cs
@@ -16,6 +16,10 @@ public sealed class DapperUserTests2(
         public List<int> Tenants { get; set; } = [];
     }
 
+    /// <summary>
+    /// EN: Tests QueryUserShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryUserShouldReturnCorrectData()
     {
@@ -68,6 +72,10 @@ public sealed class DapperUserTests2(
         Assert.Equal(user.TestGuidNull, result.TestGuidNull);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleUserResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
@@ -127,6 +135,10 @@ public sealed class DapperUserTests2(
         Assert.Equal("jane.doe@example.com", users2[0].Email);
     }
 
+    /// <summary>
+    /// EN: Tests QueryWithJoinShouldReturnJoinedData behavior.
+    /// PT: Testa o comportamento de QueryWithJoinShouldReturnJoinedData.
+    /// </summary>
     [Fact]
     public void QueryWithJoinShouldReturnJoinedData()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/ExistsTests.cs
@@ -4,6 +4,10 @@ public sealed class ExistsTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Exists_ShouldFilterUsersWithOrders behavior.
+    /// PT: Testa o comportamento de Exists_ShouldFilterUsersWithOrders.
+    /// </summary>
     [Fact]
     public void Exists_ShouldFilterUsersWithOrders()
     {
@@ -43,6 +47,10 @@ ORDER BY u.Id";
         ids.Should().Equal(1, 3);
     }
 
+    /// <summary>
+    /// EN: Tests NotExists_ShouldFilterUsersWithoutOrders behavior.
+    /// PT: Testa o comportamento de NotExists_ShouldFilterUsersWithoutOrders.
+    /// </summary>
     [Fact]
     public void NotExists_ShouldFilterUsersWithoutOrders()
     {
@@ -81,6 +89,10 @@ ORDER BY u.Id";
         ids.Should().Equal(2);
     }
 
+    /// <summary>
+    /// EN: Tests Exists_WithExtraPredicate_ShouldWork behavior.
+    /// PT: Testa o comportamento de Exists_WithExtraPredicate_ShouldWork.
+    /// </summary>
     [Fact]
     public void Exists_WithExtraPredicate_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/ExtendedPostgreSqlMockTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/ExtendedPostgreSqlMockTests.cs
@@ -4,6 +4,10 @@ public sealed class ExtendedMySqlMockTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests InsertAutoIncrementShouldAssignIdentityWhenNotSpecified behavior.
+    /// PT: Testa o comportamento de InsertAutoIncrementShouldAssignIdentityWhenNotSpecified.
+    /// </summary>
     [Fact]
     public void InsertAutoIncrementShouldAssignIdentityWhenNotSpecified()
     {
@@ -26,6 +30,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal("Bob", table[1][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertNullIntoNullableColumnShouldSucceed behavior.
+    /// PT: Testa o comportamento de InsertNullIntoNullableColumnShouldSucceed.
+    /// </summary>
     [Fact]
     public void InsertNullIntoNullableColumnShouldSucceed()
     {
@@ -41,6 +49,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Null(table[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertNullIntoNonNullableColumnShouldThrow behavior.
+    /// PT: Testa o comportamento de InsertNullIntoNonNullableColumnShouldThrow.
+    /// </summary>
     [Fact]
     public void InsertNullIntoNonNullableColumnShouldThrow()
     {
@@ -57,6 +69,10 @@ public sealed class ExtendedMySqlMockTests(
 
     private static readonly string[] item = ["first", "second"];
 
+    /// <summary>
+    /// EN: Tests CompositeIndexFilterShouldReturnCorrectRows behavior.
+    /// PT: Testa o comportamento de CompositeIndexFilterShouldReturnCorrectRows.
+    /// </summary>
     [Fact]
     public void CompositeIndexFilterShouldReturnCorrectRows()
     {
@@ -78,6 +94,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(1, (int)result[0].value);
     }
 
+    /// <summary>
+    /// EN: Tests LikeFilterShouldReturnMatchingRows behavior.
+    /// PT: Testa o comportamento de LikeFilterShouldReturnMatchingRows.
+    /// </summary>
     [Fact]
     public void LikeFilterShouldReturnMatchingRows()
     {
@@ -94,6 +114,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal("alice", res[0].name);
     }
 
+    /// <summary>
+    /// EN: Tests InFilterShouldReturnMatchingRows behavior.
+    /// PT: Testa o comportamento de InFilterShouldReturnMatchingRows.
+    /// </summary>
     [Fact]
     public void InFilterShouldReturnMatchingRows()
     {
@@ -111,6 +135,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal([1, 3], ids);
     }
 
+    /// <summary>
+    /// EN: Tests OrderByLimitOffsetDistinctShouldReturnExpectedRows behavior.
+    /// PT: Testa o comportamento de OrderByLimitOffsetDistinctShouldReturnExpectedRows.
+    /// </summary>
     [Fact]
     public void OrderByLimitOffsetDistinctShouldReturnExpectedRows()
     {
@@ -128,6 +156,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(1, (int)res[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests HavingFilterShouldApplyAfterAggregation behavior.
+    /// PT: Testa o comportamento de HavingFilterShouldApplyAfterAggregation.
+    /// </summary>
     [Fact]
     public void HavingFilterShouldApplyAfterAggregation()
     {
@@ -148,6 +180,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(2L, result[0].C);
     }
 
+    /// <summary>
+    /// EN: Tests ForeignKeyDeleteShouldThrowOnReferencedParentDeletion behavior.
+    /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletion.
+    /// </summary>
     [Fact]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletion()
     {
@@ -171,6 +207,10 @@ public sealed class ExtendedMySqlMockTests(
             cnn.Execute("DELETE FROM parent WHERE id = 1"));
     }
 
+    /// <summary>
+    /// EN: Tests ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK behavior.
+    /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK.
+    /// </summary>
     [Fact]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK()
     {
@@ -193,6 +233,10 @@ public sealed class ExtendedMySqlMockTests(
             cnn.Execute("DELETE FROM parent WHERE id = 1"));
     }
 
+    /// <summary>
+    /// EN: Tests MultipleParameterSetsInsertShouldInsertAllRows behavior.
+    /// PT: Testa o comportamento de MultipleParameterSetsInsertShouldInsertAllRows.
+    /// </summary>
     [Fact]
     public void MultipleParameterSetsInsertShouldInsertAllRows()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/FluentTest.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/FluentTest.cs
@@ -22,6 +22,10 @@ public sealed class FluentTest(
         return cnn;
     }
 
+    /// <summary>
+    /// EN: Tests InsertUpdateDeleteFluentScenario behavior.
+    /// PT: Testa o comportamento de InsertUpdateDeleteFluentScenario.
+    /// </summary>
     [Fact]
     public void InsertUpdateDeleteFluentScenario()
     {
@@ -61,6 +65,10 @@ public sealed class FluentTest(
         Assert.True(cnn.Metrics.Elapsed > TimeSpan.Zero);
     }
 
+    /// <summary>
+    /// EN: Tests TestFluent behavior.
+    /// PT: Testa o comportamento de TestFluent.
+    /// </summary>
     [Fact]
     public void TestFluent()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlExprPrinterTest.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlExprPrinterTest.cs
@@ -3,6 +3,10 @@ public sealed class SqlExprPrinterTest(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse behavior.
+    /// PT: Testa o comportamento de ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse.
+    /// </summary>
     [Theory]
     [MemberDataByNpgsqlVersion(nameof(Expressions))]
     public void ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse(string expr, int version)

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlExpressionParserTests.cs
@@ -7,6 +7,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Smoke tests: todas as expressões reais encontradas no zip (suportadas) -----------
 
+    /// <summary>
+    /// EN: Tests ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions behavior.
+    /// PT: Testa o comportamento de ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions.
+    /// </summary>
     [Theory]
     [MemberDataByNpgsqlVersion(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
@@ -74,6 +78,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Negative tests: coisas que aparecem nos testes atuais mas NÃO fazem parte do subset -----------
 
+    /// <summary>
+    /// EN: Tests ParseWhere_ShouldThrow_ForUnsupportedExpressions behavior.
+    /// PT: Testa o comportamento de ParseWhere_ShouldThrow_ForUnsupportedExpressions.
+    /// </summary>
     [Theory]
     [MemberDataByNpgsqlVersion(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
@@ -100,6 +108,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Regras (cenários extra) -----------
 
+    /// <summary>
+    /// EN: Tests Precedence_OR_ShouldBindLooserThan_AND behavior.
+    /// PT: Testa o comportamento de Precedence_OR_ShouldBindLooserThan_AND.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
@@ -124,6 +136,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(SqlBinaryOp.Eq, andRight.Op);
     }
 
+    /// <summary>
+    /// EN: Tests Parentheses_ShouldOverridePrecedence behavior.
+    /// PT: Testa o comportamento de Parentheses_ShouldOverridePrecedence.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Parentheses_ShouldOverridePrecedence(int version)
@@ -141,6 +157,10 @@ public sealed class SqlExpressionParserTests(
         Assert.False(isNull.Negated);
     }
 
+    /// <summary>
+    /// EN: Tests Not_ShouldWork behavior.
+    /// PT: Testa o comportamento de Not_ShouldWork.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Not_ShouldWork(int version)
@@ -154,6 +174,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(SqlBinaryOp.Or, or.Op);
     }
 
+    /// <summary>
+    /// EN: Tests IsNotNull_ShouldProduce_IsNullExpr_Negated behavior.
+    /// PT: Testa o comportamento de IsNotNull_ShouldProduce_IsNullExpr_Negated.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
@@ -163,6 +187,10 @@ public sealed class SqlExpressionParserTests(
         Assert.True(n.Negated);
     }
 
+    /// <summary>
+    /// EN: Tests In_ShouldParse_List behavior.
+    /// PT: Testa o comportamento de In_ShouldParse_List.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void In_ShouldParse_List(int version)
@@ -172,6 +200,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(3, ins.Items.Count);
     }
 
+    /// <summary>
+    /// EN: Tests Like_ShouldParse behavior.
+    /// PT: Testa o comportamento de Like_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Like_ShouldParse(int version)
@@ -181,6 +213,10 @@ public sealed class SqlExpressionParserTests(
         Assert.NotNull(like.Pattern);
     }
 
+    /// <summary>
+    /// EN: Tests Identifier_WithAliasDotColumn_ShouldParse behavior.
+    /// PT: Testa o comportamento de Identifier_WithAliasDotColumn_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
@@ -199,6 +235,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("userId", r.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parameter_Tokens_ShouldParse behavior.
+    /// PT: Testa o comportamento de Parameter_Tokens_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Parameter_Tokens_ShouldParse(int version)
@@ -209,6 +249,10 @@ public sealed class SqlExpressionParserTests(
         Assert.NotNull(SqlExpressionParser.ParseWhere("a = ?", d));
     }
 
+    /// <summary>
+    /// EN: Tests DoubleQuoted_Identifier_ShouldParse behavior.
+    /// PT: Testa o comportamento de DoubleQuoted_Identifier_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void DoubleQuoted_Identifier_ShouldParse(int version)
@@ -219,6 +263,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("DeletedDtt", id.Name);
     }
 
+    /// <summary>
+    /// EN: Tests SingleQuoted_String_ShouldParse behavior.
+    /// PT: Testa o comportamento de SingleQuoted_String_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void SingleQuoted_String_ShouldParse(int version)
@@ -229,6 +277,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("John", lit.Value);
     }
 
+    /// <summary>
+    /// EN: Tests Printer_ShouldBeStable_ForSimpleExpression behavior.
+    /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -582,6 +582,10 @@ select id
     }
 
 
+    /// <summary>
+    /// EN: Tests Parse_ShouldHandle_MultiStatementStrings_BySplitting behavior.
+    /// PT: Testa o comportamento de Parse_ShouldHandle_MultiStatementStrings_BySplitting.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Parse_ShouldHandle_MultiStatementStrings_BySplitting(int version)
@@ -601,6 +605,10 @@ select id
         Assert.True(q3 is SqlInsertQuery);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_Corpus behavior.
+    /// PT: Testa o comportamento de Parse_Corpus.
+    /// </summary>
     [Theory]
     [MemberDataByNpgsqlVersion(nameof(Statements))]
     public void Parse_Corpus(string sql, string why, SqlCaseExpectation expectation, int minVersion, int version)

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdditionalBehaviorCoverageTests.cs
@@ -36,6 +36,10 @@ public sealed class PostgreSqlAdditionalBehaviorCoverageTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_IsNull_And_IsNotNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_IsNull_And_IsNotNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_IsNull_And_IsNotNull_ShouldWork()
     {
@@ -46,6 +50,10 @@ public sealed class PostgreSqlAdditionalBehaviorCoverageTests : XUnitTestBase
         Assert.Equal([1, 3], notNullIds);
     }
 
+    /// <summary>
+    /// EN: Tests Where_EqualNull_ShouldReturnNoRows behavior.
+    /// PT: Testa o comportamento de Where_EqualNull_ShouldReturnNoRows.
+    /// </summary>
     [Fact]
     public void Where_EqualNull_ShouldReturnNoRows()
     {
@@ -57,6 +65,10 @@ public sealed class PostgreSqlAdditionalBehaviorCoverageTests : XUnitTestBase
         Assert.Empty(ids);
     }
 
+    /// <summary>
+    /// EN: Tests LeftJoin_ShouldPreserveLeftRows_WhenNoMatch behavior.
+    /// PT: Testa o comportamento de LeftJoin_ShouldPreserveLeftRows_WhenNoMatch.
+    /// </summary>
     [Fact]
     public void LeftJoin_ShouldPreserveLeftRows_WhenNoMatch()
     {
@@ -79,6 +91,10 @@ ORDER BY u.id
         Assert.Null((object?)rows[2].amount);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_Desc_ThenAsc_ShouldBeDeterministic behavior.
+    /// PT: Testa o comportamento de OrderBy_Desc_ThenAsc_ShouldBeDeterministic.
+    /// </summary>
     [Fact]
     public void OrderBy_Desc_ThenAsc_ShouldBeDeterministic()
     {
@@ -92,6 +108,10 @@ ORDER BY amount DESC, id ASC
         Assert.Equal([200m, 50m, 10m], [.. rows.Select(r => (decimal)r.amount)]);
     }
 
+    /// <summary>
+    /// EN: Tests Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls behavior.
+    /// PT: Testa o comportamento de Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls.
+    /// </summary>
     [Fact]
     public void Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls()
     {
@@ -101,6 +121,10 @@ ORDER BY amount DESC, id ASC
         Assert.Equal(2L, (long)r.c2);
     }
 
+    /// <summary>
+    /// EN: Tests Having_ShouldFilterGroups behavior.
+    /// PT: Testa o comportamento de Having_ShouldFilterGroups.
+    /// </summary>
     [Fact]
     public void Having_ShouldFilterGroups()
     {
@@ -115,6 +139,10 @@ ORDER BY userid
         Assert.Equal([2], userIds);
     }
 
+    /// <summary>
+    /// EN: Tests Where_In_WithParameterList_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_In_WithParameterList_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_In_WithParameterList_ShouldWork()
     {
@@ -122,6 +150,10 @@ ORDER BY userid
         Assert.Equal([1, 3], ids);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_WithColumnsOutOfOrder_ShouldMapCorrectly behavior.
+    /// PT: Testa o comportamento de Insert_WithColumnsOutOfOrder_ShouldMapCorrectly.
+    /// </summary>
     [Fact]
     public void Insert_WithColumnsOutOfOrder_ShouldMapCorrectly()
     {
@@ -133,6 +165,10 @@ ORDER BY userid
         Assert.Equal("zed@x.com", (string)row.email);
     }
 
+    /// <summary>
+    /// EN: Tests Delete_WithInParameterList_ShouldDeleteMatchingRows behavior.
+    /// PT: Testa o comportamento de Delete_WithInParameterList_ShouldDeleteMatchingRows.
+    /// </summary>
     [Fact]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
@@ -143,6 +179,10 @@ ORDER BY userid
         Assert.Equal([2], remaining);
     }
 
+    /// <summary>
+    /// EN: Tests Update_SetExpression_ShouldUpdateRows behavior.
+    /// PT: Testa o comportamento de Update_SetExpression_ShouldUpdateRows.
+    /// </summary>
     [Fact]
     public void Update_SetExpression_ShouldUpdateRows()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdvancedSqlGapTests.cs
@@ -35,6 +35,10 @@ public sealed class PostgreSqlAdvancedSqlGapTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Window_RowNumber_PartitionBy_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
+    /// </summary>
     [Fact]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
@@ -47,6 +51,10 @@ ORDER BY tenantid, id").ToList();
         Assert.Equal([1, 2, 1], [.. rows.Select(r => (int)r.rn)]);
     }
 
+    /// <summary>
+    /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
+    /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
+    /// </summary>
     [Fact]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
@@ -59,6 +67,10 @@ ORDER BY u.id").ToList();
         Assert.Equal([15m, 7m, 0m], [.. rows.Select(r => (decimal)(r.total ?? 0m))]);
     }
 
+    /// <summary>
+    /// EN: Tests DateAdd_IntervalDay_ShouldWork behavior.
+    /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
+    /// </summary>
     [Fact]
     public void DateAdd_IntervalDay_ShouldWork()
     {
@@ -74,6 +86,10 @@ ORDER BY id").ToList();
             [.. rows.Select(r => (DateTime)r.d)]);
     }
 
+    /// <summary>
+    /// EN: Tests Cast_StringToInt_ShouldWork behavior.
+    /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
+    /// </summary>
     [Fact]
     public void Cast_StringToInt_ShouldWork()
     {
@@ -82,6 +98,10 @@ ORDER BY id").ToList();
         Assert.Equal(42, (int)rows[0].v);
     }
 
+    /// <summary>
+    /// EN: Tests Regexp_Operator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
+    /// </summary>
     [Fact]
     public void Regexp_Operator_ShouldWork()
     {
@@ -89,6 +109,10 @@ ORDER BY id").ToList();
         Assert.Equal([1, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_Field_Function_ShouldWork behavior.
+    /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
+    /// </summary>
     [Fact]
     public void OrderBy_Field_Function_ShouldWork()
     {
@@ -96,6 +120,10 @@ ORDER BY id").ToList();
         Assert.Equal([3, 1, 2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Collation_CaseSensitivity_ShouldFollowColumnCollation behavior.
+    /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
+    /// </summary>
     [Fact]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAggregationTests.cs
@@ -20,6 +20,10 @@ public sealed class PostgreSqlAggregationTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
+    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
+    /// </summary>
     [Fact]
     public void GroupBy_WithCountAndSum_ShouldWork()
     {
@@ -42,6 +46,10 @@ public sealed class PostgreSqlAggregationTests : XUnitTestBase
         Assert.Equal(5m, (decimal)rows[1].sumAmount);
     }
 
+    /// <summary>
+    /// EN: Tests Having_ShouldFilterAggregates behavior.
+    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
+    /// </summary>
     [Fact]
     public void Having_ShouldFilterAggregates()
     {
@@ -57,6 +65,10 @@ public sealed class PostgreSqlAggregationTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].userId);
     }
 
+    /// <summary>
+    /// EN: Tests Distinct_Order_Limit_Offset_ShouldWork behavior.
+    /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
+    /// </summary>
     [Fact]
     public void Distinct_Order_Limit_Offset_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlDataParameterCollectionMockTest.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlDataParameterCollectionMockTest.cs
@@ -3,6 +3,10 @@ public sealed class NpgsqlDataParameterCollectionMockTest(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames behavior.
+    /// PT: Testa o comportamento de ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames.
+    /// </summary>
     [Fact]
     public void ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames()
     {
@@ -13,6 +17,10 @@ public sealed class NpgsqlDataParameterCollectionMockTest(
         Assert.Equal("id", NpgsqlDataParameterCollectionMock.NormalizeParameterName("@'id'"));
     }
 
+    /// <summary>
+    /// EN: Tests ParameterCollection_Add_DuplicateName_ShouldThrow behavior.
+    /// PT: Testa o comportamento de ParameterCollection_Add_DuplicateName_ShouldThrow.
+    /// </summary>
     [Fact]
     public void ParameterCollection_Add_DuplicateName_ShouldThrow()
     {
@@ -22,6 +30,10 @@ public sealed class NpgsqlDataParameterCollectionMockTest(
         Assert.Throws<ArgumentException>(() => pars.AddWithValue("@id", 2)); // case-insensitive
     }
 
+    /// <summary>
+    /// EN: Tests ParameterCollection_RemoveAt_ShouldReindexDictionary behavior.
+    /// PT: Testa o comportamento de ParameterCollection_RemoveAt_ShouldReindexDictionary.
+    /// </summary>
     [Fact]
     public void ParameterCollection_RemoveAt_ShouldReindexDictionary()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlJoinTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlJoinTests.cs
@@ -28,6 +28,10 @@ public sealed class PostgreSqlJoinTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests LeftJoin_ShouldKeepAllLeftRows behavior.
+    /// PT: Testa o comportamento de LeftJoin_ShouldKeepAllLeftRows.
+    /// </summary>
     [Fact]
     public void LeftJoin_ShouldKeepAllLeftRows()
     {
@@ -44,6 +48,10 @@ public sealed class PostgreSqlJoinTests : XUnitTestBase
         Assert.Contains(rows, r => (int)r.id == 2);
     }
 
+    /// <summary>
+    /// EN: Tests RightJoin_ShouldKeepAllRightRows behavior.
+    /// PT: Testa o comportamento de RightJoin_ShouldKeepAllRightRows.
+    /// </summary>
     [Fact]
     public void RightJoin_ShouldKeepAllRightRows()
     {
@@ -74,6 +82,10 @@ public sealed class PostgreSqlJoinTests : XUnitTestBase
     //    Assert.Contains(rows, r => r.id is null && (int)r.orderId == 12); // órfão
     //}
 
+    /// <summary>
+    /// EN: Tests Join_ON_WithMultipleConditions_AND_ShouldWork behavior.
+    /// PT: Testa o comportamento de Join_ON_WithMultipleConditions_AND_ShouldWork.
+    /// </summary>
     [Fact]
     public void Join_ON_WithMultipleConditions_AND_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlLinqProviderTest.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlLinqProviderTest.cs
@@ -9,6 +9,10 @@ public sealed class PostgreSqlLinqProviderTest
     }
 #pragma warning restore CA1812
 
+    /// <summary>
+    /// EN: Tests LinqProvider_ShouldQueryWhereAndReturnRows behavior.
+    /// PT: Testa o comportamento de LinqProvider_ShouldQueryWhereAndReturnRows.
+    /// </summary>
     [Fact]
     public void LinqProvider_ShouldQueryWhereAndReturnRows()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlMockTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlMockTests.cs
@@ -24,6 +24,10 @@ public sealed class PostgreSqlMockTests
         _connection.Open();
     }
 
+    /// <summary>
+    /// EN: Tests TestInsert behavior.
+    /// PT: Testa o comportamento de TestInsert.
+    /// </summary>
     [Fact]
     public void TestInsert()
     {
@@ -36,6 +40,10 @@ public sealed class PostgreSqlMockTests
         Assert.Equal("John Doe",_connection.GetTable("Users")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TestUpdate behavior.
+    /// PT: Testa o comportamento de TestUpdate.
+    /// </summary>
     [Fact]
     public void TestUpdate()
     {
@@ -51,6 +59,10 @@ public sealed class PostgreSqlMockTests
         Assert.Equal("Jane Doe",_connection.GetTable("Users")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TestDelete behavior.
+    /// PT: Testa o comportamento de TestDelete.
+    /// </summary>
     [Fact]
     public void TestDelete()
     {
@@ -66,6 +78,10 @@ public sealed class PostgreSqlMockTests
         Assert.Empty(_connection.GetTable("Users"));
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionCommit behavior.
+    /// PT: Testa o comportamento de TestTransactionCommit.
+    /// </summary>
     [Fact]
     public void TestTransactionCommit()
     {
@@ -97,6 +113,10 @@ public sealed class PostgreSqlMockTests
         Assert.Single(users);
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionCommitInsertUpdate behavior.
+    /// PT: Testa o comportamento de TestTransactionCommitInsertUpdate.
+    /// </summary>
     [Fact]
     public void TestTransactionCommitInsertUpdate()
     {
@@ -115,6 +135,10 @@ public sealed class PostgreSqlMockTests
         Assert.Equal("Bob", name);
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionRollback behavior.
+    /// PT: Testa o comportamento de TestTransactionRollback.
+    /// </summary>
     [Fact]
     public void TestTransactionRollback()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSelectAndWhereMoreCoverageTests.cs
@@ -30,6 +30,10 @@ public sealed class PostgreSqlSelectAndWhereMoreCoverageTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_Between_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Between_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Between_ShouldWork()
     {
@@ -37,6 +41,10 @@ public sealed class PostgreSqlSelectAndWhereMoreCoverageTests : XUnitTestBase
         Assert.Equal([2, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_NotIn_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_NotIn_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_NotIn_ShouldWork()
     {
@@ -45,6 +53,10 @@ public sealed class PostgreSqlSelectAndWhereMoreCoverageTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Where_ExistsSubquery_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_ExistsSubquery_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_ExistsSubquery_ShouldWork()
     {
@@ -62,6 +74,10 @@ ORDER BY u.id").ToList();
         Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_CaseWhen_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_CaseWhen_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_CaseWhen_ShouldWork()
     {
@@ -77,6 +93,10 @@ ORDER BY id").ToList();
         Assert.Equal("Y", (string)rows[2].hasEmail);
     }
 
+    /// <summary>
+    /// EN: Tests Select_IfNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_IfNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_IfNull_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSqlCompatibilityGapTests.cs
@@ -36,6 +36,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_Precedence_AND_ShouldBindStrongerThan_OR behavior.
+    /// PT: Testa o comportamento de Where_Precedence_AND_ShouldBindStrongerThan_OR.
+    /// </summary>
     [Fact]
     public void Where_Precedence_AND_ShouldBindStrongerThan_OR()
     {
@@ -45,6 +49,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_OR_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_OR_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_OR_ShouldWork()
     {
@@ -52,6 +60,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 3], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_ParenthesesGrouping_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_ParenthesesGrouping_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_ParenthesesGrouping_ShouldWork()
     {
@@ -61,6 +73,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_Arithmetic_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_Arithmetic_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_Arithmetic_ShouldWork()
     {
@@ -68,6 +84,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([2, 3, 4], [.. rows.Select(r => (int)r.nextId)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_CASE_WHEN_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_CASE_WHEN_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_CASE_WHEN_ShouldWork()
     {
@@ -75,6 +95,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 0, 1], [.. rows.Select(r => (int)r.hasEmail)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_IF_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_IF_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_IF_ShouldWork()
     {
@@ -83,6 +107,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["yes", "no", "yes"], [.. rows.Select(r => (string)r.flag)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_IIF_ShouldWork_AsAliasForIF behavior.
+    /// PT: Testa o comportamento de Select_Expressions_IIF_ShouldWork_AsAliasForIF.
+    /// </summary>
     [Fact]
     public void Select_Expressions_IIF_ShouldWork_AsAliasForIF()
     {
@@ -91,6 +119,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 0, 1], [.. rows.Select(r => (int)r.hasEmail)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_COALESCE_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_COALESCE_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_COALESCE_ShouldWork()
     {
@@ -98,6 +130,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["john@x.com", "none", "jane@x.com"], [.. rows.Select(r => (string)r.em)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_IFNULL_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_IFNULL_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_IFNULL_ShouldWork()
     {
@@ -105,6 +141,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["john@x.com", "none", "jane@x.com"], [.. rows.Select(r => (string)r.em)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_CONCAT_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_CONCAT_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_CONCAT_ShouldWork()
     {
@@ -112,6 +152,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["John#1", "Bob#2", "Jane#3"], [.. rows.Select(r => (string)r.tag)]);
     }
 
+    /// <summary>
+    /// EN: Tests Distinct_ShouldBeConsistent behavior.
+    /// PT: Testa o comportamento de Distinct_ShouldBeConsistent.
+    /// </summary>
     [Fact]
     public void Distinct_ShouldBeConsistent()
     {
@@ -121,6 +165,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["Bob", "Jane", "John"], [.. rows.Select(r => (string)r.name)]);
     }
 
+    /// <summary>
+    /// EN: Tests Join_ComplexOn_WithOr_ShouldWork behavior.
+    /// PT: Testa o comportamento de Join_ComplexOn_WithOr_ShouldWork.
+    /// </summary>
     [Fact]
     public void Join_ComplexOn_WithOr_ShouldWork()
     {
@@ -137,6 +185,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
             [.. rows.Select(r => ((int)r.uid,(int)r.oid))]);
     }
 
+    /// <summary>
+    /// EN: Tests GroupBy_Having_ShouldSupportAggregates behavior.
+    /// PT: Testa o comportamento de GroupBy_Having_ShouldSupportAggregates.
+    /// </summary>
     [Fact]
     public void GroupBy_Having_ShouldSupportAggregates()
     {
@@ -150,6 +202,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(210m, (decimal)rows[0].total);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_ShouldSupportAlias_And_Ordinal behavior.
+    /// PT: Testa o comportamento de OrderBy_ShouldSupportAlias_And_Ordinal.
+    /// </summary>
     [Fact]
     public void OrderBy_ShouldSupportAlias_And_Ordinal()
     {
@@ -161,6 +217,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([(2,"Bob"),(3,"Jane"),(1,"John")], [.. rows2.Select(r => ((int)r.id,(string)r.name))]);
     }
 
+    /// <summary>
+    /// EN: Tests Union_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_ShouldWork.
+    /// </summary>
     [Fact]
     public void Union_ShouldWork()
     {
@@ -172,6 +232,10 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1,2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Union_Inside_SubSelect_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
+    /// </summary>
     [Fact]
     public void Union_Inside_SubSelect_ShouldWork()
     {
@@ -186,6 +250,10 @@ ORDER BY id
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Cte_With_ShouldWork behavior.
+    /// PT: Testa o comportamento de Cte_With_ShouldWork.
+    /// </summary>
     [Fact]
     public void Cte_With_ShouldWork()
     {
@@ -195,6 +263,10 @@ ORDER BY id
         Assert.Equal([2,1], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault behavior.
+    /// PT: Testa o comportamento de Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault.
+    /// </summary>
     [Fact]
     public void Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlTransactionTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlTransactionTests.cs
@@ -10,6 +10,10 @@ public sealed class PostgreSqlTransactionTests(
         public string? Email { get; set; }
     }
 
+    /// <summary>
+    /// EN: Tests TransactionCommitShouldPersistData behavior.
+    /// PT: Testa o comportamento de TransactionCommitShouldPersistData.
+    /// </summary>
     [Fact]
     public void TransactionCommitShouldPersistData()
     {
@@ -38,6 +42,10 @@ public sealed class PostgreSqlTransactionTests(
         Assert.Equal(user.Email, insertedRow[2]);
     }
 
+    /// <summary>
+    /// EN: Tests TransactionRollbackShouldNotPersistData behavior.
+    /// PT: Testa o comportamento de TransactionRollbackShouldNotPersistData.
+    /// </summary>
     [Fact]
     public void TransactionRollbackShouldNotPersistData()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs
@@ -22,6 +22,10 @@ public sealed class PostgreSqlUnionLimitAndJsonCompatibilityTests : XUnitTestBas
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates behavior.
+    /// PT: Testa o comportamento de UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates.
+    /// </summary>
     [Fact]
     public void UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates()
     {
@@ -42,6 +46,10 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([1], [.. distinct.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests LimitOffset_ShouldWork behavior.
+    /// PT: Testa o comportamento de LimitOffset_ShouldWork.
+    /// </summary>
     [Fact]
     public void LimitOffset_ShouldWork()
     {
@@ -50,6 +58,10 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([2, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests JsonPathExtract_ShouldWork behavior.
+    /// PT: Testa o comportamento de JsonPathExtract_ShouldWork.
+    /// </summary>
     [Fact]
     public void JsonPathExtract_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlWhereParserAndExecutorTests.cs
@@ -21,6 +21,10 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_IN_ShouldFilter behavior.
+    /// PT: Testa o comportamento de Where_IN_ShouldFilter.
+    /// </summary>
     [Fact]
     public void Where_IN_ShouldFilter()
     {
@@ -30,6 +34,10 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Contains(rows, r => (int)r.id == 3);
     }
 
+    /// <summary>
+    /// EN: Tests Where_IsNotNull_ShouldFilter behavior.
+    /// PT: Testa o comportamento de Where_IsNotNull_ShouldFilter.
+    /// </summary>
     [Fact]
     public void Where_IsNotNull_ShouldFilter()
     {
@@ -37,6 +45,10 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(2, rows.Count);
     }
 
+    /// <summary>
+    /// EN: Tests Where_Operators_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Operators_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Operators_ShouldWork()
     {
@@ -47,6 +59,10 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal([1, 3], [.. rows2.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_Like_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Like_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Like_ShouldWork()
     {
@@ -55,6 +71,10 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Where_FindInSet_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_FindInSet_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_FindInSet_ShouldWork()
     {
@@ -63,6 +83,10 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_AND_ShouldBeCaseInsensitive_InRealLife behavior.
+    /// PT: Testa o comportamento de Where_AND_ShouldBeCaseInsensitive_InRealLife.
+    /// </summary>
     [Fact]
     public void Where_AND_ShouldBeCaseInsensitive_InRealLife()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Query/QueryExecutorExtrasTests.cs
@@ -20,6 +20,10 @@ public sealed class QueryExecutorExtrasTests(
         return db;
     }
 
+    /// <summary>
+    /// EN: Tests GroupByAndAggregationsShouldComputeCorrectly behavior.
+    /// PT: Testa o comportamento de GroupByAndAggregationsShouldComputeCorrectly.
+    /// </summary>
     [Fact]
     public void GroupByAndAggregationsShouldComputeCorrectly()
     {
@@ -53,6 +57,10 @@ GROUP BY grp";
 
     private static readonly int[] expected = [4, 3];
 
+    /// <summary>
+    /// EN: Tests OrderByLimitOffsetShouldPageCorrectly behavior.
+    /// PT: Testa o comportamento de OrderByLimitOffsetShouldPageCorrectly.
+    /// </summary>
     [Fact]
     public void OrderByLimitOffsetShouldPageCorrectly()
     {
@@ -98,6 +106,10 @@ SELECT * FROM t ORDER BY iddesc ASC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY;";
 /// </summary>
 public class SqlTranslatorTests
 {
+    /// <summary>
+    /// EN: Tests TranslateBasicWhereAndOrderBySqlCorrect behavior.
+    /// PT: Testa o comportamento de TranslateBasicWhereAndOrderBySqlCorrect.
+    /// </summary>
     [Fact]
     public void TranslateBasicWhereAndOrderBySqlCorrect()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -4,6 +4,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests CreateTableAsSelect_ShouldCreateNewTableWithRows behavior.
+    /// PT: Testa o comportamento de CreateTableAsSelect_ShouldCreateNewTableWithRows.
+    /// </summary>
     [Fact]
     public void CreateTableAsSelect_ShouldCreateNewTableWithRows()
     {
@@ -32,6 +36,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         Assert.Equal("A", active[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertIntoSelect_ShouldInsertRowsFromQuery behavior.
+    /// PT: Testa o comportamento de InsertIntoSelect_ShouldInsertRowsFromQuery.
+    /// </summary>
     [Fact]
     public void InsertIntoSelect_ShouldInsertRowsFromQuery()
     {
@@ -59,6 +67,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         Assert.Equal("A", audit[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests UpdateJoinDerivedSelect_ShouldUpdateRows behavior.
+    /// PT: Testa o comportamento de UpdateJoinDerivedSelect_ShouldUpdateRows.
+    /// </summary>
     [Fact]
     public void UpdateJoinDerivedSelect_ShouldUpdateRows()
     {
@@ -94,6 +106,10 @@ WHERE u.tenantid = 10";
         Assert.Null(users[2][2]);
     }
 
+    /// <summary>
+    /// EN: Tests DeleteJoinDerivedSelect_ShouldDeleteRows behavior.
+    /// PT: Testa o comportamento de DeleteJoinDerivedSelect_ShouldDeleteRows.
+    /// </summary>
     [Fact]
     public void DeleteJoinDerivedSelect_ShouldDeleteRows()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/SqlValueHelperTests .cs
@@ -6,6 +6,10 @@ public sealed class SqlValueHelperTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Resolve_ShouldReadDapperParameter_ByName behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_ByName.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldReadDapperParameter_ByName()
     {
@@ -22,6 +26,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(123, v);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_ShouldThrow_WhenParameterMissing behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldThrow_WhenParameterMissing()
     {
@@ -29,6 +37,10 @@ public sealed class SqlValueHelperTests(
             NpgsqlValueHelper.Resolve("@p404", DbType.Int32, isNullable: false, pars: null, colDict: null));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_ShouldParseInList_ToListOfResolvedValues behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldParseInList_ToListOfResolvedValues.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldParseInList_ToListOfResolvedValues()
     {
@@ -38,6 +50,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal([1, 2, 3], [.. list.Cast<int>()]);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_NullOnNonNullable_ShouldThrow behavior.
+    /// PT: Testa o comportamento de Resolve_NullOnNonNullable_ShouldThrow.
+    /// </summary>
     [Fact]
     public void Resolve_NullOnNonNullable_ShouldThrow()
     {
@@ -45,6 +61,10 @@ public sealed class SqlValueHelperTests(
             NpgsqlValueHelper.Resolve("null", DbType.Int32, isNullable: false, pars: null, colDict: null));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Json_ShouldReturnJsonDocument_WhenValid behavior.
+    /// PT: Testa o comportamento de Resolve_Json_ShouldReturnJsonDocument_WhenValid.
+    /// </summary>
     [Fact]
     public void Resolve_Json_ShouldReturnJsonDocument_WhenValid()
     {
@@ -54,6 +74,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(1, doc.RootElement.GetProperty("a").GetInt32());
     }
 
+    /// <summary>
+    /// EN: Tests Like_ShouldMatch_MySqlStyle behavior.
+    /// PT: Testa o comportamento de Like_ShouldMatch_MySqlStyle.
+    /// </summary>
     [Theory]
     [InlineData("John", "%oh%", true)]
     [InlineData("John", "J_hn", true)]
@@ -65,6 +89,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(expected, NpgsqlValueHelper.Like(value, pattern));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Enum_ShouldValidateAgainstColumnDef behavior.
+    /// PT: Testa o comportamento de Resolve_Enum_ShouldValidateAgainstColumnDef.
+    /// </summary>
     [Fact]
     public void Resolve_Enum_ShouldValidateAgainstColumnDef()
     {
@@ -84,6 +112,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(1265, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Set_ShouldReturnHashSet_AndValidate behavior.
+    /// PT: Testa o comportamento de Resolve_Set_ShouldReturnHashSet_AndValidate.
+    /// </summary>
     [Fact]
     public void Resolve_Set_ShouldReturnHashSet_AndValidate()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/StoredProcedureExecutionTests.cs
@@ -16,6 +16,10 @@ public sealed class StoredProcedureExecutionTests(
             Direction = dir
         };
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs()
     {
@@ -52,6 +56,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, affected);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput()
     {
@@ -86,6 +94,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(1318, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull()
     {
@@ -120,6 +132,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(1048, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue()
     {
@@ -163,6 +179,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, ((NpgsqlParameter)cmd.Parameters["@o_status"]).Value);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset behavior.
+    /// PT: Testa o comportamento de ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset.
+    /// </summary>
     [Fact]
     public void ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset()
     {
@@ -192,6 +212,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.False(r.Read());
     }
 
+    /// <summary>
+    /// EN: Tests DapperExecute_CommandTypeStoredProcedure_ShouldWork behavior.
+    /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldWork.
+    /// </summary>
     [Fact]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldWork()
     {
@@ -221,6 +245,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, affected);
     }
 
+    /// <summary>
+    /// EN: Tests DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam behavior.
+    /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam.
+    /// </summary>
     [Fact]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/StoredProcedureSignatureTests.cs
@@ -4,6 +4,10 @@ public sealed class StoredProcedureSignatureTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests StoredProcedure_ShouldValidateRequiredInAndOutParams behavior.
+    /// PT: Testa o comportamento de StoredProcedure_ShouldValidateRequiredInAndOutParams.
+    /// </summary>
     [Fact]
     public void StoredProcedure_ShouldValidateRequiredInAndOutParams()
     {
@@ -31,6 +35,10 @@ public sealed class StoredProcedureSignatureTests(
             CultureInfo.InvariantCulture));
     }
 
+    /// <summary>
+    /// EN: Tests StoredProcedure_ShouldThrowWhenMissingRequiredParam behavior.
+    /// PT: Testa o comportamento de StoredProcedure_ShouldThrowWhenMissingRequiredParam.
+    /// </summary>
     [Fact]
     public void StoredProcedure_ShouldThrowWhenMissingRequiredParam()
     {
@@ -50,6 +58,10 @@ public sealed class StoredProcedureSignatureTests(
         Assert.Equal(1318, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests CallStatement_ShouldValidateAgainstRegisteredProcedure behavior.
+    /// PT: Testa o comportamento de CallStatement_ShouldValidateAgainstRegisteredProcedure.
+    /// </summary>
     [Fact]
     public void CallStatement_ShouldValidateAgainstRegisteredProcedure()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs
@@ -4,6 +4,10 @@ public sealed class PostgreSqlCommandDeleteTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_remove_1_linha behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_1_linha.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_remove_1_linha()
     {
@@ -23,6 +27,10 @@ public sealed class PostgreSqlCommandDeleteTests(
         Assert.Equal(1, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_remove_varias_linhas behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_varias_linhas.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_remove_varias_linhas()
     {
@@ -43,6 +51,10 @@ public sealed class PostgreSqlCommandDeleteTests(
         Assert.Equal(2, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0 behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0()
     {
@@ -60,6 +72,10 @@ public sealed class PostgreSqlCommandDeleteTests(
         Assert.Equal(0, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_tabela_inexistente_dispara behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_tabela_inexistente_dispara.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_tabela_inexistente_dispara()
     {
@@ -71,6 +87,10 @@ public sealed class PostgreSqlCommandDeleteTests(
         Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara.
+    /// </summary>
     [Fact(Skip = "Isso é valido no PostgreSql")]
     public void ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara()
     {
@@ -86,6 +106,10 @@ public sealed class PostgreSqlCommandDeleteTests(
         Assert.Contains("delete", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia()
     {
@@ -108,6 +132,10 @@ public sealed class PostgreSqlCommandDeleteTests(
         Assert.Equal(0, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false.
+    /// </summary>
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -126,6 +154,10 @@ public sealed class PostgreSqlCommandDeleteTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_case_insensitive behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_case_insensitive.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_case_insensitive()
     {
@@ -142,6 +174,10 @@ public sealed class PostgreSqlCommandDeleteTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_com_parametro_se_suportado behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_com_parametro_se_suportado.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_com_parametro_se_suportado()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertOnDuplicateTests.cs
@@ -2,6 +2,10 @@ namespace DbSqlLikeMem.Npgsql.Test.Strategy;
 
 public sealed class PostgreSqlOnConflictUpsertTests(ITestOutputHelper helper) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Insert_OnConflict_ShouldInsert_WhenNoConflict behavior.
+    /// PT: Testa o comportamento de Insert_OnConflict_ShouldInsert_WhenNoConflict.
+    /// </summary>
     [Fact]
     public void Insert_OnConflict_ShouldInsert_WhenNoConflict()
     {
@@ -22,6 +26,10 @@ public sealed class PostgreSqlOnConflictUpsertTests(ITestOutputHelper helper) : 
         Assert.Equal("A", (string)t[0][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_OnConflict_ShouldUpdate_WhenConflict behavior.
+    /// PT: Testa o comportamento de Insert_OnConflict_ShouldUpdate_WhenConflict.
+    /// </summary>
     [Fact]
     public void Insert_OnConflict_ShouldUpdate_WhenConflict()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyCoverageTests.cs
@@ -4,6 +4,10 @@ public sealed class PostgreSqlInsertStrategyCoverageTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Insert_MultiRowValues_ShouldInsertAllRows behavior.
+    /// PT: Testa o comportamento de Insert_MultiRowValues_ShouldInsertAllRows.
+    /// </summary>
     [Fact]
     public void Insert_MultiRowValues_ShouldInsertAllRows()
     {
@@ -28,6 +32,10 @@ public sealed class PostgreSqlInsertStrategyCoverageTests(
         Assert.Equal("B", (string)t[1][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_WithIdentityColumnOmitted_ShouldAutoIncrement behavior.
+    /// PT: Testa o comportamento de Insert_WithIdentityColumnOmitted_ShouldAutoIncrement.
+    /// </summary>
     [Fact]
     public void Insert_WithIdentityColumnOmitted_ShouldAutoIncrement()
     {
@@ -54,6 +62,10 @@ public sealed class PostgreSqlInsertStrategyCoverageTests(
         Assert.Equal("B", (string)t[1][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests InsertSelect_ShouldInsertRowsFromSelect behavior.
+    /// PT: Testa o comportamento de InsertSelect_ShouldInsertRowsFromSelect.
+    /// </summary>
     [Fact]
     public void InsertSelect_ShouldInsertRowsFromSelect()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyExtrasTests.cs
@@ -3,6 +3,10 @@ public sealed class PostgreSqlInsertStrategyExtrasTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests MultiRowInsertShouldAddAllRows behavior.
+    /// PT: Testa o comportamento de MultiRowInsertShouldAddAllRows.
+    /// </summary>
     [Fact]
     public void MultiRowInsertShouldAddAllRows()
     {
@@ -26,6 +30,10 @@ public sealed class PostgreSqlInsertStrategyExtrasTests(
         Assert.Equal("B", table[1][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertWithDefaultValueAndIdentityShouldApplyDefaults behavior.
+    /// PT: Testa o comportamento de InsertWithDefaultValueAndIdentityShouldApplyDefaults.
+    /// </summary>
     [Fact]
     public void InsertWithDefaultValueAndIdentityShouldApplyDefaults()
     {
@@ -53,6 +61,10 @@ public sealed class PostgreSqlInsertStrategyExtrasTests(
         Assert.Equal(2, table[1][0]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertDuplicatePrimaryKeyShouldThrow behavior.
+    /// PT: Testa o comportamento de InsertDuplicatePrimaryKeyShouldThrow.
+    /// </summary>
     [Fact]
     public void InsertDuplicatePrimaryKeyShouldThrow()
     {
@@ -80,6 +92,10 @@ public sealed class PostgreSqlInsertStrategyExtrasTests(
 /// </summary>
 public class PostgreSqlDeleteStrategyForeignKeyTests
 {
+    /// <summary>
+    /// EN: Tests DeleteReferencedRowShouldThrow behavior.
+    /// PT: Testa o comportamento de DeleteReferencedRowShouldThrow.
+    /// </summary>
     [Fact]
     public void DeleteReferencedRowShouldThrow()
     {
@@ -115,6 +131,10 @@ public class PostgreSqlDeleteStrategyForeignKeyTests
 /// </summary>
 public class PostgreSqlUpdateStrategyExtrasTests
 {
+    /// <summary>
+    /// EN: Tests UpdateMultipleConditionsShouldOnlyAffectMatchingRows behavior.
+    /// PT: Testa o comportamento de UpdateMultipleConditionsShouldOnlyAffectMatchingRows.
+    /// </summary>
     [Fact]
     public void UpdateMultipleConditionsShouldOnlyAffectMatchingRows()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyTests.cs
@@ -3,6 +3,10 @@ public sealed class PostgreSqlInsertStrategyTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests InsertIntoTableShouldAddNewRow behavior.
+    /// PT: Testa o comportamento de InsertIntoTableShouldAddNewRow.
+    /// </summary>
     [Fact]
     public void InsertIntoTableShouldAddNewRow()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTransactionTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTransactionTests.cs
@@ -3,6 +3,10 @@ public sealed class PostgreSqlTransactionTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests TransactionShouldCommit behavior.
+    /// PT: Testa o comportamento de TransactionShouldCommit.
+    /// </summary>
     [Fact]
     public void TransactionShouldCommit()
     {
@@ -33,6 +37,10 @@ public sealed class PostgreSqlTransactionTests(
         Assert.Equal("John Doe", table[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TransactionShouldRollback behavior.
+    /// PT: Testa o comportamento de TransactionShouldRollback.
+    /// </summary>
     [Fact]
     public void TransactionShouldRollback()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyCoverageTests.cs
@@ -4,6 +4,10 @@ public sealed class PostgreSqlUpdateStrategyCoverageTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Update_SetNullableColumnToNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Update_SetNullableColumnToNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Update_SetNullableColumnToNull_ShouldWork()
     {
@@ -25,6 +29,10 @@ public sealed class PostgreSqlUpdateStrategyCoverageTests(
         Assert.Null(users[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests Update_SetNotNullableColumnToNull_ShouldThrow behavior.
+    /// PT: Testa o comportamento de Update_SetNotNullableColumnToNull_ShouldThrow.
+    /// </summary>
     [Fact]
     public void Update_SetNotNullableColumnToNull_ShouldThrow()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyTests.cs
@@ -4,6 +4,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
     ITestOutputHelper helper
 ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests UpdateTableShouldModifyExistingRow behavior.
+    /// PT: Testa o comportamento de UpdateTableShouldModifyExistingRow.
+    /// </summary>
     [Fact]
     public void UpdateTableShouldModifyExistingRow()
     {
@@ -28,6 +32,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldReturnZero_WhenNoRowsMatchWhere behavior.
+    /// PT: Testa o comportamento de Update_ShouldReturnZero_WhenNoRowsMatchWhere.
+    /// </summary>
     [Fact]
     public void Update_ShouldReturnZero_WhenNoRowsMatchWhere()
     {
@@ -49,6 +57,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
         Assert.Equal(0, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple behavior.
+    /// PT: Testa o comportamento de Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple.
+    /// </summary>
     [Fact]
     public void Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple()
     {
@@ -73,6 +85,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
         Assert.Equal(2, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldHandleWhereWithAnd_CaseInsensitive behavior.
+    /// PT: Testa o comportamento de Update_ShouldHandleWhereWithAnd_CaseInsensitive.
+    /// </summary>
     [Fact]
     public void Update_ShouldHandleWhereWithAnd_CaseInsensitive()
     {
@@ -97,6 +113,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldUpdateMultipleSetPairs behavior.
+    /// PT: Testa o comportamento de Update_ShouldUpdateMultipleSetPairs.
+    /// </summary>
     [Fact]
     public void Update_ShouldUpdateMultipleSetPairs()
     {
@@ -118,6 +138,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords behavior.
+    /// PT: Testa o comportamento de Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords.
+    /// </summary>
     [Fact]
     public void Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords()
     {
@@ -138,6 +162,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldWork_WithThreadSafeTrueOrFalse behavior.
+    /// PT: Testa o comportamento de Update_ShouldWork_WithThreadSafeTrueOrFalse.
+    /// </summary>
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -160,6 +188,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldThrow_WhenTableDoesNotExist behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrow_WhenTableDoesNotExist.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrow_WhenTableDoesNotExist()
     {
@@ -174,6 +206,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
         Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken()
     {
@@ -191,6 +227,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
         Assert.Contains("upd", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull behavior.
+    /// PT: Testa o comportamento de Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull.
+    /// </summary>
     [Fact]
     public void Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull()
     {
@@ -212,6 +252,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldSupportParameter_IfSqlValueHelperSupports behavior.
+    /// PT: Testa o comportamento de Update_ShouldSupportParameter_IfSqlValueHelperSupports.
+    /// </summary>
     [Fact]
     public void Update_ShouldSupportParameter_IfSqlValueHelperSupports()
     {
@@ -242,6 +286,10 @@ public sealed class PostgreSqlUpdateStrategyTests(
     // Opcional: testar ValidateUnique (preciso do IndexDef real)
     // ============================================================
     //
+    /// <summary>
+    /// EN: Tests Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/SubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/SubqueryFromAndJoinsTests.cs
@@ -4,6 +4,10 @@ public sealed class SubqueryFromAndJoinsTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests FromSubquery_ShouldReturnFilteredRows behavior.
+    /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
+    /// </summary>
     [Fact]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
@@ -32,6 +36,10 @@ public sealed class SubqueryFromAndJoinsTests(
         ids.Should().Equal(1, 3);
     }
 
+    /// <summary>
+    /// EN: Tests JoinSubquery_ShouldJoinCorrectly behavior.
+    /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
+    /// </summary>
     [Fact]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
@@ -72,6 +80,10 @@ ORDER BY u.Id, o.Amount";
         rows.Should().Equal([(1, 60m), (2, 80m)]);
     }
 
+    /// <summary>
+    /// EN: Tests NestedSubquery_ShouldWork behavior.
+    /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
+    /// </summary>
     [Fact]
     public void NestedSubquery_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/TemporaryTable/PostgreSqlTemporaryTableEngineTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/TemporaryTable/PostgreSqlTemporaryTableEngineTests.cs
@@ -4,6 +4,10 @@ public sealed class PostgreSqlTemporaryTableEngineTests
 {
     private static readonly int[] expected = [1, 2];
 
+    /// <summary>
+    /// EN: Tests CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows behavior.
+    /// PT: Testa o comportamento de CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows.
+    /// </summary>
     [Fact]
     public void CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/TemporaryTable/PostgreSqlTemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/TemporaryTable/PostgreSqlTemporaryTableParserTests.cs
@@ -2,6 +2,10 @@ namespace DbSqlLikeMem.Npgsql.Test.TemporaryTable;
 
 public sealed class PostgreSqlTemporaryTableParserTests
 {
+    /// <summary>
+    /// EN: Tests ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect behavior.
+    /// PT: Testa o comportamento de ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect(int version)
@@ -49,6 +53,10 @@ WHERE tenantid = 10",
         };
     }
 
+    /// <summary>
+    /// EN: Tests Parse_ShouldAccept_CreateTemporaryTable_Variants behavior.
+    /// PT: Testa o comportamento de Parse_ShouldAccept_CreateTemporaryTable_Variants.
+    /// </summary>
     [Theory]
     [MemberDataByNpgsqlVersion(nameof(CreateTempTableStatements))]
     public void Parse_ShouldAccept_CreateTemporaryTable_Variants(string sql, int version)

--- a/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewEngineTests.cs
@@ -28,6 +28,10 @@ public sealed class PostgreSqlCreateViewEngineTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests CreateView_ThenSelectFromView_ShouldReturnExpectedRows behavior.
+    /// PT: Testa o comportamento de CreateView_ThenSelectFromView_ShouldReturnExpectedRows.
+    /// </summary>
     [Fact]
     public void CreateView_ThenSelectFromView_ShouldReturnExpectedRows()
     {
@@ -41,6 +45,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal(["John", "Bob" ], rows.Select(r => (string)r["name"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_IsNotMaterialized_ShouldReflectBaseTableChanges behavior.
+    /// PT: Testa o comportamento de View_IsNotMaterialized_ShouldReflectBaseTableChanges.
+    /// </summary>
     [Fact]
     public void View_IsNotMaterialized_ShouldReflectBaseTableChanges()
     {
@@ -53,6 +61,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([1, 2, 3, 4], rows.Select(r => (int)r["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests CreateOrReplaceView_ShouldChangeDefinition behavior.
+    /// PT: Testa o comportamento de CreateOrReplaceView_ShouldChangeDefinition.
+    /// </summary>
     [Fact]
     public void CreateOrReplaceView_ShouldChangeDefinition()
     {
@@ -65,6 +77,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([3], r2.Select(x => (int)x["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_NameShouldShadowTable_WhenSameName behavior.
+    /// PT: Testa o comportamento de View_NameShouldShadowTable_WhenSameName.
+    /// </summary>
     [Fact]
     public void View_NameShouldShadowTable_WhenSameName()
     {
@@ -82,6 +98,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal(1, (int)rows[0]["id"]!);
     }
 
+    /// <summary>
+    /// EN: Tests View_CanReferenceAnotherView behavior.
+    /// PT: Testa o comportamento de View_CanReferenceAnotherView.
+    /// </summary>
     [Fact]
     public void View_CanReferenceAnotherView()
     {
@@ -92,6 +112,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([2], rows.Select(r => (int)r["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_WithJoinAndAggregation_ShouldWork behavior.
+    /// PT: Testa o comportamento de View_WithJoinAndAggregation_ShouldWork.
+    /// </summary>
     [Fact]
     public void View_WithJoinAndAggregation_ShouldWork()
     {
@@ -112,6 +136,10 @@ GROUP BY u.id;
         Assert.True(rows[2]["total"] is null);
     }
 
+    /// <summary>
+    /// EN: Tests CreateView_ExistingNameWithoutOrReplace_ShouldThrow behavior.
+    /// PT: Testa o comportamento de CreateView_ExistingNameWithoutOrReplace_ShouldThrow.
+    /// </summary>
     [Fact]
     public void CreateView_ExistingNameWithoutOrReplace_ShouldThrow()
     {
@@ -119,6 +147,10 @@ GROUP BY u.id;
         Assert.ThrowsAny<Exception>(() => _cnn.ExecNonQuery("CREATE VIEW vdup AS SELECT 2 AS x ;"));
     }
 
+    /// <summary>
+    /// EN: Tests DropView_ShouldRemoveDefinition behavior.
+    /// PT: Testa o comportamento de DropView_ShouldRemoveDefinition.
+    /// </summary>
     [Fact(Skip = "MySQL: DROP VIEW faz parte do ciclo de vida. Implementar depois.")]
     public void DropView_ShouldRemoveDefinition()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewParserTests.cs
@@ -4,6 +4,10 @@ public sealed class PostgreSqlCreateViewParserTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements behavior.
+    /// PT: Testa o comportamento de ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements(int version)
@@ -27,6 +31,10 @@ SELECT * FROM v_users;
         Assert.Contains("users", cv.Select.Table?.Name, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateOrReplaceView_ShouldSetFlag behavior.
+    /// PT: Testa o comportamento de Parse_CreateOrReplaceView_ShouldSetFlag.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Parse_CreateOrReplaceView_ShouldSetFlag(int version)
@@ -38,6 +46,10 @@ SELECT * FROM v_users;
         Assert.Equal("v", cv.Table?.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames(int version)
@@ -48,6 +60,10 @@ SELECT * FROM v_users;
         Assert.Equal(["a", "b"], cv.ColumnNames);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_WithBackticks_ShouldWork behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_WithBackticks_ShouldWork.
+    /// </summary>
     [Theory]
     [MemberDataNpgsqlVersion]
     public void Parse_CreateView_WithBackticks_ShouldWork(int version)
@@ -58,6 +74,10 @@ SELECT * FROM v_users;
         Assert.Equal("v", cv.Table?.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec.
+    /// </summary>
     [Theory(Skip = "MySQL não suporta IF NOT EXISTS em CREATE VIEW. O mock aceita por conveniência; habilite se quiser comportamento estrito.")]
     [MemberDataNpgsqlVersion]
     public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec(int version)

--- a/src/DbSqlLikeMem.Oracle.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/CsvLoaderAndIndexTests.cs
@@ -4,6 +4,10 @@ public sealed class CsvLoaderAndIndexTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests CsvLoader_ShouldLoadRows_ByColumnName behavior.
+    /// PT: Testa o comportamento de CsvLoader_ShouldLoadRows_ByColumnName.
+    /// </summary>
     [Fact]
     public void CsvLoader_ShouldLoadRows_ByColumnName()
     {
@@ -26,6 +30,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal("John", cnn.Db.GetTable("users")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests GetColumn_ShouldThrow_UnknownColumn behavior.
+    /// PT: Testa o comportamento de GetColumn_ShouldThrow_UnknownColumn.
+    /// </summary>
     [Fact]
     public void GetColumn_ShouldThrow_UnknownColumn()
     {
@@ -37,6 +45,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal(1054, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests Index_Lookup_ShouldReturnRowPositions behavior.
+    /// PT: Testa o comportamento de Index_Lookup_ShouldReturnRowPositions.
+    /// </summary>
     [Fact]
     public void Index_Lookup_ShouldReturnRowPositions()
     {
@@ -56,6 +68,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal([0, 1], [.. ix!.Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests BackupRestore_ShouldRollbackData behavior.
+    /// PT: Testa o comportamento de BackupRestore_ShouldRollbackData.
+    /// </summary>
     [Fact]
     public void BackupRestore_ShouldRollbackData()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/DapperTests.cs
@@ -21,6 +21,10 @@ public sealed class DapperTests : XUnitTestBase
         _connection.Open();
     }
 
+    /// <summary>
+    /// EN: Tests TestSelectQuery behavior.
+    /// PT: Testa o comportamento de TestSelectQuery.
+    /// </summary>
     [Fact]
     public void TestSelectQuery()
     {
@@ -28,6 +32,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.NotNull(users);
     }
 
+    /// <summary>
+    /// EN: Tests QueryShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryShouldReturnCorrectData()
     {
@@ -61,6 +69,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.Equal(dt, result.First().CreatedDate);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldInsertData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldInsertData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldInsertData()
     {
@@ -87,6 +99,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.Equal(dt, table[0][2]);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldUpdateData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldUpdateData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldUpdateData()
     {
@@ -126,6 +142,10 @@ UPDATE users
         Assert.Equal(dtUpdate, table[0][3]);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldDeleteData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldDeleteData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldDeleteData()
     {
@@ -148,6 +168,10 @@ UPDATE users
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleResultSets()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/DapperUserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/DapperUserTests.cs
@@ -14,6 +14,10 @@ public sealed class DapperUserTests(
         public Guid? TestGuidNull { get; set; }
     }
 
+    /// <summary>
+    /// EN: Tests InsertUserShouldAddUserToTable behavior.
+    /// PT: Testa o comportamento de InsertUserShouldAddUserToTable.
+    /// </summary>
     [Fact]
     public void InsertUserShouldAddUserToTable()
     {
@@ -58,6 +62,10 @@ public sealed class DapperUserTests(
         Assert.Equal(user.TestGuidNull, insertedRow[6]);
     }
 
+    /// <summary>
+    /// EN: Tests QueryUserShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryUserShouldReturnCorrectData()
     {
@@ -110,6 +118,10 @@ public sealed class DapperUserTests(
         Assert.Equal(user.TestGuidNull, result.TestGuidNull);
     }
 
+    /// <summary>
+    /// EN: Tests UpdateUserShouldModifyUserInTable behavior.
+    /// PT: Testa o comportamento de UpdateUserShouldModifyUserInTable.
+    /// </summary>
     [Fact]
     public void UpdateUserShouldModifyUserInTable()
     {
@@ -176,6 +188,10 @@ public sealed class DapperUserTests(
         Assert.Equal(updatedUser.TestGuidNull, updatedRow[6]);
     }
 
+    /// <summary>
+    /// EN: Tests DeleteUserShouldRemoveUserFromTable behavior.
+    /// PT: Testa o comportamento de DeleteUserShouldRemoveUserFromTable.
+    /// </summary>
     [Fact]
     public void DeleteUserShouldRemoveUserFromTable()
     {
@@ -223,6 +239,10 @@ public sealed class DapperUserTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleUserResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/DapperUserTests2.cs
@@ -16,6 +16,10 @@ public sealed class DapperUserTests2(
         public List<int> Tenants { get; set; } = [];
     }
 
+    /// <summary>
+    /// EN: Tests QueryUserShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryUserShouldReturnCorrectData()
     {
@@ -68,6 +72,10 @@ public sealed class DapperUserTests2(
         Assert.Equal(user.TestGuidNull, result.TestGuidNull);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleUserResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
@@ -127,6 +135,10 @@ public sealed class DapperUserTests2(
         Assert.Equal("jane.doe@example.com", users2[0].Email);
     }
 
+    /// <summary>
+    /// EN: Tests QueryWithJoinShouldReturnJoinedData behavior.
+    /// PT: Testa o comportamento de QueryWithJoinShouldReturnJoinedData.
+    /// </summary>
     [Fact]
     public void QueryWithJoinShouldReturnJoinedData()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/ExistsTests.cs
@@ -4,6 +4,10 @@ public sealed class ExistsTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Exists_ShouldFilterUsersWithOrders behavior.
+    /// PT: Testa o comportamento de Exists_ShouldFilterUsersWithOrders.
+    /// </summary>
     [Fact]
     public void Exists_ShouldFilterUsersWithOrders()
     {
@@ -43,6 +47,10 @@ ORDER BY u.Id";
         ids.Should().Equal(1, 3);
     }
 
+    /// <summary>
+    /// EN: Tests NotExists_ShouldFilterUsersWithoutOrders behavior.
+    /// PT: Testa o comportamento de NotExists_ShouldFilterUsersWithoutOrders.
+    /// </summary>
     [Fact]
     public void NotExists_ShouldFilterUsersWithoutOrders()
     {
@@ -81,6 +89,10 @@ ORDER BY u.Id";
         ids.Should().Equal(2);
     }
 
+    /// <summary>
+    /// EN: Tests Exists_WithExtraPredicate_ShouldWork behavior.
+    /// PT: Testa o comportamento de Exists_WithExtraPredicate_ShouldWork.
+    /// </summary>
     [Fact]
     public void Exists_WithExtraPredicate_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/ExtendedOracleMockTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/ExtendedOracleMockTests.cs
@@ -4,6 +4,10 @@ public sealed class ExtendedMySqlMockTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests InsertAutoIncrementShouldAssignIdentityWhenNotSpecified behavior.
+    /// PT: Testa o comportamento de InsertAutoIncrementShouldAssignIdentityWhenNotSpecified.
+    /// </summary>
     [Fact]
     public void InsertAutoIncrementShouldAssignIdentityWhenNotSpecified()
     {
@@ -26,6 +30,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal("Bob", table[1][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertNullIntoNullableColumnShouldSucceed behavior.
+    /// PT: Testa o comportamento de InsertNullIntoNullableColumnShouldSucceed.
+    /// </summary>
     [Fact]
     public void InsertNullIntoNullableColumnShouldSucceed()
     {
@@ -41,6 +49,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Null(table[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertNullIntoNonNullableColumnShouldThrow behavior.
+    /// PT: Testa o comportamento de InsertNullIntoNonNullableColumnShouldThrow.
+    /// </summary>
     [Fact]
     public void InsertNullIntoNonNullableColumnShouldThrow()
     {
@@ -57,6 +69,10 @@ public sealed class ExtendedMySqlMockTests(
 
     private static readonly string[] item = ["first", "second"];
 
+    /// <summary>
+    /// EN: Tests CompositeIndexFilterShouldReturnCorrectRows behavior.
+    /// PT: Testa o comportamento de CompositeIndexFilterShouldReturnCorrectRows.
+    /// </summary>
     [Fact]
     public void CompositeIndexFilterShouldReturnCorrectRows()
     {
@@ -78,6 +94,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(1, (int)result[0].value);
     }
 
+    /// <summary>
+    /// EN: Tests LikeFilterShouldReturnMatchingRows behavior.
+    /// PT: Testa o comportamento de LikeFilterShouldReturnMatchingRows.
+    /// </summary>
     [Fact]
     public void LikeFilterShouldReturnMatchingRows()
     {
@@ -94,6 +114,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal("alice", res[0].name);
     }
 
+    /// <summary>
+    /// EN: Tests InFilterShouldReturnMatchingRows behavior.
+    /// PT: Testa o comportamento de InFilterShouldReturnMatchingRows.
+    /// </summary>
     [Fact]
     public void InFilterShouldReturnMatchingRows()
     {
@@ -111,6 +135,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal([1, 3], ids);
     }
 
+    /// <summary>
+    /// EN: Tests OrderByLimitOffsetDistinctShouldReturnExpectedRows behavior.
+    /// PT: Testa o comportamento de OrderByLimitOffsetDistinctShouldReturnExpectedRows.
+    /// </summary>
     [Fact]
     public void OrderByLimitOffsetDistinctShouldReturnExpectedRows()
     {
@@ -128,6 +156,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(1, (int)res[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests HavingFilterShouldApplyAfterAggregation behavior.
+    /// PT: Testa o comportamento de HavingFilterShouldApplyAfterAggregation.
+    /// </summary>
     [Fact]
     public void HavingFilterShouldApplyAfterAggregation()
     {
@@ -148,6 +180,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(2L, result[0].C);
     }
 
+    /// <summary>
+    /// EN: Tests ForeignKeyDeleteShouldThrowOnReferencedParentDeletion behavior.
+    /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletion.
+    /// </summary>
     [Fact]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletion()
     {
@@ -171,6 +207,10 @@ public sealed class ExtendedMySqlMockTests(
             cnn.Execute("DELETE FROM parent WHERE id = 1"));
     }
 
+    /// <summary>
+    /// EN: Tests ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK behavior.
+    /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK.
+    /// </summary>
     [Fact]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK()
     {
@@ -193,6 +233,10 @@ public sealed class ExtendedMySqlMockTests(
             cnn.Execute("DELETE FROM parent WHERE id = 1"));
     }
 
+    /// <summary>
+    /// EN: Tests MultipleParameterSetsInsertShouldInsertAllRows behavior.
+    /// PT: Testa o comportamento de MultipleParameterSetsInsertShouldInsertAllRows.
+    /// </summary>
     [Fact]
     public void MultipleParameterSetsInsertShouldInsertAllRows()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/FluentTest.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/FluentTest.cs
@@ -22,6 +22,10 @@ public sealed class FluentTest(
         return cnn;
     }
 
+    /// <summary>
+    /// EN: Tests InsertUpdateDeleteFluentScenario behavior.
+    /// PT: Testa o comportamento de InsertUpdateDeleteFluentScenario.
+    /// </summary>
     [Fact]
     public void InsertUpdateDeleteFluentScenario()
     {
@@ -61,6 +65,10 @@ public sealed class FluentTest(
         Assert.True(cnn.Metrics.Elapsed > TimeSpan.Zero);
     }
 
+    /// <summary>
+    /// EN: Tests TestFluent behavior.
+    /// PT: Testa o comportamento de TestFluent.
+    /// </summary>
     [Fact]
     public void TestFluent()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAdditionalBehaviorCoverageTests.cs
@@ -36,6 +36,10 @@ public sealed class OracleAdditionalBehaviorCoverageTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_IsNull_And_IsNotNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_IsNull_And_IsNotNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_IsNull_And_IsNotNull_ShouldWork()
     {
@@ -46,6 +50,10 @@ public sealed class OracleAdditionalBehaviorCoverageTests : XUnitTestBase
         Assert.Equal([1, 3], notNullIds);
     }
 
+    /// <summary>
+    /// EN: Tests Where_EqualNull_ShouldReturnNoRows behavior.
+    /// PT: Testa o comportamento de Where_EqualNull_ShouldReturnNoRows.
+    /// </summary>
     [Fact]
     public void Where_EqualNull_ShouldReturnNoRows()
     {
@@ -57,6 +65,10 @@ public sealed class OracleAdditionalBehaviorCoverageTests : XUnitTestBase
         Assert.Empty(ids);
     }
 
+    /// <summary>
+    /// EN: Tests LeftJoin_ShouldPreserveLeftRows_WhenNoMatch behavior.
+    /// PT: Testa o comportamento de LeftJoin_ShouldPreserveLeftRows_WhenNoMatch.
+    /// </summary>
     [Fact]
     public void LeftJoin_ShouldPreserveLeftRows_WhenNoMatch()
     {
@@ -79,6 +91,10 @@ ORDER BY u.id
         Assert.Null((object?)rows[2].amount);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_Desc_ThenAsc_ShouldBeDeterministic behavior.
+    /// PT: Testa o comportamento de OrderBy_Desc_ThenAsc_ShouldBeDeterministic.
+    /// </summary>
     [Fact]
     public void OrderBy_Desc_ThenAsc_ShouldBeDeterministic()
     {
@@ -92,6 +108,10 @@ ORDER BY amount DESC, id ASC
         Assert.Equal([200m, 50m, 10m], [.. rows.Select(r => (decimal)r.amount)]);
     }
 
+    /// <summary>
+    /// EN: Tests Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls behavior.
+    /// PT: Testa o comportamento de Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls.
+    /// </summary>
     [Fact]
     public void Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls()
     {
@@ -101,6 +121,10 @@ ORDER BY amount DESC, id ASC
         Assert.Equal(2L, (long)r.c2);
     }
 
+    /// <summary>
+    /// EN: Tests Having_ShouldFilterGroups behavior.
+    /// PT: Testa o comportamento de Having_ShouldFilterGroups.
+    /// </summary>
     [Fact]
     public void Having_ShouldFilterGroups()
     {
@@ -115,6 +139,10 @@ ORDER BY userid
         Assert.Equal([2], userIds);
     }
 
+    /// <summary>
+    /// EN: Tests Where_In_WithParameterList_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_In_WithParameterList_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_In_WithParameterList_ShouldWork()
     {
@@ -122,6 +150,10 @@ ORDER BY userid
         Assert.Equal([1, 3], ids);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_WithColumnsOutOfOrder_ShouldMapCorrectly behavior.
+    /// PT: Testa o comportamento de Insert_WithColumnsOutOfOrder_ShouldMapCorrectly.
+    /// </summary>
     [Fact]
     public void Insert_WithColumnsOutOfOrder_ShouldMapCorrectly()
     {
@@ -133,6 +165,10 @@ ORDER BY userid
         Assert.Equal("zed@x.com", (string)row.email);
     }
 
+    /// <summary>
+    /// EN: Tests Delete_WithInParameterList_ShouldDeleteMatchingRows behavior.
+    /// PT: Testa o comportamento de Delete_WithInParameterList_ShouldDeleteMatchingRows.
+    /// </summary>
     [Fact]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
@@ -143,6 +179,10 @@ ORDER BY userid
         Assert.Equal([2], remaining);
     }
 
+    /// <summary>
+    /// EN: Tests Update_SetExpression_ShouldUpdateRows behavior.
+    /// PT: Testa o comportamento de Update_SetExpression_ShouldUpdateRows.
+    /// </summary>
     [Fact]
     public void Update_SetExpression_ShouldUpdateRows()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAdvancedSqlGapTests.cs
@@ -35,6 +35,10 @@ public sealed class OracleAdvancedSqlGapTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Window_RowNumber_PartitionBy_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
+    /// </summary>
     [Fact]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
@@ -47,6 +51,10 @@ ORDER BY tenantid, id").ToList();
         Assert.Equal([1, 2, 1], [.. rows.Select(r => (int)r.rn)]);
     }
 
+    /// <summary>
+    /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
+    /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
+    /// </summary>
     [Fact]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
@@ -59,6 +67,10 @@ ORDER BY u.id").ToList();
         Assert.Equal([15m, 7m, 0m], [.. rows.Select(r => (decimal)(r.total ?? 0m))]);
     }
 
+    /// <summary>
+    /// EN: Tests DateAdd_IntervalDay_ShouldWork behavior.
+    /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
+    /// </summary>
     [Fact]
     public void DateAdd_IntervalDay_ShouldWork()
     {
@@ -74,6 +86,10 @@ ORDER BY id").ToList();
             [.. rows.Select(r => (DateTime)r.d)]);
     }
 
+    /// <summary>
+    /// EN: Tests Cast_StringToInt_ShouldWork behavior.
+    /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
+    /// </summary>
     [Fact]
     public void Cast_StringToInt_ShouldWork()
     {
@@ -82,6 +98,10 @@ ORDER BY id").ToList();
         Assert.Equal(42, (int)rows[0].v);
     }
 
+    /// <summary>
+    /// EN: Tests Regexp_Operator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
+    /// </summary>
     [Fact]
     public void Regexp_Operator_ShouldWork()
     {
@@ -89,6 +109,10 @@ ORDER BY id").ToList();
         Assert.Equal([1, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_Field_Function_ShouldWork behavior.
+    /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
+    /// </summary>
     [Fact]
     public void OrderBy_Field_Function_ShouldWork()
     {
@@ -96,6 +120,10 @@ ORDER BY id").ToList();
         Assert.Equal([3, 1, 2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Collation_CaseSensitivity_ShouldFollowColumnCollation behavior.
+    /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
+    /// </summary>
     [Fact]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAggregationTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAggregationTests.cs
@@ -20,6 +20,10 @@ public sealed class OracleAggregationTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
+    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
+    /// </summary>
     [Fact]
     public void GroupBy_WithCountAndSum_ShouldWork()
     {
@@ -42,6 +46,10 @@ public sealed class OracleAggregationTests : XUnitTestBase
         Assert.Equal(5m, (decimal)rows[1].sumAmount);
     }
 
+    /// <summary>
+    /// EN: Tests Having_ShouldFilterAggregates behavior.
+    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
+    /// </summary>
     [Fact]
     public void Having_ShouldFilterAggregates()
     {
@@ -57,6 +65,10 @@ public sealed class OracleAggregationTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].userId);
     }
 
+    /// <summary>
+    /// EN: Tests Distinct_Order_Limit_Offset_ShouldWork behavior.
+    /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
+    /// </summary>
     [Fact]
     public void Distinct_Order_Limit_Offset_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleDataParameterCollectionMockTest.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleDataParameterCollectionMockTest.cs
@@ -3,6 +3,10 @@ public sealed class OracleDataParameterCollectionMockTest(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames behavior.
+    /// PT: Testa o comportamento de ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames.
+    /// </summary>
     [Fact]
     public void ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames()
     {
@@ -13,6 +17,10 @@ public sealed class OracleDataParameterCollectionMockTest(
         Assert.Equal("id", OracleDataParameterCollectionMock.NormalizeParameterName("@'id'"));
     }
 
+    /// <summary>
+    /// EN: Tests ParameterCollection_Add_DuplicateName_ShouldThrow behavior.
+    /// PT: Testa o comportamento de ParameterCollection_Add_DuplicateName_ShouldThrow.
+    /// </summary>
     [Fact]
     public void ParameterCollection_Add_DuplicateName_ShouldThrow()
     {
@@ -22,6 +30,10 @@ public sealed class OracleDataParameterCollectionMockTest(
         Assert.Throws<ArgumentException>(() => pars.AddWithValue("@id", 2)); // case-insensitive
     }
 
+    /// <summary>
+    /// EN: Tests ParameterCollection_RemoveAt_ShouldReindexDictionary behavior.
+    /// PT: Testa o comportamento de ParameterCollection_RemoveAt_ShouldReindexDictionary.
+    /// </summary>
     [Fact]
     public void ParameterCollection_RemoveAt_ShouldReindexDictionary()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleJoinTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleJoinTests.cs
@@ -28,6 +28,10 @@ public sealed class OracleJoinTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests LeftJoin_ShouldKeepAllLeftRows behavior.
+    /// PT: Testa o comportamento de LeftJoin_ShouldKeepAllLeftRows.
+    /// </summary>
     [Fact]
     public void LeftJoin_ShouldKeepAllLeftRows()
     {
@@ -44,6 +48,10 @@ public sealed class OracleJoinTests : XUnitTestBase
         Assert.Contains(rows, r => (int)r.id == 2);
     }
 
+    /// <summary>
+    /// EN: Tests RightJoin_ShouldKeepAllRightRows behavior.
+    /// PT: Testa o comportamento de RightJoin_ShouldKeepAllRightRows.
+    /// </summary>
     [Fact]
     public void RightJoin_ShouldKeepAllRightRows()
     {
@@ -74,6 +82,10 @@ public sealed class OracleJoinTests : XUnitTestBase
     //    Assert.Contains(rows, r => r.id is null && (int)r.orderId == 12); // órfão
     //}
 
+    /// <summary>
+    /// EN: Tests Join_ON_WithMultipleConditions_AND_ShouldWork behavior.
+    /// PT: Testa o comportamento de Join_ON_WithMultipleConditions_AND_ShouldWork.
+    /// </summary>
     [Fact]
     public void Join_ON_WithMultipleConditions_AND_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleLinqProviderTest.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleLinqProviderTest.cs
@@ -9,6 +9,10 @@ public sealed class OracleLinqProviderTest
     }
 #pragma warning restore CA1812
 
+    /// <summary>
+    /// EN: Tests LinqProvider_ShouldQueryWhereAndReturnRows behavior.
+    /// PT: Testa o comportamento de LinqProvider_ShouldQueryWhereAndReturnRows.
+    /// </summary>
     [Fact]
     public void LinqProvider_ShouldQueryWhereAndReturnRows()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleMockTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleMockTests.cs
@@ -25,6 +25,10 @@ public sealed class OracleMockTests
         _connection.Open();
     }
 
+    /// <summary>
+    /// EN: Tests TestInsert behavior.
+    /// PT: Testa o comportamento de TestInsert.
+    /// </summary>
     [Fact]
     public void TestInsert()
     {
@@ -37,6 +41,10 @@ public sealed class OracleMockTests
         Assert.Equal("John Doe",_connection.GetTable("user")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TestUpdate behavior.
+    /// PT: Testa o comportamento de TestUpdate.
+    /// </summary>
     [Fact]
     public void TestUpdate()
     {
@@ -52,6 +60,10 @@ public sealed class OracleMockTests
         Assert.Equal("Jane Doe",_connection.GetTable("user")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TestDelete behavior.
+    /// PT: Testa o comportamento de TestDelete.
+    /// </summary>
     [Fact]
     public void TestDelete()
     {
@@ -67,6 +79,10 @@ public sealed class OracleMockTests
         Assert.Empty(_connection.GetTable("user"));
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionCommit behavior.
+    /// PT: Testa o comportamento de TestTransactionCommit.
+    /// </summary>
     [Fact]
     public void TestTransactionCommit()
     {
@@ -98,6 +114,10 @@ public sealed class OracleMockTests
         Assert.Single(users);
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionCommitInsertUpdate behavior.
+    /// PT: Testa o comportamento de TestTransactionCommitInsertUpdate.
+    /// </summary>
     [Fact]
     public void TestTransactionCommitInsertUpdate()
     {
@@ -116,6 +136,10 @@ public sealed class OracleMockTests
         Assert.Equal("Bob", name);
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionRollback behavior.
+    /// PT: Testa o comportamento de TestTransactionRollback.
+    /// </summary>
     [Fact]
     public void TestTransactionRollback()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleSelectAndWhereMoreCoverageTests.cs
@@ -30,6 +30,10 @@ public sealed class OracleSelectAndWhereMoreCoverageTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_Between_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Between_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Between_ShouldWork()
     {
@@ -37,6 +41,10 @@ public sealed class OracleSelectAndWhereMoreCoverageTests : XUnitTestBase
         Assert.Equal([2, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_NotIn_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_NotIn_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_NotIn_ShouldWork()
     {
@@ -45,6 +53,10 @@ public sealed class OracleSelectAndWhereMoreCoverageTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Where_ExistsSubquery_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_ExistsSubquery_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_ExistsSubquery_ShouldWork()
     {
@@ -62,6 +74,10 @@ ORDER BY u.id").ToList();
         Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_CaseWhen_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_CaseWhen_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_CaseWhen_ShouldWork()
     {
@@ -77,6 +93,10 @@ ORDER BY id").ToList();
         Assert.Equal("Y", (string)rows[2].hasEmail);
     }
 
+    /// <summary>
+    /// EN: Tests Select_IfNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_IfNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_IfNull_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleSqlCompatibilityGapTests.cs
@@ -36,6 +36,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_Precedence_AND_ShouldBindStrongerThan_OR behavior.
+    /// PT: Testa o comportamento de Where_Precedence_AND_ShouldBindStrongerThan_OR.
+    /// </summary>
     [Fact]
     public void Where_Precedence_AND_ShouldBindStrongerThan_OR()
     {
@@ -45,6 +49,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_OR_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_OR_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_OR_ShouldWork()
     {
@@ -52,6 +60,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 3], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_ParenthesesGrouping_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_ParenthesesGrouping_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_ParenthesesGrouping_ShouldWork()
     {
@@ -61,6 +73,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_Arithmetic_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_Arithmetic_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_Arithmetic_ShouldWork()
     {
@@ -68,6 +84,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([2, 3, 4], [.. rows.Select(r => (int)r.nextId)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_CASE_WHEN_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_CASE_WHEN_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_CASE_WHEN_ShouldWork()
     {
@@ -75,6 +95,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 0, 1], [.. rows.Select(r => (int)r.hasEmail)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_IF_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_IF_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_IF_ShouldWork()
     {
@@ -83,6 +107,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["yes", "no", "yes"], [.. rows.Select(r => (string)r.flag)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_IIF_ShouldWork_AsAliasForIF behavior.
+    /// PT: Testa o comportamento de Select_Expressions_IIF_ShouldWork_AsAliasForIF.
+    /// </summary>
     [Fact]
     public void Select_Expressions_IIF_ShouldWork_AsAliasForIF()
     {
@@ -91,6 +119,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 0, 1], [.. rows.Select(r => (int)r.hasEmail)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_COALESCE_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_COALESCE_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_COALESCE_ShouldWork()
     {
@@ -98,6 +130,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["john@x.com", "none", "jane@x.com"], [.. rows.Select(r => (string)r.em)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_IFNULL_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_IFNULL_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_IFNULL_ShouldWork()
     {
@@ -105,6 +141,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["john@x.com", "none", "jane@x.com"], [.. rows.Select(r => (string)r.em)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_CONCAT_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_CONCAT_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_CONCAT_ShouldWork()
     {
@@ -112,6 +152,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["John#1", "Bob#2", "Jane#3"], [.. rows.Select(r => (string)r.tag)]);
     }
 
+    /// <summary>
+    /// EN: Tests Distinct_ShouldBeConsistent behavior.
+    /// PT: Testa o comportamento de Distinct_ShouldBeConsistent.
+    /// </summary>
     [Fact]
     public void Distinct_ShouldBeConsistent()
     {
@@ -121,6 +165,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["Bob", "Jane", "John"], [.. rows.Select(r => (string)r.name)]);
     }
 
+    /// <summary>
+    /// EN: Tests Join_ComplexOn_WithOr_ShouldWork behavior.
+    /// PT: Testa o comportamento de Join_ComplexOn_WithOr_ShouldWork.
+    /// </summary>
     [Fact]
     public void Join_ComplexOn_WithOr_ShouldWork()
     {
@@ -137,6 +185,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
             [.. rows.Select(r => ((int)r.uid,(int)r.oid))]);
     }
 
+    /// <summary>
+    /// EN: Tests GroupBy_Having_ShouldSupportAggregates behavior.
+    /// PT: Testa o comportamento de GroupBy_Having_ShouldSupportAggregates.
+    /// </summary>
     [Fact]
     public void GroupBy_Having_ShouldSupportAggregates()
     {
@@ -150,6 +202,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(210m, (decimal)rows[0].total);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_ShouldSupportAlias_And_Ordinal behavior.
+    /// PT: Testa o comportamento de OrderBy_ShouldSupportAlias_And_Ordinal.
+    /// </summary>
     [Fact]
     public void OrderBy_ShouldSupportAlias_And_Ordinal()
     {
@@ -161,6 +217,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([(2,"Bob"),(3,"Jane"),(1,"John")], [.. rows2.Select(r => ((int)r.id,(string)r.name))]);
     }
 
+    /// <summary>
+    /// EN: Tests Union_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_ShouldWork.
+    /// </summary>
     [Fact]
     public void Union_ShouldWork()
     {
@@ -172,6 +232,10 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1,2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Union_Inside_SubSelect_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
+    /// </summary>
     [Fact]
     public void Union_Inside_SubSelect_ShouldWork()
     {
@@ -186,6 +250,10 @@ ORDER BY id
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Cte_With_ShouldWork behavior.
+    /// PT: Testa o comportamento de Cte_With_ShouldWork.
+    /// </summary>
     [Fact]
     public void Cte_With_ShouldWork()
     {
@@ -195,6 +263,10 @@ ORDER BY id
         Assert.Equal([2,1], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault behavior.
+    /// PT: Testa o comportamento de Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault.
+    /// </summary>
     [Fact]
     public void Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleTransactionTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleTransactionTests.cs
@@ -10,6 +10,10 @@ public sealed class OracleTransactionTests(
         public string? Email { get; set; }
     }
 
+    /// <summary>
+    /// EN: Tests TransactionCommitShouldPersistData behavior.
+    /// PT: Testa o comportamento de TransactionCommitShouldPersistData.
+    /// </summary>
     [Fact]
     public void TransactionCommitShouldPersistData()
     {
@@ -38,6 +42,10 @@ public sealed class OracleTransactionTests(
         Assert.Equal(user.Email, insertedRow[2]);
     }
 
+    /// <summary>
+    /// EN: Tests TransactionRollbackShouldNotPersistData behavior.
+    /// PT: Testa o comportamento de TransactionRollbackShouldNotPersistData.
+    /// </summary>
     [Fact]
     public void TransactionRollbackShouldNotPersistData()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs
@@ -22,6 +22,10 @@ public sealed class OracleUnionLimitAndJsonCompatibilityTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates behavior.
+    /// PT: Testa o comportamento de UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates.
+    /// </summary>
     [Fact]
     public void UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates()
     {
@@ -42,6 +46,10 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([1], [.. distinct.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests OffsetFetch_ShouldWork behavior.
+    /// PT: Testa o comportamento de OffsetFetch_ShouldWork.
+    /// </summary>
     [Fact]
     public void OffsetFetch_ShouldWork()
     {
@@ -50,6 +58,10 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([2, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests JsonValue_SimpleObjectPath_ShouldWork behavior.
+    /// PT: Testa o comportamento de JsonValue_SimpleObjectPath_ShouldWork.
+    /// </summary>
     [Fact]
     public void JsonValue_SimpleObjectPath_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleWhereParserAndExecutorTests.cs
@@ -21,6 +21,10 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_IN_ShouldFilter behavior.
+    /// PT: Testa o comportamento de Where_IN_ShouldFilter.
+    /// </summary>
     [Fact]
     public void Where_IN_ShouldFilter()
     {
@@ -30,6 +34,10 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
         Assert.Contains(rows, r => (int)r.id == 3);
     }
 
+    /// <summary>
+    /// EN: Tests Where_IsNotNull_ShouldFilter behavior.
+    /// PT: Testa o comportamento de Where_IsNotNull_ShouldFilter.
+    /// </summary>
     [Fact]
     public void Where_IsNotNull_ShouldFilter()
     {
@@ -37,6 +45,10 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(2, rows.Count);
     }
 
+    /// <summary>
+    /// EN: Tests Where_Operators_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Operators_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Operators_ShouldWork()
     {
@@ -47,6 +59,10 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal([1, 3], [.. rows2.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_Like_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Like_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Like_ShouldWork()
     {
@@ -55,6 +71,10 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Where_FindInSet_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_FindInSet_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_FindInSet_ShouldWork()
     {
@@ -63,6 +83,10 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_AND_ShouldBeCaseInsensitive_InRealLife behavior.
+    /// PT: Testa o comportamento de Where_AND_ShouldBeCaseInsensitive_InRealLife.
+    /// </summary>
     [Fact]
     public void Where_AND_ShouldBeCaseInsensitive_InRealLife()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/SqlExprPrinterTest.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/SqlExprPrinterTest.cs
@@ -3,6 +3,10 @@ public sealed class SqlExprPrinterTest(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse behavior.
+    /// PT: Testa o comportamento de ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse.
+    /// </summary>
     [Theory]
     [MemberDataByOracleVersion(nameof(Expressions))]
     public void ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse(string expr, int version)

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/SqlExpressionParserTests.cs
@@ -7,6 +7,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Smoke tests: todas as expressões reais encontradas no zip (suportadas) -----------
 
+    /// <summary>
+    /// EN: Tests ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions behavior.
+    /// PT: Testa o comportamento de ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions.
+    /// </summary>
     [Theory]
     [MemberDataByOracleVersion(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
@@ -74,6 +78,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Negative tests: coisas que aparecem nos testes atuais mas NÃO fazem parte do subset -----------
 
+    /// <summary>
+    /// EN: Tests ParseWhere_ShouldThrow_ForUnsupportedExpressions behavior.
+    /// PT: Testa o comportamento de ParseWhere_ShouldThrow_ForUnsupportedExpressions.
+    /// </summary>
     [Theory]
     [MemberDataByOracleVersion(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
@@ -100,6 +108,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Regras (cenários extra) -----------
 
+    /// <summary>
+    /// EN: Tests Precedence_OR_ShouldBindLooserThan_AND behavior.
+    /// PT: Testa o comportamento de Precedence_OR_ShouldBindLooserThan_AND.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
@@ -124,6 +136,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(SqlBinaryOp.Eq, andRight.Op);
     }
 
+    /// <summary>
+    /// EN: Tests Parentheses_ShouldOverridePrecedence behavior.
+    /// PT: Testa o comportamento de Parentheses_ShouldOverridePrecedence.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Parentheses_ShouldOverridePrecedence(int version)
@@ -141,6 +157,10 @@ public sealed class SqlExpressionParserTests(
         Assert.False(isNull.Negated);
     }
 
+    /// <summary>
+    /// EN: Tests Not_ShouldWork behavior.
+    /// PT: Testa o comportamento de Not_ShouldWork.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Not_ShouldWork(int version)
@@ -154,6 +174,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(SqlBinaryOp.Or, or.Op);
     }
 
+    /// <summary>
+    /// EN: Tests IsNotNull_ShouldProduce_IsNullExpr_Negated behavior.
+    /// PT: Testa o comportamento de IsNotNull_ShouldProduce_IsNullExpr_Negated.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
@@ -163,6 +187,10 @@ public sealed class SqlExpressionParserTests(
         Assert.True(n.Negated);
     }
 
+    /// <summary>
+    /// EN: Tests In_ShouldParse_List behavior.
+    /// PT: Testa o comportamento de In_ShouldParse_List.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void In_ShouldParse_List(int version)
@@ -172,6 +200,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(3, ins.Items.Count);
     }
 
+    /// <summary>
+    /// EN: Tests Like_ShouldParse behavior.
+    /// PT: Testa o comportamento de Like_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Like_ShouldParse(int version)
@@ -181,6 +213,10 @@ public sealed class SqlExpressionParserTests(
         Assert.NotNull(like.Pattern);
     }
 
+    /// <summary>
+    /// EN: Tests Identifier_WithAliasDotColumn_ShouldParse behavior.
+    /// PT: Testa o comportamento de Identifier_WithAliasDotColumn_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
@@ -199,6 +235,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("userId", r.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parameter_Tokens_ShouldParse behavior.
+    /// PT: Testa o comportamento de Parameter_Tokens_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Parameter_Tokens_ShouldParse(int version)
@@ -209,6 +249,10 @@ public sealed class SqlExpressionParserTests(
         Assert.NotNull(SqlExpressionParser.ParseWhere("a = ?", d));
     }
 
+    /// <summary>
+    /// EN: Tests DoubleQuoted_Identifier_ShouldParse behavior.
+    /// PT: Testa o comportamento de DoubleQuoted_Identifier_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void DoubleQuoted_Identifier_ShouldParse(int version)
@@ -219,6 +263,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("DeletedDtt", id.Name);
     }
 
+    /// <summary>
+    /// EN: Tests SingleQuoted_String_ShouldParse behavior.
+    /// PT: Testa o comportamento de SingleQuoted_String_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void SingleQuoted_String_ShouldParse(int version)
@@ -229,6 +277,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("John", lit.Value);
     }
 
+    /// <summary>
+    /// EN: Tests DoubleQuoted_Token_IsIdentifier_NotString behavior.
+    /// PT: Testa o comportamento de DoubleQuoted_Token_IsIdentifier_NotString.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void DoubleQuoted_Token_IsIdentifier_NotString(int version)
@@ -238,6 +290,10 @@ public sealed class SqlExpressionParserTests(
         Assert.IsType<IdentifierExpr>(eq.Right);
     }
 
+    /// <summary>
+    /// EN: Tests Printer_ShouldBeStable_ForSimpleExpression behavior.
+    /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -592,6 +592,10 @@ select id
 
 
 
+    /// <summary>
+    /// EN: Tests Parse_ShouldHandle_MultiStatementStrings_BySplitting behavior.
+    /// PT: Testa o comportamento de Parse_ShouldHandle_MultiStatementStrings_BySplitting.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Parse_ShouldHandle_MultiStatementStrings_BySplitting(int version)
@@ -611,6 +615,10 @@ select id
         Assert.True(q3 is SqlInsertQuery);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_Corpus behavior.
+    /// PT: Testa o comportamento de Parse_Corpus.
+    /// </summary>
     [Theory]
     [MemberDataByOracleVersion(nameof(Statements))]
     public void Parse_Corpus(string sql, string why, SqlCaseExpectation expectation, int minVersion, int version)

--- a/src/DbSqlLikeMem.Oracle.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Query/QueryExecutorExtrasTests.cs
@@ -20,6 +20,10 @@ public sealed class QueryExecutorExtrasTests(
         return db;
     }
 
+    /// <summary>
+    /// EN: Tests GroupByAndAggregationsShouldComputeCorrectly behavior.
+    /// PT: Testa o comportamento de GroupByAndAggregationsShouldComputeCorrectly.
+    /// </summary>
     [Fact]
     public void GroupByAndAggregationsShouldComputeCorrectly()
     {
@@ -53,6 +57,10 @@ GROUP BY grp";
 
     private static readonly int[] expected = [4, 3];
 
+    /// <summary>
+    /// EN: Tests OrderByLimitOffsetShouldPageCorrectly behavior.
+    /// PT: Testa o comportamento de OrderByLimitOffsetShouldPageCorrectly.
+    /// </summary>
     [Fact]
     public void OrderByLimitOffsetShouldPageCorrectly()
     {
@@ -92,12 +100,16 @@ SELECT * FROM t ORDER BY iddesc ASC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY;";
     }
 }
 
-/// <summary>
-/// EN: Extra tests for SQL translation behavior.
-/// PT: Testes extras para o comportamento de tradução SQL.
-/// </summary>
+    /// <summary>
+    /// EN: Extra tests for SQL translation behavior.
+    /// PT: Testes extras para o comportamento de tradução SQL.
+    /// </summary>
 public class SqlTranslatorTests
 {
+    /// <summary>
+    /// EN: Tests TranslateBasicWhereAndOrderBySqlCorrect behavior.
+    /// PT: Testa o comportamento de TranslateBasicWhereAndOrderBySqlCorrect.
+    /// </summary>
     [Fact]
     public void TranslateBasicWhereAndOrderBySqlCorrect()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -4,6 +4,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests CreateTableAsSelect_ShouldCreateNewTableWithRows behavior.
+    /// PT: Testa o comportamento de CreateTableAsSelect_ShouldCreateNewTableWithRows.
+    /// </summary>
     [Fact]
     public void CreateTableAsSelect_ShouldCreateNewTableWithRows()
     {
@@ -32,6 +36,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         Assert.Equal("A", active[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertIntoSelect_ShouldInsertRowsFromQuery behavior.
+    /// PT: Testa o comportamento de InsertIntoSelect_ShouldInsertRowsFromQuery.
+    /// </summary>
     [Fact]
     public void InsertIntoSelect_ShouldInsertRowsFromQuery()
     {
@@ -59,6 +67,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         Assert.Equal("A", audit[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests UpdateJoinDerivedSelect_ShouldUpdateRows behavior.
+    /// PT: Testa o comportamento de UpdateJoinDerivedSelect_ShouldUpdateRows.
+    /// </summary>
     [Fact]
     public void UpdateJoinDerivedSelect_ShouldUpdateRows()
     {
@@ -94,6 +106,10 @@ WHERE u.tenantid = 10";
         Assert.Null(users[2][2]);
     }
 
+    /// <summary>
+    /// EN: Tests DeleteJoinDerivedSelect_ShouldDeleteRows behavior.
+    /// PT: Testa o comportamento de DeleteJoinDerivedSelect_ShouldDeleteRows.
+    /// </summary>
     [Fact]
     public void DeleteJoinDerivedSelect_ShouldDeleteRows()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.Oracle.Test/SqlValueHelperTests .cs
@@ -6,6 +6,10 @@ public sealed class SqlValueHelperTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Resolve_ShouldReadDapperParameter_ByName behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_ByName.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldReadDapperParameter_ByName()
     {
@@ -22,6 +26,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(123, v);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_ShouldThrow_WhenParameterMissing behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldThrow_WhenParameterMissing()
     {
@@ -29,6 +37,10 @@ public sealed class SqlValueHelperTests(
             OracleValueHelper.Resolve("@p404", DbType.Int32, isNullable: false, pars: null, colDict: null));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_ShouldParseInList_ToListOfResolvedValues behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldParseInList_ToListOfResolvedValues.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldParseInList_ToListOfResolvedValues()
     {
@@ -38,6 +50,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal([1, 2, 3], [.. list.Cast<int>()]);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_NullOnNonNullable_ShouldThrow behavior.
+    /// PT: Testa o comportamento de Resolve_NullOnNonNullable_ShouldThrow.
+    /// </summary>
     [Fact]
     public void Resolve_NullOnNonNullable_ShouldThrow()
     {
@@ -45,6 +61,10 @@ public sealed class SqlValueHelperTests(
             OracleValueHelper.Resolve("null", DbType.Int32, isNullable: false, pars: null, colDict: null));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Json_ShouldReturnJsonDocument_WhenValid behavior.
+    /// PT: Testa o comportamento de Resolve_Json_ShouldReturnJsonDocument_WhenValid.
+    /// </summary>
     [Fact]
     public void Resolve_Json_ShouldReturnJsonDocument_WhenValid()
     {
@@ -54,6 +74,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(1, doc.RootElement.GetProperty("a").GetInt32());
     }
 
+    /// <summary>
+    /// EN: Tests Like_ShouldMatch_MySqlStyle behavior.
+    /// PT: Testa o comportamento de Like_ShouldMatch_MySqlStyle.
+    /// </summary>
     [Theory]
     [InlineData("John", "%oh%", true)]
     [InlineData("John", "J_hn", true)]
@@ -65,6 +89,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(expected, OracleValueHelper.Like(value, pattern));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Enum_ShouldValidateAgainstColumnDef behavior.
+    /// PT: Testa o comportamento de Resolve_Enum_ShouldValidateAgainstColumnDef.
+    /// </summary>
     [Fact]
     public void Resolve_Enum_ShouldValidateAgainstColumnDef()
     {
@@ -84,6 +112,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(1265, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Set_ShouldReturnHashSet_AndValidate behavior.
+    /// PT: Testa o comportamento de Resolve_Set_ShouldReturnHashSet_AndValidate.
+    /// </summary>
     [Fact]
     public void Resolve_Set_ShouldReturnHashSet_AndValidate()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/StoredProcedureExecutionTests.cs
@@ -16,6 +16,10 @@ public sealed class StoredProcedureExecutionTests(
             Direction = dir
         };
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs()
     {
@@ -52,6 +56,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, affected);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput()
     {
@@ -86,6 +94,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(1318, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull()
     {
@@ -120,6 +132,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(1048, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue()
     {
@@ -163,6 +179,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, ((OracleParameter)cmd.Parameters["@o_status"]).Value);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset behavior.
+    /// PT: Testa o comportamento de ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset.
+    /// </summary>
     [Fact]
     public void ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset()
     {
@@ -192,6 +212,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.False(r.Read());
     }
 
+    /// <summary>
+    /// EN: Tests DapperExecute_CommandTypeStoredProcedure_ShouldWork behavior.
+    /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldWork.
+    /// </summary>
     [Fact]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldWork()
     {
@@ -221,6 +245,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, affected);
     }
 
+    /// <summary>
+    /// EN: Tests DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam behavior.
+    /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam.
+    /// </summary>
     [Fact]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/StoredProcedureSignatureTests.cs
@@ -4,6 +4,10 @@ public sealed class StoredProcedureSignatureTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests StoredProcedure_ShouldValidateRequiredInAndOutParams behavior.
+    /// PT: Testa o comportamento de StoredProcedure_ShouldValidateRequiredInAndOutParams.
+    /// </summary>
     [Fact]
     public void StoredProcedure_ShouldValidateRequiredInAndOutParams()
     {
@@ -31,6 +35,10 @@ public sealed class StoredProcedureSignatureTests(
             CultureInfo.InvariantCulture));
     }
 
+    /// <summary>
+    /// EN: Tests StoredProcedure_ShouldThrowWhenMissingRequiredParam behavior.
+    /// PT: Testa o comportamento de StoredProcedure_ShouldThrowWhenMissingRequiredParam.
+    /// </summary>
     [Fact]
     public void StoredProcedure_ShouldThrowWhenMissingRequiredParam()
     {
@@ -50,6 +58,10 @@ public sealed class StoredProcedureSignatureTests(
         Assert.Equal(1318, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests CallStatement_ShouldValidateAgainstRegisteredProcedure behavior.
+    /// PT: Testa o comportamento de CallStatement_ShouldValidateAgainstRegisteredProcedure.
+    /// </summary>
     [Fact]
     public void CallStatement_ShouldValidateAgainstRegisteredProcedure()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleDeleteStrategyTests.cs
@@ -4,6 +4,10 @@ public sealed class OracleCommandDeleteTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_remove_1_linha behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_1_linha.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_remove_1_linha()
     {
@@ -23,6 +27,10 @@ public sealed class OracleCommandDeleteTests(
         Assert.Equal(1, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_remove_varias_linhas behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_varias_linhas.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_remove_varias_linhas()
     {
@@ -43,6 +51,10 @@ public sealed class OracleCommandDeleteTests(
         Assert.Equal(2, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0 behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0()
     {
@@ -60,6 +72,10 @@ public sealed class OracleCommandDeleteTests(
         Assert.Equal(0, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_tabela_inexistente_dispara behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_tabela_inexistente_dispara.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_tabela_inexistente_dispara()
     {
@@ -71,6 +87,10 @@ public sealed class OracleCommandDeleteTests(
         Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara.
+    /// </summary>
     [Fact(Skip = "Isso é valido no Oracle")]
     public void ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara()
     {
@@ -86,6 +106,10 @@ public sealed class OracleCommandDeleteTests(
         Assert.Contains("delete", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia()
     {
@@ -108,6 +132,10 @@ public sealed class OracleCommandDeleteTests(
         Assert.Equal(0, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false.
+    /// </summary>
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -126,6 +154,10 @@ public sealed class OracleCommandDeleteTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_case_insensitive behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_case_insensitive.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_case_insensitive()
     {
@@ -142,6 +174,10 @@ public sealed class OracleCommandDeleteTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_com_parametro_se_suportado behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_com_parametro_se_suportado.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_com_parametro_se_suportado()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertOnDuplicateTests.cs
@@ -2,6 +2,10 @@ namespace DbSqlLikeMem.Oracle.Test.Strategy;
 
 public sealed class OracleMergeUpsertTests(ITestOutputHelper helper) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Merge_ShouldInsert_WhenNotMatched behavior.
+    /// PT: Testa o comportamento de Merge_ShouldInsert_WhenNotMatched.
+    /// </summary>
     [Fact]
     public void Merge_ShouldInsert_WhenNotMatched()
     {
@@ -28,6 +32,10 @@ WHEN NOT MATCHED THEN
         Assert.Equal("A", (string)t[0][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests Merge_ShouldUpdate_WhenMatched behavior.
+    /// PT: Testa o comportamento de Merge_ShouldUpdate_WhenMatched.
+    /// </summary>
     [Fact]
     public void Merge_ShouldUpdate_WhenMatched()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyCoverageTests.cs
@@ -4,6 +4,10 @@ public sealed class OracleInsertStrategyCoverageTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Insert_MultiRowValues_ShouldInsertAllRows behavior.
+    /// PT: Testa o comportamento de Insert_MultiRowValues_ShouldInsertAllRows.
+    /// </summary>
     [Fact]
     public void Insert_MultiRowValues_ShouldInsertAllRows()
     {
@@ -28,6 +32,10 @@ public sealed class OracleInsertStrategyCoverageTests(
         Assert.Equal("B", (string)t[1][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_WithIdentityColumnOmitted_ShouldAutoIncrement behavior.
+    /// PT: Testa o comportamento de Insert_WithIdentityColumnOmitted_ShouldAutoIncrement.
+    /// </summary>
     [Fact]
     public void Insert_WithIdentityColumnOmitted_ShouldAutoIncrement()
     {
@@ -54,6 +62,10 @@ public sealed class OracleInsertStrategyCoverageTests(
         Assert.Equal("B", (string)t[1][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests InsertSelect_ShouldInsertRowsFromSelect behavior.
+    /// PT: Testa o comportamento de InsertSelect_ShouldInsertRowsFromSelect.
+    /// </summary>
     [Fact]
     public void InsertSelect_ShouldInsertRowsFromSelect()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyExtrasTests.cs
@@ -3,6 +3,10 @@ public sealed class OracleInsertStrategyExtrasTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests MultiRowInsertShouldAddAllRows behavior.
+    /// PT: Testa o comportamento de MultiRowInsertShouldAddAllRows.
+    /// </summary>
     [Fact]
     public void MultiRowInsertShouldAddAllRows()
     {
@@ -26,6 +30,10 @@ public sealed class OracleInsertStrategyExtrasTests(
         Assert.Equal("B", table[1][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertWithDefaultValueAndIdentityShouldApplyDefaults behavior.
+    /// PT: Testa o comportamento de InsertWithDefaultValueAndIdentityShouldApplyDefaults.
+    /// </summary>
     [Fact]
     public void InsertWithDefaultValueAndIdentityShouldApplyDefaults()
     {
@@ -53,6 +61,10 @@ public sealed class OracleInsertStrategyExtrasTests(
         Assert.Equal(2, table[1][0]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertDuplicatePrimaryKeyShouldThrow behavior.
+    /// PT: Testa o comportamento de InsertDuplicatePrimaryKeyShouldThrow.
+    /// </summary>
     [Fact]
     public void InsertDuplicatePrimaryKeyShouldThrow()
     {
@@ -74,12 +86,16 @@ public sealed class OracleInsertStrategyExtrasTests(
     }
 }
 
-/// <summary>
-/// EN: Tests delete strategy behavior with foreign keys.
-/// PT: Testes do comportamento da estratégia de delete com chaves estrangeiras.
-/// </summary>
+    /// <summary>
+    /// EN: Tests delete strategy behavior with foreign keys.
+    /// PT: Testes do comportamento da estratégia de delete com chaves estrangeiras.
+    /// </summary>
 public class OracleDeleteStrategyForeignKeyTests
 {
+    /// <summary>
+    /// EN: Tests DeleteReferencedRowShouldThrow behavior.
+    /// PT: Testa o comportamento de DeleteReferencedRowShouldThrow.
+    /// </summary>
     [Fact]
     public void DeleteReferencedRowShouldThrow()
     {
@@ -109,12 +125,16 @@ public class OracleDeleteStrategyForeignKeyTests
     }
 }
 
-/// <summary>
-/// EN: Extra tests for update strategy behavior.
-/// PT: Testes extras do comportamento da estratégia de update.
-/// </summary>
+    /// <summary>
+    /// EN: Extra tests for update strategy behavior.
+    /// PT: Testes extras do comportamento da estratégia de update.
+    /// </summary>
 public class OracleUpdateStrategyExtrasTests
 {
+    /// <summary>
+    /// EN: Tests UpdateMultipleConditionsShouldOnlyAffectMatchingRows behavior.
+    /// PT: Testa o comportamento de UpdateMultipleConditionsShouldOnlyAffectMatchingRows.
+    /// </summary>
     [Fact]
     public void UpdateMultipleConditionsShouldOnlyAffectMatchingRows()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyTests.cs
@@ -3,6 +3,10 @@ public sealed class OracleInsertStrategyTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests InsertIntoTableShouldAddNewRow behavior.
+    /// PT: Testa o comportamento de InsertIntoTableShouldAddNewRow.
+    /// </summary>
     [Fact]
     public void InsertIntoTableShouldAddNewRow()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTransactionTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTransactionTests.cs
@@ -3,6 +3,10 @@ public sealed class OracleTransactionTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests TransactionShouldCommit behavior.
+    /// PT: Testa o comportamento de TransactionShouldCommit.
+    /// </summary>
     [Fact]
     public void TransactionShouldCommit()
     {
@@ -33,6 +37,10 @@ public sealed class OracleTransactionTests(
         Assert.Equal("John Doe", table[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TransactionShouldRollback behavior.
+    /// PT: Testa o comportamento de TransactionShouldRollback.
+    /// </summary>
     [Fact]
     public void TransactionShouldRollback()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyCoverageTests.cs
@@ -4,6 +4,10 @@ public sealed class OracleUpdateStrategyCoverageTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Update_SetNullableColumnToNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Update_SetNullableColumnToNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Update_SetNullableColumnToNull_ShouldWork()
     {
@@ -25,6 +29,10 @@ public sealed class OracleUpdateStrategyCoverageTests(
         Assert.Null(users[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests Update_SetNotNullableColumnToNull_ShouldThrow behavior.
+    /// PT: Testa o comportamento de Update_SetNotNullableColumnToNull_ShouldThrow.
+    /// </summary>
     [Fact]
     public void Update_SetNotNullableColumnToNull_ShouldThrow()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyTests.cs
@@ -4,6 +4,10 @@ public sealed class OracleUpdateStrategyTests(
     ITestOutputHelper helper
 ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests UpdateTableShouldModifyExistingRow behavior.
+    /// PT: Testa o comportamento de UpdateTableShouldModifyExistingRow.
+    /// </summary>
     [Fact]
     public void UpdateTableShouldModifyExistingRow()
     {
@@ -28,6 +32,10 @@ public sealed class OracleUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldReturnZero_WhenNoRowsMatchWhere behavior.
+    /// PT: Testa o comportamento de Update_ShouldReturnZero_WhenNoRowsMatchWhere.
+    /// </summary>
     [Fact]
     public void Update_ShouldReturnZero_WhenNoRowsMatchWhere()
     {
@@ -49,6 +57,10 @@ public sealed class OracleUpdateStrategyTests(
         Assert.Equal(0, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple behavior.
+    /// PT: Testa o comportamento de Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple.
+    /// </summary>
     [Fact]
     public void Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple()
     {
@@ -73,6 +85,10 @@ public sealed class OracleUpdateStrategyTests(
         Assert.Equal(2, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldHandleWhereWithAnd_CaseInsensitive behavior.
+    /// PT: Testa o comportamento de Update_ShouldHandleWhereWithAnd_CaseInsensitive.
+    /// </summary>
     [Fact]
     public void Update_ShouldHandleWhereWithAnd_CaseInsensitive()
     {
@@ -97,6 +113,10 @@ public sealed class OracleUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldUpdateMultipleSetPairs behavior.
+    /// PT: Testa o comportamento de Update_ShouldUpdateMultipleSetPairs.
+    /// </summary>
     [Fact]
     public void Update_ShouldUpdateMultipleSetPairs()
     {
@@ -118,6 +138,10 @@ public sealed class OracleUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords behavior.
+    /// PT: Testa o comportamento de Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords.
+    /// </summary>
     [Fact]
     public void Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords()
     {
@@ -138,6 +162,10 @@ public sealed class OracleUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldWork_WithThreadSafeTrueOrFalse behavior.
+    /// PT: Testa o comportamento de Update_ShouldWork_WithThreadSafeTrueOrFalse.
+    /// </summary>
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -160,6 +188,10 @@ public sealed class OracleUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldThrow_WhenTableDoesNotExist behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrow_WhenTableDoesNotExist.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrow_WhenTableDoesNotExist()
     {
@@ -174,6 +206,10 @@ public sealed class OracleUpdateStrategyTests(
         Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken()
     {
@@ -191,6 +227,10 @@ public sealed class OracleUpdateStrategyTests(
         Assert.Contains("upd", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull behavior.
+    /// PT: Testa o comportamento de Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull.
+    /// </summary>
     [Fact]
     public void Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull()
     {
@@ -212,6 +252,10 @@ public sealed class OracleUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldSupportParameter_IfSqlValueHelperSupports behavior.
+    /// PT: Testa o comportamento de Update_ShouldSupportParameter_IfSqlValueHelperSupports.
+    /// </summary>
     [Fact]
     public void Update_ShouldSupportParameter_IfSqlValueHelperSupports()
     {
@@ -242,6 +286,10 @@ public sealed class OracleUpdateStrategyTests(
     // Opcional: testar ValidateUnique (preciso do IndexDef real)
     // ============================================================
     //
+    /// <summary>
+    /// EN: Tests Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/SubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/SubqueryFromAndJoinsTests.cs
@@ -4,6 +4,10 @@ public sealed class SubqueryFromAndJoinsTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests FromSubquery_ShouldReturnFilteredRows behavior.
+    /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
+    /// </summary>
     [Fact]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
@@ -32,6 +36,10 @@ public sealed class SubqueryFromAndJoinsTests(
         ids.Should().Equal(1, 3);
     }
 
+    /// <summary>
+    /// EN: Tests JoinSubquery_ShouldJoinCorrectly behavior.
+    /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
+    /// </summary>
     [Fact]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
@@ -72,6 +80,10 @@ ORDER BY u.Id, o.Amount";
         rows.Should().Equal([(1, 60m), (2, 80m)]);
     }
 
+    /// <summary>
+    /// EN: Tests NestedSubquery_ShouldWork behavior.
+    /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
+    /// </summary>
     [Fact]
     public void NestedSubquery_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/TemporaryTable/OracleTemporaryTableEngineTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/TemporaryTable/OracleTemporaryTableEngineTests.cs
@@ -4,6 +4,10 @@ public sealed class OracleTemporaryTableEngineTests
 {
     private static readonly int[] expected = [1, 2];
 
+    /// <summary>
+    /// EN: Tests CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows behavior.
+    /// PT: Testa o comportamento de CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows.
+    /// </summary>
     [Fact]
     public void CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/TemporaryTable/OracleTemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/TemporaryTable/OracleTemporaryTableParserTests.cs
@@ -2,6 +2,10 @@ namespace DbSqlLikeMem.Oracle.Test.TemporaryTable;
 
 public sealed class OracleTemporaryTableParserTests
 {
+    /// <summary>
+    /// EN: Tests ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect behavior.
+    /// PT: Testa o comportamento de ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect(int version)
@@ -49,6 +53,10 @@ WHERE tenantid = 10",
         };
     }
 
+    /// <summary>
+    /// EN: Tests Parse_ShouldAccept_CreateTemporaryTable_Variants behavior.
+    /// PT: Testa o comportamento de Parse_ShouldAccept_CreateTemporaryTable_Variants.
+    /// </summary>
     [Theory]
     [MemberDataByOracleVersion(nameof(CreateTempTableStatements))]
     public void Parse_ShouldAccept_CreateTemporaryTable_Variants(string sql, int version)

--- a/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewEngineTests.cs
@@ -28,6 +28,10 @@ public sealed class OracleCreateViewEngineTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests CreateView_ThenSelectFromView_ShouldReturnExpectedRows behavior.
+    /// PT: Testa o comportamento de CreateView_ThenSelectFromView_ShouldReturnExpectedRows.
+    /// </summary>
     [Fact]
     public void CreateView_ThenSelectFromView_ShouldReturnExpectedRows()
     {
@@ -41,6 +45,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal(["John", "Bob" ], rows.Select(r => (string)r["name"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_IsNotMaterialized_ShouldReflectBaseTableChanges behavior.
+    /// PT: Testa o comportamento de View_IsNotMaterialized_ShouldReflectBaseTableChanges.
+    /// </summary>
     [Fact]
     public void View_IsNotMaterialized_ShouldReflectBaseTableChanges()
     {
@@ -53,6 +61,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([1, 2, 3, 4], rows.Select(r => (int)r["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests CreateOrReplaceView_ShouldChangeDefinition behavior.
+    /// PT: Testa o comportamento de CreateOrReplaceView_ShouldChangeDefinition.
+    /// </summary>
     [Fact]
     public void CreateOrReplaceView_ShouldChangeDefinition()
     {
@@ -65,6 +77,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([3], r2.Select(x => (int)x["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_NameShouldShadowTable_WhenSameName behavior.
+    /// PT: Testa o comportamento de View_NameShouldShadowTable_WhenSameName.
+    /// </summary>
     [Fact]
     public void View_NameShouldShadowTable_WhenSameName()
     {
@@ -81,6 +97,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal(1, (int)rows[0]["id"]!);
     }
 
+    /// <summary>
+    /// EN: Tests View_CanReferenceAnotherView behavior.
+    /// PT: Testa o comportamento de View_CanReferenceAnotherView.
+    /// </summary>
     [Fact]
     public void View_CanReferenceAnotherView()
     {
@@ -91,6 +111,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([2], rows.Select(r => (int)r["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_WithJoinAndAggregation_ShouldWork behavior.
+    /// PT: Testa o comportamento de View_WithJoinAndAggregation_ShouldWork.
+    /// </summary>
     [Fact]
     public void View_WithJoinAndAggregation_ShouldWork()
     {
@@ -111,6 +135,10 @@ GROUP BY u.id;
         Assert.True(rows[2]["total"] is null);
     }
 
+    /// <summary>
+    /// EN: Tests CreateView_ExistingNameWithoutOrReplace_ShouldThrow behavior.
+    /// PT: Testa o comportamento de CreateView_ExistingNameWithoutOrReplace_ShouldThrow.
+    /// </summary>
     [Fact]
     public void CreateView_ExistingNameWithoutOrReplace_ShouldThrow()
     {
@@ -118,6 +146,10 @@ GROUP BY u.id;
         Assert.ThrowsAny<Exception>(() => _cnn.ExecNonQuery("CREATE VIEW vdup AS SELECT 2 AS x FROM DUAL;"));
     }
 
+    /// <summary>
+    /// EN: Tests DropView_ShouldRemoveDefinition behavior.
+    /// PT: Testa o comportamento de DropView_ShouldRemoveDefinition.
+    /// </summary>
     [Fact(Skip = "MySQL: DROP VIEW faz parte do ciclo de vida. Implementar depois.")]
     public void DropView_ShouldRemoveDefinition()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewParserTests.cs
@@ -4,6 +4,10 @@ public sealed class OracleCreateViewParserTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements behavior.
+    /// PT: Testa o comportamento de ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements(int version)
@@ -27,6 +31,10 @@ SELECT * FROM v_users;
         Assert.Contains("users", cv.Select.Table?.Name, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateOrReplaceView_ShouldSetFlag behavior.
+    /// PT: Testa o comportamento de Parse_CreateOrReplaceView_ShouldSetFlag.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Parse_CreateOrReplaceView_ShouldSetFlag(int version)
@@ -38,6 +46,10 @@ SELECT * FROM v_users;
         Assert.Equal("v", cv.Table?.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames(int version)
@@ -48,6 +60,10 @@ SELECT * FROM v_users;
         Assert.Equal(["a", "b"], cv.ColumnNames);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_WithBackticks_ShouldWork behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_WithBackticks_ShouldWork.
+    /// </summary>
     [Theory]
     [MemberDataOracleVersion]
     public void Parse_CreateView_WithBackticks_ShouldWork(int version)
@@ -58,6 +74,10 @@ SELECT * FROM v_users;
         Assert.Equal("v", cv.Table?.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec.
+    /// </summary>
     [Theory(Skip = "MySQL não suporta IF NOT EXISTS em CREATE VIEW. O mock aceita por conveniência; habilite se quiser comportamento estrito.")]
     [MemberDataOracleVersion]
     public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec(int version)

--- a/src/DbSqlLikeMem.SqlServer.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/CsvLoaderAndIndexTests.cs
@@ -4,6 +4,10 @@ public sealed class CsvLoaderAndIndexTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests CsvLoader_ShouldLoadRows_ByColumnName behavior.
+    /// PT: Testa o comportamento de CsvLoader_ShouldLoadRows_ByColumnName.
+    /// </summary>
     [Fact]
     public void CsvLoader_ShouldLoadRows_ByColumnName()
     {
@@ -26,6 +30,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal("John", cnn.GetTable("users")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests GetColumn_ShouldThrow_UnknownColumn behavior.
+    /// PT: Testa o comportamento de GetColumn_ShouldThrow_UnknownColumn.
+    /// </summary>
     [Fact]
     public void GetColumn_ShouldThrow_UnknownColumn()
     {
@@ -37,6 +45,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal(1054, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests Index_Lookup_ShouldReturnRowPositions behavior.
+    /// PT: Testa o comportamento de Index_Lookup_ShouldReturnRowPositions.
+    /// </summary>
     [Fact]
     public void Index_Lookup_ShouldReturnRowPositions()
     {
@@ -56,6 +68,10 @@ public sealed class CsvLoaderAndIndexTests(
         Assert.Equal([0, 1], [.. ix!.Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests BackupRestore_ShouldRollbackData behavior.
+    /// PT: Testa o comportamento de BackupRestore_ShouldRollbackData.
+    /// </summary>
     [Fact]
     public void BackupRestore_ShouldRollbackData()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/DapperTests.cs
@@ -21,6 +21,10 @@ public sealed class DapperTests : XUnitTestBase
         _connection.Open();
     }
 
+    /// <summary>
+    /// EN: Tests TestSelectQuery behavior.
+    /// PT: Testa o comportamento de TestSelectQuery.
+    /// </summary>
     [Fact]
     public void TestSelectQuery()
     {
@@ -28,6 +32,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.NotNull(users);
     }
 
+    /// <summary>
+    /// EN: Tests QueryShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryShouldReturnCorrectData()
     {
@@ -61,6 +69,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.Equal(dt, result.First().CreatedDate);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldInsertData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldInsertData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldInsertData()
     {
@@ -87,6 +99,10 @@ public sealed class DapperTests : XUnitTestBase
         Assert.Equal(dt, table[0][2]);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldUpdateData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldUpdateData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldUpdateData()
     {
@@ -126,6 +142,10 @@ UPDATE users
         Assert.Equal(dtUpdate, table[0][3]);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteShouldDeleteData behavior.
+    /// PT: Testa o comportamento de ExecuteShouldDeleteData.
+    /// </summary>
     [Fact]
     public void ExecuteShouldDeleteData()
     {
@@ -148,6 +168,10 @@ UPDATE users
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleResultSets()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/DapperUserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/DapperUserTests.cs
@@ -14,6 +14,10 @@ public sealed class DapperUserTests(
         public Guid? TestGuidNull { get; set; }
     }
 
+    /// <summary>
+    /// EN: Tests InsertUserShouldAddUserToTable behavior.
+    /// PT: Testa o comportamento de InsertUserShouldAddUserToTable.
+    /// </summary>
     [Fact]
     public void InsertUserShouldAddUserToTable()
     {
@@ -58,6 +62,10 @@ public sealed class DapperUserTests(
         Assert.Equal(user.TestGuidNull, insertedRow[6]);
     }
 
+    /// <summary>
+    /// EN: Tests QueryUserShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryUserShouldReturnCorrectData()
     {
@@ -110,6 +118,10 @@ public sealed class DapperUserTests(
         Assert.Equal(user.TestGuidNull, result.TestGuidNull);
     }
 
+    /// <summary>
+    /// EN: Tests UpdateUserShouldModifyUserInTable behavior.
+    /// PT: Testa o comportamento de UpdateUserShouldModifyUserInTable.
+    /// </summary>
     [Fact]
     public void UpdateUserShouldModifyUserInTable()
     {
@@ -176,6 +188,10 @@ public sealed class DapperUserTests(
         Assert.Equal(updatedUser.TestGuidNull, updatedRow[6]);
     }
 
+    /// <summary>
+    /// EN: Tests DeleteUserShouldRemoveUserFromTable behavior.
+    /// PT: Testa o comportamento de DeleteUserShouldRemoveUserFromTable.
+    /// </summary>
     [Fact]
     public void DeleteUserShouldRemoveUserFromTable()
     {
@@ -223,6 +239,10 @@ public sealed class DapperUserTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleUserResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/DapperUserTests2.cs
@@ -16,6 +16,10 @@ public sealed class DapperUserTests2(
         public List<int> Tenants { get; set; } = [];
     }
 
+    /// <summary>
+    /// EN: Tests QueryUserShouldReturnCorrectData behavior.
+    /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
+    /// </summary>
     [Fact]
     public void QueryUserShouldReturnCorrectData()
     {
@@ -68,6 +72,10 @@ public sealed class DapperUserTests2(
         Assert.Equal(user.TestGuidNull, result.TestGuidNull);
     }
 
+    /// <summary>
+    /// EN: Tests QueryMultipleShouldReturnMultipleUserResultSets behavior.
+    /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
+    /// </summary>
     [Fact]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
@@ -127,6 +135,10 @@ public sealed class DapperUserTests2(
         Assert.Equal("jane.doe@example.com", users2[0].Email);
     }
 
+    /// <summary>
+    /// EN: Tests QueryWithJoinShouldReturnJoinedData behavior.
+    /// PT: Testa o comportamento de QueryWithJoinShouldReturnJoinedData.
+    /// </summary>
     [Fact]
     public void QueryWithJoinShouldReturnJoinedData()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/ExistsTests.cs
@@ -4,6 +4,10 @@ public sealed class ExistsTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Exists_ShouldFilterUsersWithOrders behavior.
+    /// PT: Testa o comportamento de Exists_ShouldFilterUsersWithOrders.
+    /// </summary>
     [Fact]
     public void Exists_ShouldFilterUsersWithOrders()
     {
@@ -43,6 +47,10 @@ ORDER BY u.Id";
         ids.Should().Equal(1, 3);
     }
 
+    /// <summary>
+    /// EN: Tests NotExists_ShouldFilterUsersWithoutOrders behavior.
+    /// PT: Testa o comportamento de NotExists_ShouldFilterUsersWithoutOrders.
+    /// </summary>
     [Fact]
     public void NotExists_ShouldFilterUsersWithoutOrders()
     {
@@ -81,6 +89,10 @@ ORDER BY u.Id";
         ids.Should().Equal(2);
     }
 
+    /// <summary>
+    /// EN: Tests Exists_WithExtraPredicate_ShouldWork behavior.
+    /// PT: Testa o comportamento de Exists_WithExtraPredicate_ShouldWork.
+    /// </summary>
     [Fact]
     public void Exists_WithExtraPredicate_ShouldWork()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/ExtendedSqlServerMockTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/ExtendedSqlServerMockTests.cs
@@ -4,6 +4,10 @@ public sealed class ExtendedMySqlMockTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests InsertAutoIncrementShouldAssignIdentityWhenNotSpecified behavior.
+    /// PT: Testa o comportamento de InsertAutoIncrementShouldAssignIdentityWhenNotSpecified.
+    /// </summary>
     [Fact]
     public void InsertAutoIncrementShouldAssignIdentityWhenNotSpecified()
     {
@@ -26,6 +30,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal("Bob", table[1][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertNullIntoNullableColumnShouldSucceed behavior.
+    /// PT: Testa o comportamento de InsertNullIntoNullableColumnShouldSucceed.
+    /// </summary>
     [Fact]
     public void InsertNullIntoNullableColumnShouldSucceed()
     {
@@ -41,6 +49,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Null(table[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertNullIntoNonNullableColumnShouldThrow behavior.
+    /// PT: Testa o comportamento de InsertNullIntoNonNullableColumnShouldThrow.
+    /// </summary>
     [Fact]
     public void InsertNullIntoNonNullableColumnShouldThrow()
     {
@@ -57,6 +69,10 @@ public sealed class ExtendedMySqlMockTests(
 
     private static readonly string[] item = ["first", "second"];
 
+    /// <summary>
+    /// EN: Tests CompositeIndexFilterShouldReturnCorrectRows behavior.
+    /// PT: Testa o comportamento de CompositeIndexFilterShouldReturnCorrectRows.
+    /// </summary>
     [Fact]
     public void CompositeIndexFilterShouldReturnCorrectRows()
     {
@@ -78,6 +94,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(1, (int)result[0].value);
     }
 
+    /// <summary>
+    /// EN: Tests LikeFilterShouldReturnMatchingRows behavior.
+    /// PT: Testa o comportamento de LikeFilterShouldReturnMatchingRows.
+    /// </summary>
     [Fact]
     public void LikeFilterShouldReturnMatchingRows()
     {
@@ -94,6 +114,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal("alice", res[0].name);
     }
 
+    /// <summary>
+    /// EN: Tests InFilterShouldReturnMatchingRows behavior.
+    /// PT: Testa o comportamento de InFilterShouldReturnMatchingRows.
+    /// </summary>
     [Fact]
     public void InFilterShouldReturnMatchingRows()
     {
@@ -111,6 +135,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal([1, 3], ids);
     }
 
+    /// <summary>
+    /// EN: Tests OrderByLimitOffsetDistinctShouldReturnExpectedRows behavior.
+    /// PT: Testa o comportamento de OrderByLimitOffsetDistinctShouldReturnExpectedRows.
+    /// </summary>
     [Fact]
     public void OrderByLimitOffsetDistinctShouldReturnExpectedRows()
     {
@@ -128,6 +156,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(1, (int)res[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests HavingFilterShouldApplyAfterAggregation behavior.
+    /// PT: Testa o comportamento de HavingFilterShouldApplyAfterAggregation.
+    /// </summary>
     [Fact]
     public void HavingFilterShouldApplyAfterAggregation()
     {
@@ -148,6 +180,10 @@ public sealed class ExtendedMySqlMockTests(
         Assert.Equal(2L, result[0].C);
     }
 
+    /// <summary>
+    /// EN: Tests ForeignKeyDeleteShouldThrowOnReferencedParentDeletion behavior.
+    /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletion.
+    /// </summary>
     [Fact]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletion()
     {
@@ -171,6 +207,10 @@ public sealed class ExtendedMySqlMockTests(
             cnn.Execute("DELETE FROM parent WHERE id = 1"));
     }
 
+    /// <summary>
+    /// EN: Tests ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK behavior.
+    /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK.
+    /// </summary>
     [Fact]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK()
     {
@@ -193,6 +233,10 @@ public sealed class ExtendedMySqlMockTests(
             cnn.Execute("DELETE FROM parent WHERE id = 1"));
     }
 
+    /// <summary>
+    /// EN: Tests MultipleParameterSetsInsertShouldInsertAllRows behavior.
+    /// PT: Testa o comportamento de MultipleParameterSetsInsertShouldInsertAllRows.
+    /// </summary>
     [Fact]
     public void MultipleParameterSetsInsertShouldInsertAllRows()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/FluentTest.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/FluentTest.cs
@@ -22,6 +22,10 @@ public sealed class FluentTest(
         return cnn;
     }
 
+    /// <summary>
+    /// EN: Tests InsertUpdateDeleteFluentScenario behavior.
+    /// PT: Testa o comportamento de InsertUpdateDeleteFluentScenario.
+    /// </summary>
     [Fact]
     public void InsertUpdateDeleteFluentScenario()
     {
@@ -61,6 +65,10 @@ public sealed class FluentTest(
         Assert.True(cnn.Metrics.Elapsed > TimeSpan.Zero);
     }
 
+    /// <summary>
+    /// EN: Tests TestFluent behavior.
+    /// PT: Testa o comportamento de TestFluent.
+    /// </summary>
     [Fact]
     public void TestFluent()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlExprPrinterTest.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlExprPrinterTest.cs
@@ -3,6 +3,10 @@ public sealed class SqlExprPrinterTest(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse behavior.
+    /// PT: Testa o comportamento de ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse.
+    /// </summary>
     [Theory]
     [MemberDataBySqlServerVersion(nameof(Expressions))]
     public void ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse(string expr, int version)

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlExpressionParserTests.cs
@@ -7,6 +7,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Smoke tests: todas as expressões reais encontradas no zip (suportadas) -----------
 
+    /// <summary>
+    /// EN: Tests ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions behavior.
+    /// PT: Testa o comportamento de ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions.
+    /// </summary>
     [Theory]
     [MemberDataBySqlServerVersion(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
@@ -74,6 +78,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Negative tests: coisas que aparecem nos testes atuais mas NÃO fazem parte do subset -----------
 
+    /// <summary>
+    /// EN: Tests ParseWhere_ShouldThrow_ForUnsupportedExpressions behavior.
+    /// PT: Testa o comportamento de ParseWhere_ShouldThrow_ForUnsupportedExpressions.
+    /// </summary>
     [Theory]
     [MemberDataBySqlServerVersion(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
@@ -100,6 +108,10 @@ public sealed class SqlExpressionParserTests(
 
     // ----------- Regras (cenários extra) -----------
 
+    /// <summary>
+    /// EN: Tests Precedence_OR_ShouldBindLooserThan_AND behavior.
+    /// PT: Testa o comportamento de Precedence_OR_ShouldBindLooserThan_AND.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
@@ -124,6 +136,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(SqlBinaryOp.Eq, andRight.Op);
     }
 
+    /// <summary>
+    /// EN: Tests Parentheses_ShouldOverridePrecedence behavior.
+    /// PT: Testa o comportamento de Parentheses_ShouldOverridePrecedence.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Parentheses_ShouldOverridePrecedence(int version)
@@ -141,6 +157,10 @@ public sealed class SqlExpressionParserTests(
         Assert.False(isNull.Negated);
     }
 
+    /// <summary>
+    /// EN: Tests Not_ShouldWork behavior.
+    /// PT: Testa o comportamento de Not_ShouldWork.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Not_ShouldWork(int version)
@@ -154,6 +174,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(SqlBinaryOp.Or, or.Op);
     }
 
+    /// <summary>
+    /// EN: Tests IsNotNull_ShouldProduce_IsNullExpr_Negated behavior.
+    /// PT: Testa o comportamento de IsNotNull_ShouldProduce_IsNullExpr_Negated.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
@@ -163,6 +187,10 @@ public sealed class SqlExpressionParserTests(
         Assert.True(n.Negated);
     }
 
+    /// <summary>
+    /// EN: Tests In_ShouldParse_List behavior.
+    /// PT: Testa o comportamento de In_ShouldParse_List.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void In_ShouldParse_List(int version)
@@ -172,6 +200,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal(3, ins.Items.Count);
     }
 
+    /// <summary>
+    /// EN: Tests Like_ShouldParse behavior.
+    /// PT: Testa o comportamento de Like_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Like_ShouldParse(int version)
@@ -181,6 +213,10 @@ public sealed class SqlExpressionParserTests(
         Assert.NotNull(like.Pattern);
     }
 
+    /// <summary>
+    /// EN: Tests Identifier_WithAliasDotColumn_ShouldParse behavior.
+    /// PT: Testa o comportamento de Identifier_WithAliasDotColumn_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
@@ -199,6 +235,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("userId", r.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parameter_Tokens_ShouldParse behavior.
+    /// PT: Testa o comportamento de Parameter_Tokens_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Parameter_Tokens_ShouldParse(int version)
@@ -209,6 +249,10 @@ public sealed class SqlExpressionParserTests(
         Assert.NotNull(SqlExpressionParser.ParseWhere("a = ?", d));
     }
 
+    /// <summary>
+    /// EN: Tests Backtick_Identifier_ShouldParse behavior.
+    /// PT: Testa o comportamento de Backtick_Identifier_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Backtick_Identifier_ShouldParse(int version)
@@ -219,6 +263,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("DeletedDtt", id.Name);
     }
 
+    /// <summary>
+    /// EN: Tests DoubleQuoted_String_ShouldParse behavior.
+    /// PT: Testa o comportamento de DoubleQuoted_String_ShouldParse.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void DoubleQuoted_String_ShouldParse(int version)
@@ -229,6 +277,10 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("John", lit.Value);
     }
 
+    /// <summary>
+    /// EN: Tests Printer_ShouldBeStable_ForSimpleExpression behavior.
+    /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -584,6 +584,10 @@ select id
         };
     }
 
+    /// <summary>
+    /// EN: Tests Parse_ShouldHandle_MultiStatementStrings_BySplitting behavior.
+    /// PT: Testa o comportamento de Parse_ShouldHandle_MultiStatementStrings_BySplitting.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Parse_ShouldHandle_MultiStatementStrings_BySplitting(int version)
@@ -603,6 +607,10 @@ select id
         Assert.True(q3 is SqlInsertQuery);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_Corpus behavior.
+    /// PT: Testa o comportamento de Parse_Corpus.
+    /// </summary>
     [Theory]
     [MemberDataBySqlServerVersion(nameof(Statements))]
     public void Parse_Corpus(string sql, string why, SqlCaseExpectation expectation, int minVersion, int version)

--- a/src/DbSqlLikeMem.SqlServer.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Query/QueryExecutorExtrasTests.cs
@@ -20,6 +20,10 @@ public sealed class QueryExecutorExtrasTests(
         return db;
     }
 
+    /// <summary>
+    /// EN: Tests GroupByAndAggregationsShouldComputeCorrectly behavior.
+    /// PT: Testa o comportamento de GroupByAndAggregationsShouldComputeCorrectly.
+    /// </summary>
     [Fact]
     public void GroupByAndAggregationsShouldComputeCorrectly()
     {
@@ -53,6 +57,10 @@ GROUP BY grp";
 
     private static readonly int[] expected = [4, 3];
 
+    /// <summary>
+    /// EN: Tests OrderByLimitOffsetShouldPageCorrectly behavior.
+    /// PT: Testa o comportamento de OrderByLimitOffsetShouldPageCorrectly.
+    /// </summary>
     [Fact]
     public void OrderByLimitOffsetShouldPageCorrectly()
     {
@@ -92,12 +100,16 @@ SELECT * FROM t ORDER BY iddesc ASC OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY;";
     }
 }
 
-/// <summary>
-/// EN: Extra tests for SQL translation behavior.
-/// PT: Testes extras para o comportamento de tradução SQL.
-/// </summary>
+    /// <summary>
+    /// EN: Extra tests for SQL translation behavior.
+    /// PT: Testes extras para o comportamento de tradução SQL.
+    /// </summary>
 public class SqlTranslatorTests
 {
+    /// <summary>
+    /// EN: Tests TranslateBasicWhereAndOrderBySqlCorrect behavior.
+    /// PT: Testa o comportamento de TranslateBasicWhereAndOrderBySqlCorrect.
+    /// </summary>
     [Fact]
     public void TranslateBasicWhereAndOrderBySqlCorrect()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -4,6 +4,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests CreateTableAsSelect_ShouldCreateNewTableWithRows behavior.
+    /// PT: Testa o comportamento de CreateTableAsSelect_ShouldCreateNewTableWithRows.
+    /// </summary>
     [Fact]
     public void CreateTableAsSelect_ShouldCreateNewTableWithRows()
     {
@@ -32,6 +36,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         Assert.Equal("A", active[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertIntoSelect_ShouldInsertRowsFromQuery behavior.
+    /// PT: Testa o comportamento de InsertIntoSelect_ShouldInsertRowsFromQuery.
+    /// </summary>
     [Fact]
     public void InsertIntoSelect_ShouldInsertRowsFromQuery()
     {
@@ -59,6 +67,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         Assert.Equal("A", audit[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests UpdateJoinDerivedSelect_ShouldUpdateRows behavior.
+    /// PT: Testa o comportamento de UpdateJoinDerivedSelect_ShouldUpdateRows.
+    /// </summary>
     [Fact]
     public void UpdateJoinDerivedSelect_ShouldUpdateRows()
     {
@@ -94,6 +106,10 @@ WHERE u.tenantid = 10";
         Assert.Null(users[2][2]);
     }
 
+    /// <summary>
+    /// EN: Tests DeleteJoinDerivedSelect_ShouldDeleteRows behavior.
+    /// PT: Testa o comportamento de DeleteJoinDerivedSelect_ShouldDeleteRows.
+    /// </summary>
     [Fact]
     public void DeleteJoinDerivedSelect_ShouldDeleteRows()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdditionalBehaviorCoverageTests.cs
@@ -36,6 +36,10 @@ public sealed class SqlServerAdditionalBehaviorCoverageTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_IsNull_And_IsNotNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_IsNull_And_IsNotNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_IsNull_And_IsNotNull_ShouldWork()
     {
@@ -46,6 +50,10 @@ public sealed class SqlServerAdditionalBehaviorCoverageTests : XUnitTestBase
         Assert.Equal([1, 3], notNullIds);
     }
 
+    /// <summary>
+    /// EN: Tests Where_EqualNull_ShouldReturnNoRows behavior.
+    /// PT: Testa o comportamento de Where_EqualNull_ShouldReturnNoRows.
+    /// </summary>
     [Fact]
     public void Where_EqualNull_ShouldReturnNoRows()
     {
@@ -57,6 +65,10 @@ public sealed class SqlServerAdditionalBehaviorCoverageTests : XUnitTestBase
         Assert.Empty(ids);
     }
 
+    /// <summary>
+    /// EN: Tests LeftJoin_ShouldPreserveLeftRows_WhenNoMatch behavior.
+    /// PT: Testa o comportamento de LeftJoin_ShouldPreserveLeftRows_WhenNoMatch.
+    /// </summary>
     [Fact]
     public void LeftJoin_ShouldPreserveLeftRows_WhenNoMatch()
     {
@@ -79,6 +91,10 @@ ORDER BY u.id
         Assert.Null((object?)rows[2].amount);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_Desc_ThenAsc_ShouldBeDeterministic behavior.
+    /// PT: Testa o comportamento de OrderBy_Desc_ThenAsc_ShouldBeDeterministic.
+    /// </summary>
     [Fact]
     public void OrderBy_Desc_ThenAsc_ShouldBeDeterministic()
     {
@@ -92,6 +108,10 @@ ORDER BY amount DESC, id ASC
         Assert.Equal([200m, 50m, 10m], [.. rows.Select(r => (decimal)r.amount)]);
     }
 
+    /// <summary>
+    /// EN: Tests Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls behavior.
+    /// PT: Testa o comportamento de Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls.
+    /// </summary>
     [Fact]
     public void Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls()
     {
@@ -101,6 +121,10 @@ ORDER BY amount DESC, id ASC
         Assert.Equal(2L, (long)r.c2);
     }
 
+    /// <summary>
+    /// EN: Tests Having_ShouldFilterGroups behavior.
+    /// PT: Testa o comportamento de Having_ShouldFilterGroups.
+    /// </summary>
     [Fact]
     public void Having_ShouldFilterGroups()
     {
@@ -115,6 +139,10 @@ ORDER BY userid
         Assert.Equal([2], userIds);
     }
 
+    /// <summary>
+    /// EN: Tests Where_In_WithParameterList_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_In_WithParameterList_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_In_WithParameterList_ShouldWork()
     {
@@ -122,6 +150,10 @@ ORDER BY userid
         Assert.Equal([1, 3], ids);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_WithColumnsOutOfOrder_ShouldMapCorrectly behavior.
+    /// PT: Testa o comportamento de Insert_WithColumnsOutOfOrder_ShouldMapCorrectly.
+    /// </summary>
     [Fact]
     public void Insert_WithColumnsOutOfOrder_ShouldMapCorrectly()
     {
@@ -133,6 +165,10 @@ ORDER BY userid
         Assert.Equal("zed@x.com", (string)row.email);
     }
 
+    /// <summary>
+    /// EN: Tests Delete_WithInParameterList_ShouldDeleteMatchingRows behavior.
+    /// PT: Testa o comportamento de Delete_WithInParameterList_ShouldDeleteMatchingRows.
+    /// </summary>
     [Fact]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
@@ -143,6 +179,10 @@ ORDER BY userid
         Assert.Equal([2], remaining);
     }
 
+    /// <summary>
+    /// EN: Tests Update_SetExpression_ShouldUpdateRows behavior.
+    /// PT: Testa o comportamento de Update_SetExpression_ShouldUpdateRows.
+    /// </summary>
     [Fact]
     public void Update_SetExpression_ShouldUpdateRows()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdvancedSqlGapTests.cs
@@ -35,6 +35,10 @@ public sealed class SqlServerAdvancedSqlGapTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Window_RowNumber_PartitionBy_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
+    /// </summary>
     [Fact]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
@@ -47,6 +51,10 @@ ORDER BY tenantid, id").ToList();
         Assert.Equal([1, 2, 1], [.. rows.Select(r => (int)r.rn)]);
     }
 
+    /// <summary>
+    /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
+    /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
+    /// </summary>
     [Fact]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
@@ -59,6 +67,10 @@ ORDER BY u.id").ToList();
         Assert.Equal([15m, 7m, 0m], [.. rows.Select(r => (decimal)(r.total ?? 0m))]);
     }
 
+    /// <summary>
+    /// EN: Tests DateAdd_IntervalDay_ShouldWork behavior.
+    /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
+    /// </summary>
     [Fact]
     public void DateAdd_IntervalDay_ShouldWork()
     {
@@ -74,6 +86,10 @@ ORDER BY id").ToList();
             [.. rows.Select(r => (DateTime)r.d)]);
     }
 
+    /// <summary>
+    /// EN: Tests Cast_StringToInt_ShouldWork behavior.
+    /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
+    /// </summary>
     [Fact]
     public void Cast_StringToInt_ShouldWork()
     {
@@ -82,6 +98,10 @@ ORDER BY id").ToList();
         Assert.Equal(42, (int)rows[0].v);
     }
 
+    /// <summary>
+    /// EN: Tests Regexp_Operator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
+    /// </summary>
     [Fact]
     public void Regexp_Operator_ShouldWork()
     {
@@ -89,6 +109,10 @@ ORDER BY id").ToList();
         Assert.Equal([1, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_Field_Function_ShouldWork behavior.
+    /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
+    /// </summary>
     [Fact]
     public void OrderBy_Field_Function_ShouldWork()
     {
@@ -96,6 +120,10 @@ ORDER BY id").ToList();
         Assert.Equal([3, 1, 2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Collation_CaseSensitivity_ShouldFollowColumnCollation behavior.
+    /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
+    /// </summary>
     [Fact]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerAggregationTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerAggregationTests.cs
@@ -20,6 +20,10 @@ public sealed class SqlServerAggregationTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
+    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
+    /// </summary>
     [Fact]
     public void GroupBy_WithCountAndSum_ShouldWork()
     {
@@ -42,6 +46,10 @@ public sealed class SqlServerAggregationTests : XUnitTestBase
         Assert.Equal(5m, (decimal)rows[1].sumAmount);
     }
 
+    /// <summary>
+    /// EN: Tests Having_ShouldFilterAggregates behavior.
+    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
+    /// </summary>
     [Fact]
     public void Having_ShouldFilterAggregates()
     {
@@ -57,6 +65,10 @@ public sealed class SqlServerAggregationTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].userId);
     }
 
+    /// <summary>
+    /// EN: Tests Distinct_Order_Limit_Offset_ShouldWork behavior.
+    /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
+    /// </summary>
     [Fact]
     public void Distinct_Order_Limit_Offset_ShouldWork()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerDataParameterCollectionMockTest.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerDataParameterCollectionMockTest.cs
@@ -3,6 +3,10 @@ public sealed class SqlServerDataParameterCollectionMockTest(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames behavior.
+    /// PT: Testa o comportamento de ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames.
+    /// </summary>
     [Fact]
     public void ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames()
     {
@@ -13,6 +17,10 @@ public sealed class SqlServerDataParameterCollectionMockTest(
         Assert.Equal("id", SqlServerDataParameterCollectionMock.NormalizeParameterName("@'id'"));
     }
 
+    /// <summary>
+    /// EN: Tests ParameterCollection_Add_DuplicateName_ShouldThrow behavior.
+    /// PT: Testa o comportamento de ParameterCollection_Add_DuplicateName_ShouldThrow.
+    /// </summary>
     [Fact]
     public void ParameterCollection_Add_DuplicateName_ShouldThrow()
     {
@@ -22,6 +30,10 @@ public sealed class SqlServerDataParameterCollectionMockTest(
         Assert.Throws<ArgumentException>(() => pars.AddWithValue("@id", 2)); // case-insensitive
     }
 
+    /// <summary>
+    /// EN: Tests ParameterCollection_RemoveAt_ShouldReindexDictionary behavior.
+    /// PT: Testa o comportamento de ParameterCollection_RemoveAt_ShouldReindexDictionary.
+    /// </summary>
     [Fact]
     public void ParameterCollection_RemoveAt_ShouldReindexDictionary()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerJoinTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerJoinTests.cs
@@ -28,6 +28,10 @@ public sealed class SqlServerJoinTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests LeftJoin_ShouldKeepAllLeftRows behavior.
+    /// PT: Testa o comportamento de LeftJoin_ShouldKeepAllLeftRows.
+    /// </summary>
     [Fact]
     public void LeftJoin_ShouldKeepAllLeftRows()
     {
@@ -44,6 +48,10 @@ public sealed class SqlServerJoinTests : XUnitTestBase
         Assert.Contains(rows, r => (int)r.id == 2);
     }
 
+    /// <summary>
+    /// EN: Tests RightJoin_ShouldKeepAllRightRows behavior.
+    /// PT: Testa o comportamento de RightJoin_ShouldKeepAllRightRows.
+    /// </summary>
     [Fact]
     public void RightJoin_ShouldKeepAllRightRows()
     {
@@ -74,6 +82,10 @@ public sealed class SqlServerJoinTests : XUnitTestBase
     //    Assert.Contains(rows, r => r.id is null && (int)r.orderId == 12); // órfão
     //}
 
+    /// <summary>
+    /// EN: Tests Join_ON_WithMultipleConditions_AND_ShouldWork behavior.
+    /// PT: Testa o comportamento de Join_ON_WithMultipleConditions_AND_ShouldWork.
+    /// </summary>
     [Fact]
     public void Join_ON_WithMultipleConditions_AND_ShouldWork()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerLinqProviderTest.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerLinqProviderTest.cs
@@ -9,6 +9,10 @@ public sealed class SqlServerLinqProviderTest
     }
 #pragma warning restore CA1812
 
+    /// <summary>
+    /// EN: Tests LinqProvider_ShouldQueryWhereAndReturnRows behavior.
+    /// PT: Testa o comportamento de LinqProvider_ShouldQueryWhereAndReturnRows.
+    /// </summary>
     [Fact]
     public void LinqProvider_ShouldQueryWhereAndReturnRows()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerMockTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerMockTests.cs
@@ -24,6 +24,10 @@ public sealed class SqlServerMockTests
         _connection.Open();
     }
 
+    /// <summary>
+    /// EN: Tests TestInsert behavior.
+    /// PT: Testa o comportamento de TestInsert.
+    /// </summary>
     [Fact]
     public void TestInsert()
     {
@@ -36,6 +40,10 @@ public sealed class SqlServerMockTests
         Assert.Equal("John Doe",_connection.GetTable("Users")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TestUpdate behavior.
+    /// PT: Testa o comportamento de TestUpdate.
+    /// </summary>
     [Fact]
     public void TestUpdate()
     {
@@ -51,6 +59,10 @@ public sealed class SqlServerMockTests
         Assert.Equal("Jane Doe",_connection.GetTable("Users")[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TestDelete behavior.
+    /// PT: Testa o comportamento de TestDelete.
+    /// </summary>
     [Fact]
     public void TestDelete()
     {
@@ -66,6 +78,10 @@ public sealed class SqlServerMockTests
         Assert.Empty(_connection.GetTable("Users"));
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionCommit behavior.
+    /// PT: Testa o comportamento de TestTransactionCommit.
+    /// </summary>
     [Fact]
     public void TestTransactionCommit()
     {
@@ -97,6 +113,10 @@ public sealed class SqlServerMockTests
         Assert.Single(users);
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionCommitInsertUpdate behavior.
+    /// PT: Testa o comportamento de TestTransactionCommitInsertUpdate.
+    /// </summary>
     [Fact]
     public void TestTransactionCommitInsertUpdate()
     {
@@ -115,6 +135,10 @@ public sealed class SqlServerMockTests
         Assert.Equal("Bob", name);
     }
 
+    /// <summary>
+    /// EN: Tests TestTransactionRollback behavior.
+    /// PT: Testa o comportamento de TestTransactionRollback.
+    /// </summary>
     [Fact]
     public void TestTransactionRollback()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerSelectAndWhereMoreCoverageTests.cs
@@ -30,6 +30,10 @@ public sealed class SqlServerSelectAndWhereMoreCoverageTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_Between_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Between_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Between_ShouldWork()
     {
@@ -37,6 +41,10 @@ public sealed class SqlServerSelectAndWhereMoreCoverageTests : XUnitTestBase
         Assert.Equal([2, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_NotIn_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_NotIn_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_NotIn_ShouldWork()
     {
@@ -45,6 +53,10 @@ public sealed class SqlServerSelectAndWhereMoreCoverageTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Where_ExistsSubquery_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_ExistsSubquery_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_ExistsSubquery_ShouldWork()
     {
@@ -62,6 +74,10 @@ ORDER BY u.id").ToList();
         Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_CaseWhen_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_CaseWhen_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_CaseWhen_ShouldWork()
     {
@@ -77,6 +93,10 @@ ORDER BY id").ToList();
         Assert.Equal("Y", (string)rows[2].hasEmail);
     }
 
+    /// <summary>
+    /// EN: Tests Select_IfNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_IfNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_IfNull_ShouldWork()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerSqlCompatibilityGapTests.cs
@@ -36,6 +36,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_Precedence_AND_ShouldBindStrongerThan_OR behavior.
+    /// PT: Testa o comportamento de Where_Precedence_AND_ShouldBindStrongerThan_OR.
+    /// </summary>
     [Fact]
     public void Where_Precedence_AND_ShouldBindStrongerThan_OR()
     {
@@ -45,6 +49,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_OR_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_OR_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_OR_ShouldWork()
     {
@@ -52,6 +60,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 3], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_ParenthesesGrouping_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_ParenthesesGrouping_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_ParenthesesGrouping_ShouldWork()
     {
@@ -61,6 +73,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(2, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_Arithmetic_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_Arithmetic_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_Arithmetic_ShouldWork()
     {
@@ -68,6 +84,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([2, 3, 4], [.. rows.Select(r => (int)r.nextId)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_CASE_WHEN_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_CASE_WHEN_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_CASE_WHEN_ShouldWork()
     {
@@ -75,6 +95,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 0, 1], [.. rows.Select(r => (int)r.hasEmail)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_IF_ShouldWork behavior.
+    /// PT: Testa o comportamento de Select_Expressions_IF_ShouldWork.
+    /// </summary>
     [Fact]
     public void Select_Expressions_IF_ShouldWork()
     {
@@ -83,6 +107,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["yes", "no", "yes"], [.. rows.Select(r => (string)r.flag)]);
     }
 
+    /// <summary>
+    /// EN: Tests Select_Expressions_IIF_ShouldWork_AsAliasForIF behavior.
+    /// PT: Testa o comportamento de Select_Expressions_IIF_ShouldWork_AsAliasForIF.
+    /// </summary>
     [Fact]
     public void Select_Expressions_IIF_ShouldWork_AsAliasForIF()
     {
@@ -91,6 +119,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1, 0, 1], [.. rows.Select(r => (int)r.hasEmail)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_COALESCE_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_COALESCE_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_COALESCE_ShouldWork()
     {
@@ -98,6 +130,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["john@x.com", "none", "jane@x.com"], [.. rows.Select(r => (string)r.em)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_IFNULL_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_IFNULL_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_IFNULL_ShouldWork()
     {
@@ -105,6 +141,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["john@x.com", "none", "jane@x.com"], [.. rows.Select(r => (string)r.em)]);
     }
 
+    /// <summary>
+    /// EN: Tests Functions_CONCAT_ShouldWork behavior.
+    /// PT: Testa o comportamento de Functions_CONCAT_ShouldWork.
+    /// </summary>
     [Fact]
     public void Functions_CONCAT_ShouldWork()
     {
@@ -112,6 +152,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["John#1", "Bob#2", "Jane#3"], [.. rows.Select(r => (string)r.tag)]);
     }
 
+    /// <summary>
+    /// EN: Tests Distinct_ShouldBeConsistent behavior.
+    /// PT: Testa o comportamento de Distinct_ShouldBeConsistent.
+    /// </summary>
     [Fact]
     public void Distinct_ShouldBeConsistent()
     {
@@ -121,6 +165,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(["Bob", "Jane", "John"], [.. rows.Select(r => (string)r.name)]);
     }
 
+    /// <summary>
+    /// EN: Tests Join_ComplexOn_WithOr_ShouldWork behavior.
+    /// PT: Testa o comportamento de Join_ComplexOn_WithOr_ShouldWork.
+    /// </summary>
     [Fact]
     public void Join_ComplexOn_WithOr_ShouldWork()
     {
@@ -137,6 +185,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
             [.. rows.Select(r => ((int)r.uid,(int)r.oid))]);
     }
 
+    /// <summary>
+    /// EN: Tests GroupBy_Having_ShouldSupportAggregates behavior.
+    /// PT: Testa o comportamento de GroupBy_Having_ShouldSupportAggregates.
+    /// </summary>
     [Fact]
     public void GroupBy_Having_ShouldSupportAggregates()
     {
@@ -150,6 +202,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal(210m, (decimal)rows[0].total);
     }
 
+    /// <summary>
+    /// EN: Tests OrderBy_ShouldSupportAlias_And_Ordinal behavior.
+    /// PT: Testa o comportamento de OrderBy_ShouldSupportAlias_And_Ordinal.
+    /// </summary>
     [Fact]
     public void OrderBy_ShouldSupportAlias_And_Ordinal()
     {
@@ -161,6 +217,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([(2,"Bob"),(3,"Jane"),(1,"John")], [.. rows2.Select(r => ((int)r.id,(string)r.name))]);
     }
 
+    /// <summary>
+    /// EN: Tests Union_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_ShouldWork.
+    /// </summary>
     [Fact]
     public void Union_ShouldWork()
     {
@@ -172,6 +232,10 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
         Assert.Equal([1,2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Union_Inside_SubSelect_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
+    /// </summary>
     [Fact]
     public void Union_Inside_SubSelect_ShouldWork()
     {
@@ -186,6 +250,10 @@ ORDER BY id
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Cte_With_ShouldWork behavior.
+    /// PT: Testa o comportamento de Cte_With_ShouldWork.
+    /// </summary>
     [Fact]
     public void Cte_With_ShouldWork()
     {
@@ -195,6 +263,10 @@ ORDER BY id
         Assert.Equal([2,1], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault behavior.
+    /// PT: Testa o comportamento de Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault.
+    /// </summary>
     [Fact]
     public void Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerSubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerSubqueryFromAndJoinsTests.cs
@@ -4,6 +4,10 @@ public sealed class SqlServerSubqueryFromAndJoinsTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests FromSubquery_ShouldReturnFilteredRows behavior.
+    /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
+    /// </summary>
     [Fact]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
@@ -32,6 +36,10 @@ public sealed class SqlServerSubqueryFromAndJoinsTests(
         ids.Should().Equal(1, 3);
     }
 
+    /// <summary>
+    /// EN: Tests JoinSubquery_ShouldJoinCorrectly behavior.
+    /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
+    /// </summary>
     [Fact]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
@@ -72,6 +80,10 @@ ORDER BY u.Id, o.Amount";
         rows.Should().Equal([(1, 60m), (2, 80m)]);
     }
 
+    /// <summary>
+    /// EN: Tests NestedSubquery_ShouldWork behavior.
+    /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
+    /// </summary>
     [Fact]
     public void NestedSubquery_ShouldWork()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerTransactionTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerTransactionTests.cs
@@ -10,6 +10,10 @@ public sealed class SqlServerTransactionTests(
         public string? Email { get; set; }
     }
 
+    /// <summary>
+    /// EN: Tests TransactionCommitShouldPersistData behavior.
+    /// PT: Testa o comportamento de TransactionCommitShouldPersistData.
+    /// </summary>
     [Fact]
     public void TransactionCommitShouldPersistData()
     {
@@ -38,6 +42,10 @@ public sealed class SqlServerTransactionTests(
         Assert.Equal(user.Email, insertedRow[2]);
     }
 
+    /// <summary>
+    /// EN: Tests TransactionRollbackShouldNotPersistData behavior.
+    /// PT: Testa o comportamento de TransactionRollbackShouldNotPersistData.
+    /// </summary>
     [Fact]
     public void TransactionRollbackShouldNotPersistData()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs
@@ -22,6 +22,10 @@ public sealed class SqlServerUnionLimitAndJsonCompatibilityTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates behavior.
+    /// PT: Testa o comportamento de UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates.
+    /// </summary>
     [Fact]
     public void UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates()
     {
@@ -42,6 +46,10 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([1], [.. distinct.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests OffsetFetch_ShouldWork behavior.
+    /// PT: Testa o comportamento de OffsetFetch_ShouldWork.
+    /// </summary>
     [Fact]
     public void OffsetFetch_ShouldWork()
     {
@@ -50,6 +58,10 @@ SELECT id FROM t WHERE id = 1
         Assert.Equal([2, 3], [.. rows.Select(r => (int)r.id)]);
     }
 
+    /// <summary>
+    /// EN: Tests JsonValue_SimpleObjectPath_ShouldWork behavior.
+    /// PT: Testa o comportamento de JsonValue_SimpleObjectPath_ShouldWork.
+    /// </summary>
     [Fact]
     public void JsonValue_SimpleObjectPath_ShouldWork()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerWhereParserAndExecutorTests.cs
@@ -21,6 +21,10 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests Where_IN_ShouldFilter behavior.
+    /// PT: Testa o comportamento de Where_IN_ShouldFilter.
+    /// </summary>
     [Fact]
     public void Where_IN_ShouldFilter()
     {
@@ -30,6 +34,10 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
         Assert.Contains(rows, r => (int)r.id == 3);
     }
 
+    /// <summary>
+    /// EN: Tests Where_IsNotNull_ShouldFilter behavior.
+    /// PT: Testa o comportamento de Where_IsNotNull_ShouldFilter.
+    /// </summary>
     [Fact]
     public void Where_IsNotNull_ShouldFilter()
     {
@@ -37,6 +45,10 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(2, rows.Count);
     }
 
+    /// <summary>
+    /// EN: Tests Where_Operators_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Operators_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Operators_ShouldWork()
     {
@@ -47,6 +59,10 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal([1, 3], [.. rows2.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_Like_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_Like_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_Like_ShouldWork()
     {
@@ -55,6 +71,10 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(1, (int)rows[0].id);
     }
 
+    /// <summary>
+    /// EN: Tests Where_FindInSet_ShouldWork behavior.
+    /// PT: Testa o comportamento de Where_FindInSet_ShouldWork.
+    /// </summary>
     [Fact]
     public void Where_FindInSet_ShouldWork()
     {
@@ -63,6 +83,10 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id).Order()]);
     }
 
+    /// <summary>
+    /// EN: Tests Where_AND_ShouldBeCaseInsensitive_InRealLife behavior.
+    /// PT: Testa o comportamento de Where_AND_ShouldBeCaseInsensitive_InRealLife.
+    /// </summary>
     [Fact]
     public void Where_AND_ShouldBeCaseInsensitive_InRealLife()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlValueHelperTests .cs
@@ -6,6 +6,10 @@ public sealed class SqlValueHelperTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Resolve_ShouldReadDapperParameter_ByName behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_ByName.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldReadDapperParameter_ByName()
     {
@@ -22,6 +26,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(123, v);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_ShouldThrow_WhenParameterMissing behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldThrow_WhenParameterMissing()
     {
@@ -29,6 +37,10 @@ public sealed class SqlValueHelperTests(
             SqlServerValueHelper.Resolve("@p404", DbType.Int32, isNullable: false, pars: null, colDict: null));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_ShouldParseInList_ToListOfResolvedValues behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldParseInList_ToListOfResolvedValues.
+    /// </summary>
     [Fact]
     public void Resolve_ShouldParseInList_ToListOfResolvedValues()
     {
@@ -38,6 +50,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal([1, 2, 3], [.. list.Cast<int>()]);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_NullOnNonNullable_ShouldThrow behavior.
+    /// PT: Testa o comportamento de Resolve_NullOnNonNullable_ShouldThrow.
+    /// </summary>
     [Fact]
     public void Resolve_NullOnNonNullable_ShouldThrow()
     {
@@ -45,6 +61,10 @@ public sealed class SqlValueHelperTests(
             SqlServerValueHelper.Resolve("null", DbType.Int32, isNullable: false, pars: null, colDict: null));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Json_ShouldReturnJsonDocument_WhenValid behavior.
+    /// PT: Testa o comportamento de Resolve_Json_ShouldReturnJsonDocument_WhenValid.
+    /// </summary>
     [Fact]
     public void Resolve_Json_ShouldReturnJsonDocument_WhenValid()
     {
@@ -54,6 +74,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(1, doc.RootElement.GetProperty("a").GetInt32());
     }
 
+    /// <summary>
+    /// EN: Tests Like_ShouldMatch_MySqlStyle behavior.
+    /// PT: Testa o comportamento de Like_ShouldMatch_MySqlStyle.
+    /// </summary>
     [Theory]
     [InlineData("John", "%oh%", true)]
     [InlineData("John", "J_hn", true)]
@@ -65,6 +89,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(expected, SqlServerValueHelper.Like(value, pattern));
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Enum_ShouldValidateAgainstColumnDef behavior.
+    /// PT: Testa o comportamento de Resolve_Enum_ShouldValidateAgainstColumnDef.
+    /// </summary>
     [Fact]
     public void Resolve_Enum_ShouldValidateAgainstColumnDef()
     {
@@ -84,6 +112,10 @@ public sealed class SqlValueHelperTests(
         Assert.Equal(1265, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests Resolve_Set_ShouldReturnHashSet_AndValidate behavior.
+    /// PT: Testa o comportamento de Resolve_Set_ShouldReturnHashSet_AndValidate.
+    /// </summary>
     [Fact]
     public void Resolve_Set_ShouldReturnHashSet_AndValidate()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/StoredProcedureExecutionTests.cs
@@ -16,6 +16,10 @@ public sealed class StoredProcedureExecutionTests(
             Direction = dir
         };
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs()
     {
@@ -52,6 +56,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, affected);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput()
     {
@@ -86,6 +94,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(1318, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull()
     {
@@ -120,6 +132,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(1048, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue()
     {
@@ -163,6 +179,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, ((SqlParameter)cmd.Parameters["@o_status"]).Value);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset behavior.
+    /// PT: Testa o comportamento de ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset.
+    /// </summary>
     [Fact]
     public void ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset()
     {
@@ -192,6 +212,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.False(r.Read());
     }
 
+    /// <summary>
+    /// EN: Tests DapperExecute_CommandTypeStoredProcedure_ShouldWork behavior.
+    /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldWork.
+    /// </summary>
     [Fact]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldWork()
     {
@@ -221,6 +245,10 @@ public sealed class StoredProcedureExecutionTests(
         Assert.Equal(0, affected);
     }
 
+    /// <summary>
+    /// EN: Tests DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam behavior.
+    /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam.
+    /// </summary>
     [Fact]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/StoredProcedureSignatureTests.cs
@@ -4,6 +4,10 @@ public sealed class StoredProcedureSignatureTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests StoredProcedure_ShouldValidateRequiredInAndOutParams behavior.
+    /// PT: Testa o comportamento de StoredProcedure_ShouldValidateRequiredInAndOutParams.
+    /// </summary>
     [Fact]
     public void StoredProcedure_ShouldValidateRequiredInAndOutParams()
     {
@@ -31,6 +35,10 @@ public sealed class StoredProcedureSignatureTests(
             CultureInfo.InvariantCulture));
     }
 
+    /// <summary>
+    /// EN: Tests StoredProcedure_ShouldThrowWhenMissingRequiredParam behavior.
+    /// PT: Testa o comportamento de StoredProcedure_ShouldThrowWhenMissingRequiredParam.
+    /// </summary>
     [Fact]
     public void StoredProcedure_ShouldThrowWhenMissingRequiredParam()
     {
@@ -50,6 +58,10 @@ public sealed class StoredProcedureSignatureTests(
         Assert.Equal(1318, ex.ErrorCode);
     }
 
+    /// <summary>
+    /// EN: Tests CallStatement_ShouldValidateAgainstRegisteredProcedure behavior.
+    /// PT: Testa o comportamento de CallStatement_ShouldValidateAgainstRegisteredProcedure.
+    /// </summary>
     [Fact]
     public void CallStatement_ShouldValidateAgainstRegisteredProcedure()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs
@@ -4,6 +4,10 @@ public sealed class SqlServerCommandDeleteTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_remove_1_linha behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_1_linha.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_remove_1_linha()
     {
@@ -23,6 +27,10 @@ public sealed class SqlServerCommandDeleteTests(
         Assert.Equal(1, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_remove_varias_linhas behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_varias_linhas.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_remove_varias_linhas()
     {
@@ -43,6 +51,10 @@ public sealed class SqlServerCommandDeleteTests(
         Assert.Equal(2, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0 behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0()
     {
@@ -60,6 +72,10 @@ public sealed class SqlServerCommandDeleteTests(
         Assert.Equal(0, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_tabela_inexistente_dispara behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_tabela_inexistente_dispara.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_tabela_inexistente_dispara()
     {
@@ -71,6 +87,10 @@ public sealed class SqlServerCommandDeleteTests(
         Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara.
+    /// </summary>
     [Fact(Skip = "Isso é valido no SqlServer")]
     public void ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara()
     {
@@ -86,6 +106,10 @@ public sealed class SqlServerCommandDeleteTests(
         Assert.Contains("delete", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia()
     {
@@ -108,6 +132,10 @@ public sealed class SqlServerCommandDeleteTests(
         Assert.Equal(0, conn.Metrics.Deletes);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false.
+    /// </summary>
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -126,6 +154,10 @@ public sealed class SqlServerCommandDeleteTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_case_insensitive behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_case_insensitive.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_case_insensitive()
     {
@@ -142,6 +174,10 @@ public sealed class SqlServerCommandDeleteTests(
         Assert.Empty(table);
     }
 
+    /// <summary>
+    /// EN: Tests ExecuteNonQuery_DELETE_com_parametro_se_suportado behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_com_parametro_se_suportado.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_DELETE_com_parametro_se_suportado()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertOnDuplicateTests.cs
@@ -2,6 +2,10 @@ namespace DbSqlLikeMem.SqlServer.Test.Strategy;
 
 public sealed class SqlServerMergeUpsertTests(ITestOutputHelper helper) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Merge_ShouldInsert_WhenNotMatched behavior.
+    /// PT: Testa o comportamento de Merge_ShouldInsert_WhenNotMatched.
+    /// </summary>
     [Fact]
     public void Merge_ShouldInsert_WhenNotMatched()
     {
@@ -29,6 +33,10 @@ WHEN NOT MATCHED THEN
         Assert.Equal("A", (string)t[0][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests Merge_ShouldUpdate_WhenMatched behavior.
+    /// PT: Testa o comportamento de Merge_ShouldUpdate_WhenMatched.
+    /// </summary>
     [Fact]
     public void Merge_ShouldUpdate_WhenMatched()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyCoverageTests.cs
@@ -4,6 +4,10 @@ public sealed class SqlServerInsertStrategyCoverageTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Insert_MultiRowValues_ShouldInsertAllRows behavior.
+    /// PT: Testa o comportamento de Insert_MultiRowValues_ShouldInsertAllRows.
+    /// </summary>
     [Fact]
     public void Insert_MultiRowValues_ShouldInsertAllRows()
     {
@@ -28,6 +32,10 @@ public sealed class SqlServerInsertStrategyCoverageTests(
         Assert.Equal("B", (string)t[1][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests Insert_WithIdentityColumnOmitted_ShouldAutoIncrement behavior.
+    /// PT: Testa o comportamento de Insert_WithIdentityColumnOmitted_ShouldAutoIncrement.
+    /// </summary>
     [Fact]
     public void Insert_WithIdentityColumnOmitted_ShouldAutoIncrement()
     {
@@ -54,6 +62,10 @@ public sealed class SqlServerInsertStrategyCoverageTests(
         Assert.Equal("B", (string)t[1][1]!);
     }
 
+    /// <summary>
+    /// EN: Tests InsertSelect_ShouldInsertRowsFromSelect behavior.
+    /// PT: Testa o comportamento de InsertSelect_ShouldInsertRowsFromSelect.
+    /// </summary>
     [Fact]
     public void InsertSelect_ShouldInsertRowsFromSelect()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyExtrasTests.cs
@@ -3,6 +3,10 @@ public sealed class SqlServerInsertStrategyExtrasTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests MultiRowInsertShouldAddAllRows behavior.
+    /// PT: Testa o comportamento de MultiRowInsertShouldAddAllRows.
+    /// </summary>
     [Fact]
     public void MultiRowInsertShouldAddAllRows()
     {
@@ -26,6 +30,10 @@ public sealed class SqlServerInsertStrategyExtrasTests(
         Assert.Equal("B", table[1][1]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertWithDefaultValueAndIdentityShouldApplyDefaults behavior.
+    /// PT: Testa o comportamento de InsertWithDefaultValueAndIdentityShouldApplyDefaults.
+    /// </summary>
     [Fact]
     public void InsertWithDefaultValueAndIdentityShouldApplyDefaults()
     {
@@ -53,6 +61,10 @@ public sealed class SqlServerInsertStrategyExtrasTests(
         Assert.Equal(2, table[1][0]);
     }
 
+    /// <summary>
+    /// EN: Tests InsertDuplicatePrimaryKeyShouldThrow behavior.
+    /// PT: Testa o comportamento de InsertDuplicatePrimaryKeyShouldThrow.
+    /// </summary>
     [Fact]
     public void InsertDuplicatePrimaryKeyShouldThrow()
     {
@@ -74,12 +86,16 @@ public sealed class SqlServerInsertStrategyExtrasTests(
     }
 }
 
-/// <summary>
-/// EN: Tests delete strategy behavior with foreign keys.
-/// PT: Testes do comportamento da estratégia de delete com chaves estrangeiras.
-/// </summary>
+    /// <summary>
+    /// EN: Tests delete strategy behavior with foreign keys.
+    /// PT: Testes do comportamento da estratégia de delete com chaves estrangeiras.
+    /// </summary>
 public class SqlServerDeleteStrategyForeignKeyTests
 {
+    /// <summary>
+    /// EN: Tests DeleteReferencedRowShouldThrow behavior.
+    /// PT: Testa o comportamento de DeleteReferencedRowShouldThrow.
+    /// </summary>
     [Fact]
     public void DeleteReferencedRowShouldThrow()
     {
@@ -109,12 +125,16 @@ public class SqlServerDeleteStrategyForeignKeyTests
     }
 }
 
-/// <summary>
-/// EN: Extra tests for update strategy behavior.
-/// PT: Testes extras do comportamento da estratégia de update.
-/// </summary>
+    /// <summary>
+    /// EN: Extra tests for update strategy behavior.
+    /// PT: Testes extras do comportamento da estratégia de update.
+    /// </summary>
 public class SqlServerUpdateStrategyExtrasTests
 {
+    /// <summary>
+    /// EN: Tests UpdateMultipleConditionsShouldOnlyAffectMatchingRows behavior.
+    /// PT: Testa o comportamento de UpdateMultipleConditionsShouldOnlyAffectMatchingRows.
+    /// </summary>
     [Fact]
     public void UpdateMultipleConditionsShouldOnlyAffectMatchingRows()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyTests.cs
@@ -3,6 +3,10 @@ public sealed class SqlServerInsertStrategyTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests InsertIntoTableShouldAddNewRow behavior.
+    /// PT: Testa o comportamento de InsertIntoTableShouldAddNewRow.
+    /// </summary>
     [Fact]
     public void InsertIntoTableShouldAddNewRow()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTransactionTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTransactionTests.cs
@@ -3,6 +3,10 @@ public sealed class SqlServerTransactionTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests TransactionShouldCommit behavior.
+    /// PT: Testa o comportamento de TransactionShouldCommit.
+    /// </summary>
     [Fact]
     public void TransactionShouldCommit()
     {
@@ -33,6 +37,10 @@ public sealed class SqlServerTransactionTests(
         Assert.Equal("John Doe", table[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests TransactionShouldRollback behavior.
+    /// PT: Testa o comportamento de TransactionShouldRollback.
+    /// </summary>
     [Fact]
     public void TransactionShouldRollback()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyCoverageTests.cs
@@ -4,6 +4,10 @@ public sealed class SqlServerUpdateStrategyCoverageTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests Update_SetNullableColumnToNull_ShouldWork behavior.
+    /// PT: Testa o comportamento de Update_SetNullableColumnToNull_ShouldWork.
+    /// </summary>
     [Fact]
     public void Update_SetNullableColumnToNull_ShouldWork()
     {
@@ -25,6 +29,10 @@ public sealed class SqlServerUpdateStrategyCoverageTests(
         Assert.Null(users[0][1]);
     }
 
+    /// <summary>
+    /// EN: Tests Update_SetNotNullableColumnToNull_ShouldThrow behavior.
+    /// PT: Testa o comportamento de Update_SetNotNullableColumnToNull_ShouldThrow.
+    /// </summary>
     [Fact]
     public void Update_SetNotNullableColumnToNull_ShouldThrow()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs
@@ -4,6 +4,10 @@ public sealed class SqlServerUpdateStrategyTests(
     ITestOutputHelper helper
 ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests UpdateTableShouldModifyExistingRow behavior.
+    /// PT: Testa o comportamento de UpdateTableShouldModifyExistingRow.
+    /// </summary>
     [Fact]
     public void UpdateTableShouldModifyExistingRow()
     {
@@ -28,6 +32,10 @@ public sealed class SqlServerUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldReturnZero_WhenNoRowsMatchWhere behavior.
+    /// PT: Testa o comportamento de Update_ShouldReturnZero_WhenNoRowsMatchWhere.
+    /// </summary>
     [Fact]
     public void Update_ShouldReturnZero_WhenNoRowsMatchWhere()
     {
@@ -49,6 +57,10 @@ public sealed class SqlServerUpdateStrategyTests(
         Assert.Equal(0, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple behavior.
+    /// PT: Testa o comportamento de Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple.
+    /// </summary>
     [Fact]
     public void Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple()
     {
@@ -73,6 +85,10 @@ public sealed class SqlServerUpdateStrategyTests(
         Assert.Equal(2, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldHandleWhereWithAnd_CaseInsensitive behavior.
+    /// PT: Testa o comportamento de Update_ShouldHandleWhereWithAnd_CaseInsensitive.
+    /// </summary>
     [Fact]
     public void Update_ShouldHandleWhereWithAnd_CaseInsensitive()
     {
@@ -97,6 +113,10 @@ public sealed class SqlServerUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldUpdateMultipleSetPairs behavior.
+    /// PT: Testa o comportamento de Update_ShouldUpdateMultipleSetPairs.
+    /// </summary>
     [Fact]
     public void Update_ShouldUpdateMultipleSetPairs()
     {
@@ -118,6 +138,10 @@ public sealed class SqlServerUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords behavior.
+    /// PT: Testa o comportamento de Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords.
+    /// </summary>
     [Fact]
     public void Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords()
     {
@@ -138,6 +162,10 @@ public sealed class SqlServerUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldWork_WithThreadSafeTrueOrFalse behavior.
+    /// PT: Testa o comportamento de Update_ShouldWork_WithThreadSafeTrueOrFalse.
+    /// </summary>
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -160,6 +188,10 @@ public sealed class SqlServerUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldThrow_WhenTableDoesNotExist behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrow_WhenTableDoesNotExist.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrow_WhenTableDoesNotExist()
     {
@@ -174,6 +206,10 @@ public sealed class SqlServerUpdateStrategyTests(
         Assert.Contains("does not exist", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken()
     {
@@ -191,6 +227,10 @@ public sealed class SqlServerUpdateStrategyTests(
         Assert.Contains("upd", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull behavior.
+    /// PT: Testa o comportamento de Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull.
+    /// </summary>
     [Fact]
     public void Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull()
     {
@@ -212,6 +252,10 @@ public sealed class SqlServerUpdateStrategyTests(
         Assert.Equal(1, connection.Metrics.Updates);
     }
 
+    /// <summary>
+    /// EN: Tests Update_ShouldSupportParameter_IfSqlValueHelperSupports behavior.
+    /// PT: Testa o comportamento de Update_ShouldSupportParameter_IfSqlValueHelperSupports.
+    /// </summary>
     [Fact]
     public void Update_ShouldSupportParameter_IfSqlValueHelperSupports()
     {
@@ -242,6 +286,10 @@ public sealed class SqlServerUpdateStrategyTests(
     // Opcional: testar ValidateUnique (preciso do IndexDef real)
     // ============================================================
     //
+    /// <summary>
+    /// EN: Tests Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides behavior.
+    /// PT: Testa o comportamento de Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides.
+    /// </summary>
     [Fact]
     public void Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/SubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SubqueryFromAndJoinsTests.cs
@@ -4,6 +4,10 @@ public sealed class SubqueryFromAndJoinsTests(
         ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests FromSubquery_ShouldReturnFilteredRows behavior.
+    /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
+    /// </summary>
     [Fact]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
@@ -32,6 +36,10 @@ public sealed class SubqueryFromAndJoinsTests(
         ids.Should().Equal(1, 3);
     }
 
+    /// <summary>
+    /// EN: Tests JoinSubquery_ShouldJoinCorrectly behavior.
+    /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
+    /// </summary>
     [Fact]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
@@ -72,6 +80,10 @@ ORDER BY u.Id, o.Amount";
         rows.Should().Equal([(1, 60m), (2, 80m)]);
     }
 
+    /// <summary>
+    /// EN: Tests NestedSubquery_ShouldWork behavior.
+    /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
+    /// </summary>
     [Fact]
     public void NestedSubquery_ShouldWork()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/TemporaryTable/SqlServerTemporaryTableEngineTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/TemporaryTable/SqlServerTemporaryTableEngineTests.cs
@@ -4,6 +4,10 @@ public sealed class SqlServerTemporaryTableEngineTests
 {
     private static readonly int[] expected = [1, 2];
 
+    /// <summary>
+    /// EN: Tests CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows behavior.
+    /// PT: Testa o comportamento de CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows.
+    /// </summary>
     [Fact]
     public void CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/TemporaryTable/SqlServerTemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/TemporaryTable/SqlServerTemporaryTableParserTests.cs
@@ -2,6 +2,10 @@ namespace DbSqlLikeMem.SqlServer.Test.TemporaryTable;
 
 public sealed class SqlServerTemporaryTableParserTests
 {
+    /// <summary>
+    /// EN: Tests ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect behavior.
+    /// PT: Testa o comportamento de ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect(int version)
@@ -49,6 +53,10 @@ WHERE tenantid = 10",
         };
     }
 
+    /// <summary>
+    /// EN: Tests Parse_ShouldAccept_CreateTemporaryTable_Variants behavior.
+    /// PT: Testa o comportamento de Parse_ShouldAccept_CreateTemporaryTable_Variants.
+    /// </summary>
     [Theory]
     [MemberDataBySqlServerVersion(nameof(CreateTempTableStatements))]
     public void Parse_ShouldAccept_CreateTemporaryTable_Variants(string sql, int version)

--- a/src/DbSqlLikeMem.SqlServer.Test/Views/SqlServerCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Views/SqlServerCreateViewEngineTests.cs
@@ -28,6 +28,10 @@ public sealed class SqlServerCreateViewEngineTests : XUnitTestBase
         _cnn.Open();
     }
 
+    /// <summary>
+    /// EN: Tests CreateView_ThenSelectFromView_ShouldReturnExpectedRows behavior.
+    /// PT: Testa o comportamento de CreateView_ThenSelectFromView_ShouldReturnExpectedRows.
+    /// </summary>
     [Fact]
     public void CreateView_ThenSelectFromView_ShouldReturnExpectedRows()
     {
@@ -41,6 +45,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal(["John", "Bob" ], rows.Select(r => (string)r["name"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_IsNotMaterialized_ShouldReflectBaseTableChanges behavior.
+    /// PT: Testa o comportamento de View_IsNotMaterialized_ShouldReflectBaseTableChanges.
+    /// </summary>
     [Fact]
     public void View_IsNotMaterialized_ShouldReflectBaseTableChanges()
     {
@@ -53,6 +61,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([1, 2, 3, 4], rows.Select(r => (int)r["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests CreateOrReplaceView_ShouldChangeDefinition behavior.
+    /// PT: Testa o comportamento de CreateOrReplaceView_ShouldChangeDefinition.
+    /// </summary>
     [Fact]
     public void CreateOrReplaceView_ShouldChangeDefinition()
     {
@@ -65,6 +77,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([3], r2.Select(x => (int)x["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_NameShouldShadowTable_WhenSameName behavior.
+    /// PT: Testa o comportamento de View_NameShouldShadowTable_WhenSameName.
+    /// </summary>
     [Fact]
     public void View_NameShouldShadowTable_WhenSameName()
     {
@@ -82,6 +98,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal(1, (int)rows[0]["id"]!);
     }
 
+    /// <summary>
+    /// EN: Tests View_CanReferenceAnotherView behavior.
+    /// PT: Testa o comportamento de View_CanReferenceAnotherView.
+    /// </summary>
     [Fact]
     public void View_CanReferenceAnotherView()
     {
@@ -92,6 +112,10 @@ SELECT id, name FROM users WHERE tenantid = 10;
         Assert.Equal([2], rows.Select(r => (int)r["id"]!).ToArray());
     }
 
+    /// <summary>
+    /// EN: Tests View_WithJoinAndAggregation_ShouldWork behavior.
+    /// PT: Testa o comportamento de View_WithJoinAndAggregation_ShouldWork.
+    /// </summary>
     [Fact]
     public void View_WithJoinAndAggregation_ShouldWork()
     {
@@ -112,6 +136,10 @@ GROUP BY u.id;
         Assert.True(rows[2]["total"] is null);
     }
 
+    /// <summary>
+    /// EN: Tests CreateView_ExistingNameWithoutOrReplace_ShouldThrow behavior.
+    /// PT: Testa o comportamento de CreateView_ExistingNameWithoutOrReplace_ShouldThrow.
+    /// </summary>
     [Fact]
     public void CreateView_ExistingNameWithoutOrReplace_ShouldThrow()
     {
@@ -119,6 +147,10 @@ GROUP BY u.id;
         Assert.ThrowsAny<Exception>(() => _cnn.ExecNonQuery("CREATE VIEW vdup AS SELECT 2 AS x ;"));
     }
 
+    /// <summary>
+    /// EN: Tests DropView_ShouldRemoveDefinition behavior.
+    /// PT: Testa o comportamento de DropView_ShouldRemoveDefinition.
+    /// </summary>
     [Fact(Skip = "MySQL: DROP VIEW faz parte do ciclo de vida. Implementar depois.")]
     public void DropView_ShouldRemoveDefinition()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Views/SqlServerCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Views/SqlServerCreateViewParserTests.cs
@@ -4,6 +4,10 @@ public sealed class SqlServerCreateViewParserTests(
     ITestOutputHelper helper
     ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Tests ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements behavior.
+    /// PT: Testa o comportamento de ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements(int version)
@@ -27,6 +31,10 @@ SELECT * FROM v_users;
         Assert.Contains("users", cv.Select.Table?.Name, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateOrReplaceView_ShouldSetFlag behavior.
+    /// PT: Testa o comportamento de Parse_CreateOrReplaceView_ShouldSetFlag.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Parse_CreateOrReplaceView_ShouldSetFlag(int version)
@@ -38,6 +46,10 @@ SELECT * FROM v_users;
         Assert.Equal("v", cv.Table?.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames(int version)
@@ -48,6 +60,10 @@ SELECT * FROM v_users;
         Assert.Equal(["a", "b"], cv.ColumnNames);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_WithBackticks_ShouldWork behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_WithBackticks_ShouldWork.
+    /// </summary>
     [Theory]
     [MemberDataSqlServerVersion]
     public void Parse_CreateView_WithBackticks_ShouldWork(int version)
@@ -58,6 +74,10 @@ SELECT * FROM v_users;
         Assert.Equal("v", cv.Table?.Name);
     }
 
+    /// <summary>
+    /// EN: Tests Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec behavior.
+    /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec.
+    /// </summary>
     [Theory(Skip = "MySQL não suporta IF NOT EXISTS em CREATE VIEW. O mock aceita por conveniência; habilite se quiser comportamento estrito.")]
     [MemberDataSqlServerVersion]
     public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec(int version)


### PR DESCRIPTION
### Motivation
- Improve test code documentation and IDE/tooling support by adding consistent XML summaries for every xUnit test method. 
- Ensure summaries exist in both English and Portuguese so the repository is easier to navigate and review in multilingual contexts.

### Description
- Insert XML `<summary>` blocks immediately above `[Fact]`/`[Theory]` attribute blocks across the MySql, Npgsql, Oracle, and SqlServer test projects, using the pattern `EN: Tests <MethodName> behavior.` and `PT: Testa o comportamento de <MethodName>.`.
- Normalize placement and indentation so each test has a single aligned summary block and avoid duplicate/misaligned summary fragments near attribute lists.
- Changes touch the test suites and parser/engine tests to keep the documentation consistent across ~160 test files.

### Testing
- Ran an automated script that scanned all test files, inserted missing XML summaries, and re-scanned the codebase; the verification reported zero test methods missing summaries (success).
- No unit test suites were executed as part of this change (no test runner was invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a7956313c832c8cb61d0c751977d6)