### PR TITLE
Fix Oracle ExecuteReader handling for temporary table batches

### DIFF
--- a/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
@@ -150,12 +150,38 @@ public class OracleCommandMock(
         }
 
         var queries = SqlQueryParser.ParseMulti(sql, connection.Db.Dialect).ToList();
-        var selectQueries = queries.OfType<SqlSelectQuery>().ToList();
+        var tables = new List<TableResultMock>();
 
-        if (selectQueries.Count == 0 && queries.Count > 0)
+        foreach (var query in queries)
+        {
+            switch (query)
+            {
+                case SqlSelectQuery selectQ:
+                    tables.Add(executor.ExecuteSelect(selectQ));
+                    break;
+                case SqlInsertQuery insertQ:
+                    connection.ExecuteInsert(insertQ, Parameters, connection.Db.Dialect);
+                    break;
+                case SqlUpdateQuery updateQ:
+                    connection.ExecuteUpdate(updateQ, Parameters);
+                    break;
+                case SqlDeleteQuery deleteQ:
+                    connection.ExecuteDelete(deleteQ, Parameters);
+                    break;
+                case SqlCreateTemporaryTableQuery tempQ:
+                    connection.ExecuteCreateTemporaryTableAsSelect(tempQ, Parameters, connection.Db.Dialect);
+                    break;
+                case SqlCreateViewQuery viewQ:
+                    connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect);
+                    break;
+                default:
+                    throw new NotSupportedException($"Tipo de query não suportado em ExecuteReader: {query.GetType().Name}");
+            }
+        }
+
+        if (tables.Count == 0 && queries.Count > 0)
             throw new InvalidOperationException("ExecuteReader foi chamado, mas nenhuma query SELECT foi encontrada.");
 
-        var tables = selectQueries.ConvertAll(executor.ExecuteSelect);
         connection.Metrics.Selects += tables.Sum(t => t.Count);
 
         return new OracleDataReaderMock(tables);


### PR DESCRIPTION
### Motivation
- Fix the failure where a `CREATE TEMPORARY TABLE ... AS SELECT` in the same command batch was not executed before a subsequent `SELECT`, causing errors like `Tabela não existe cadastrada tmp_users` during Oracle tests.
- Make `OracleCommandMock.ExecuteDbDataReader` behavior consistent with other dialect mocks by executing all parsed statements in order so setup statements in the same batch run before reads.

### Description
- Replaced the previous logic that only collected `SELECT` queries with an ordered `foreach` over `SqlQueryParser.ParseMulti(...)` and a `switch` that executes each parsed query in turn. 
- Added explicit handling for `SqlCreateTemporaryTableQuery` to call `connection.ExecuteCreateTemporaryTableAsSelect(...)` so temporary tables are created before later statements. 
- Added handling for `SqlInsertQuery`, `SqlUpdateQuery`, `SqlDeleteQuery`, and `SqlCreateViewQuery` in `ExecuteDbDataReader` and preserved the existing error when no `SELECT` is present in the batch.

### Testing
- Attempted to run `dotnet test --filter "CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows"`, but the attempt failed in this environment because `dotnet` is not installed (`bash: command not found: dotnet`).
- Change was validated by comparing behavior to `NpgsqlCommandMock.ExecuteDbDataReader` and by code inspection; no automated test run succeeded in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a98766ff8832c832967f2bfad870b)