### PR TITLE
Docs: clarify NuGet package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Then add references to:
 - `DbSqlLikeMem.dll`
 - One provider DLL (e.g., `DbSqlLikeMem.SqlServer.dll`)
 
+### NuGet packages and dependencies
+
+Each provider ships as its own NuGet package (e.g., `DbSqlLikeMem.MySql`, `DbSqlLikeMem.Npgsql`, etc.). The provider projects reference the core project (`DbSqlLikeMem`) via `ProjectReference`, so when you run `dotnet pack` the resulting provider `.nupkg` includes a dependency on the core package. When you install a provider package from nuget.org, NuGet will automatically install `DbSqlLikeMem` as a dependency.
+
 ## Registering the provider DLL (choosing a database at runtime)
 
 When the database is chosen by the user at runtime, load the corresponding provider assembly and create its connection mock. A simple factory approach looks like this:


### PR DESCRIPTION
### Motivation
- Clarify how provider NuGet packages are published and whether installing a provider (for example, `DbSqlLikeMem.MySql`) will pull in the core package `DbSqlLikeMem` automatically.

### Description
- Add a `NuGet packages and dependencies` paragraph to `README.md` explaining that each provider ships as its own NuGet package, provider projects reference the core via `ProjectReference`, and `dotnet pack` produces provider `.nupkg` files that include a dependency on `DbSqlLikeMem` so NuGet will install the core package when a provider is installed.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a84c691c0832c850236cc7326b7c7)