### PR TITLE
Fix Oracle UPDATE/DELETE JOIN derived-select behavior

### DIFF
--- a/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
@@ -107,8 +107,8 @@ public class OracleCommandMock(
         return query switch
         {
             SqlInsertQuery insertQ => connection.ExecuteInsert(insertQ, Parameters, connection.Db.Dialect),
-            SqlUpdateQuery updateQ => connection.ExecuteUpdate(updateQ, Parameters),
-            SqlDeleteQuery deleteQ => connection.ExecuteDelete(deleteQ, Parameters),
+            SqlUpdateQuery updateQ => connection.ExecuteUpdateSmart(updateQ, Parameters, connection.Db.Dialect),
+            SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
             _ => throw new NotSupportedException($"Tipo de query não suportado em ExecuteNonQuery: {query.GetType().Name}")
         };

--- a/src/DbSqlLikeMem.Oracle/OracleDialect.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDialect.cs
@@ -77,7 +77,7 @@ internal sealed class OracleDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsDeleteTargetAlias => false;
+    public override bool SupportsDeleteTargetAlias => true;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>


### PR DESCRIPTION
### Motivation
- Fix failing Oracle tests where `UPDATE` with JOIN/derived-select tried to parse expressions like `s.total` as literals and `DELETE u FROM ...` was rejected by the parser.
- Ensure Oracle command execution uses the dialect-aware "smart" strategies for JOIN/derived-select DML so semantics match other dialect implementations.

### Description
- Dispatch `UPDATE` and `DELETE` in `OracleCommandMock.ExecuteNonQuery` to `ExecuteUpdateSmart` and `ExecuteDeleteSmart` respectively so execution receives the dialect and raw SQL for smart handling (`src/DbSqlLikeMem.Oracle/OracleCommandMock.cs`).
- Enable parsing of `DELETE <alias> FROM ...` patterns for Oracle by setting `SupportsDeleteTargetAlias` to `true` in `OracleDialect` (`src/DbSqlLikeMem.Oracle/OracleDialect.cs`).

### Testing
- Attempted to run the targeted test suite with `dotnet test` for `SelectIntoInsertSelectUpdateDeleteFromSelectTests`, but the environment lacks `dotnet` and the command failed (`bash: command not found: dotnet`).
- No automated tests could be executed successfully in this environment due to the missing .NET runtime/tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a981b6e34832c999cb898e3ba7f9f)