### PR TITLE
Handle MERGE (SqlMergeQuery) in OracleCommandMock.ExecuteNonQuery

### DIFF
--- a/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
@@ -105,6 +105,7 @@ public class OracleCommandMock(
             SqlInsertQuery insertQ => connection.ExecuteInsert(insertQ, Parameters, connection.Db.Dialect),
             SqlUpdateQuery updateQ => connection.ExecuteUpdateSmart(updateQ, Parameters, connection.Db.Dialect),
             SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
+            SqlMergeQuery mergeQ => connection.ExecuteMerge(mergeQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery viewQ => connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect),
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
             _ => throw new NotSupportedException($"Tipo de query não suportado em ExecuteNonQuery: {query.GetType().Name}")


### PR DESCRIPTION
### Motivation
- The Oracle `MERGE` statement was parsed as `SqlMergeQuery` but not handled by `OracleCommandMock.ExecuteNonQuery`, causing a `NotSupportedException` and failing the merge upsert tests.

### Description
- Add a `SqlMergeQuery` case to the `ExecuteNonQuery` switch in `src/DbSqlLikeMem.Oracle/OracleCommandMock.cs` that routes to `connection.ExecuteMerge(mergeQ, Parameters, connection.Db.Dialect)`.

### Testing
- Attempted to run `dotnet test src/DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj --filter "FullyQualifiedName~OracleMergeUpsertTests"` but `dotnet` is not available in the environment, so automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9d0c3394832c9f94143e53bc98dd)