### PR TITLE
Route Npgsql UPDATE/DELETE through join-aware strategies and support EXCLUDED in ON CONFLICT

### DIFF
--- a/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
@@ -83,8 +83,8 @@ public class NpgsqlCommandMock(
         return query switch
         {
             SqlInsertQuery insertQ => connection.ExecuteInsert(insertQ, Parameters, connection.Db.Dialect),
-            SqlUpdateQuery updateQ => connection.ExecuteUpdate(updateQ, Parameters),
-            SqlDeleteQuery deleteQ => connection.ExecuteDelete(deleteQ, Parameters),
+            SqlUpdateQuery updateQ => connection.ExecuteUpdateSmart(updateQ, Parameters, connection.Db.Dialect),
+            SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
             SqlCreateTemporaryTableQuery tempQ => connection.ExecuteCreateTemporaryTableAsSelect(tempQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery viewQ => connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect),
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
@@ -141,10 +141,10 @@ public class NpgsqlCommandMock(
                     connection.ExecuteInsert(insertQ, Parameters, connection.Db.Dialect);
                     break;
                 case SqlUpdateQuery updateQ:
-                    connection.ExecuteUpdate(updateQ, Parameters);
+                    connection.ExecuteUpdateSmart(updateQ, Parameters, connection.Db.Dialect);
                     break;
                 case SqlDeleteQuery deleteQ:
-                    connection.ExecuteDelete(deleteQ, Parameters);
+                    connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect);
                     break;
                 case SqlCreateTemporaryTableQuery tempQ:
                     connection.ExecuteCreateTemporaryTableAsSelect(tempQ, Parameters, connection.Db.Dialect);


### PR DESCRIPTION
### Motivation
- Fix incorrect behavior when executing MySQL/Postgres-style `UPDATE ... JOIN (...)` and `DELETE ... JOIN (...)` through the Npgsql command path so derived-join update/delete tests succeed.
- Ensure `ON CONFLICT ... DO UPDATE` uses the PostgreSQL `EXCLUDED` values when referenced so upsert tests report the updated value instead of the old one.

### Description
- Route Npgsql update and delete execution via the join-aware strategies by calling `ExecuteUpdateSmart` and `ExecuteDeleteSmart` from `NpgsqlCommandMock` instead of the non-join-aware `ExecuteUpdate`/`ExecuteDelete` (`src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs`).
- Support `EXCLUDED` references during `ON CONFLICT DO UPDATE` evaluation by resolving `excluded.col` qualifier and dotted `IdentifierExpr` forms to the inserted row values in the `Eval` used by `DbInsertStrategy` (`src/DbSqlLikeMem/Strategies/DbInsertStrategy.cs`).
- Added helper `TryGetExcludedValueFromName` to detect `excluded.x` in identifier text and return the proper inserted value when evaluating conflict-assignment expressions.

### Testing
- No automated tests were executed in this change; CI/local unit tests were not run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8f0d2214832c81a41ac7073e816f)