### PR TITLE
Fix SQL Server JSON_VALUE extraction and MERGE match coercion

### DIFF
--- a/src/DbSqlLikeMem/Strategies/DbMergeStrategy.cs
+++ b/src/DbSqlLikeMem/Strategies/DbMergeStrategy.cs
@@ -98,8 +98,9 @@ internal static class DbMergeStrategy
                 srcValues[colName] = srcRow.TryGetValue(i, out var v) ? v : null;
             }
 
-            srcValues.TryGetValue(sourceJoinColumn, out var srcKey);
+            srcValues.TryGetValue(sourceJoinColumn, out var srcKeyRaw);
             var targetCol = table.GetColumn(targetJoinColumn);
+            var srcKey = CoerceToColumnType(srcKeyRaw, targetCol.DbType);
             var existingIndex = FindRowIndex(table, targetCol.Index, srcKey);
 
             if (existingIndex >= 0)


### PR DESCRIPTION
### Motivation
- Dois testes falharam porque `JSON_VALUE(...)` não estava sendo reconhecido/avaliado e o `MERGE` não encontrava a linha existente por diferença de tipo, levando a tentativa de inserir uma PK duplicada. 
- Objetivo é alinhar o comportamento JSON com `JSON_EXTRACT` e garantir comparação de chaves consistente no `MERGE` para bancos SQL Server.

### Description
- Adiciona suporte a `JSON_VALUE(...)` em `AstQueryExecutorBase` reutilizando a mesma lógica de leitura de path JSON. (`src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs`).
- Extrai a navegação do path JSON para o helper `TryReadJsonPathValue` para unificar comportamento entre `JSON_EXTRACT` e `JSON_VALUE`. (`src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs`).
- Coerce a chave de junção de origem para o tipo da coluna alvo antes de procurar a linha existente no `MERGE`, evitando não-detecções e inserts duplicados de PK. (`src/DbSqlLikeMem/Strategies/DbMergeStrategy.cs`).

### Testing
- Tentei executar os testes filtrados para `SqlServerUnionLimitAndJsonCompatibilityTests.JsonValue_SimpleObjectPath_ShouldWork` e `SqlServerMergeUpsertTests.Merge_ShouldUpdate_WhenMatched` com `dotnet test ... --filter ...`, porém o ambiente não possui o `dotnet` instalado (`bash: command not found: dotnet`), então os testes não puderam ser executados aqui.
- As alterações foram aplicadas e commitadas localmente; validação automatizada não pôde ser concluída neste ambiente por falta do runtime de testes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9543dba4832c97a60b336c53735e)