### PR TITLE
Fix Oracle LINQ pagination SQL to use OFFSET/FETCH

### DIFF
--- a/src/DbSqlLikeMem.Oracle/OracleTranslator.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleTranslator.cs
@@ -46,9 +46,14 @@ public class OracleTranslator : ExpressionVisitor
         if (!string.IsNullOrWhiteSpace(_orderByClause))
             _sb.Append(" ORDER BY ").Append(_orderByClause);
         if (_offset.HasValue)
-            _sb.Append(" OFFSET ").Append(_offset.Value);
+            _sb.Append(" OFFSET ").Append(_offset.Value).Append(" ROWS");
         if (_limit.HasValue)
-            _sb.Append(" LIMIT ").Append(_limit.Value);
+        {
+            if (_offset.HasValue)
+                _sb.Append(" FETCH NEXT ").Append(_limit.Value).Append(" ROWS ONLY");
+            else
+                _sb.Append(" FETCH FIRST ").Append(_limit.Value).Append(" ROWS ONLY");
+        }
 
         return new TranslationResult(_sb.ToString(), BuildParameters(_values));
     }


### PR DESCRIPTION
### Motivation
- The LINQ-to-SQL translator emitted `LIMIT` and `OFFSET` without Oracle-specific suffixes, causing `SqlTranslatorTests.TranslateBasicWhereAndOrderBySqlCorrect` to expect `FETCH NEXT` but find `LIMIT` instead.

### Description
- Updated `OracleTranslator.Translate` in `src/DbSqlLikeMem.Oracle/OracleTranslator.cs` to append `ROWS` to `OFFSET` (`OFFSET <n> ROWS`).
- Replaced the `LIMIT` rendering with Oracle-compatible variants: `FETCH NEXT <n> ROWS ONLY` when an `OFFSET` is present and `FETCH FIRST <n> ROWS ONLY` when no `OFFSET` is present.
- Preserved existing parameter building and other translation logic.

### Testing
- Attempted to run the targeted unit test via `dotnet test src/DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj --filter "FullyQualifiedName~SqlTranslatorTests.TranslateBasicWhereAndOrderBySqlCorrect"`, but the command failed because `dotnet` is not installed in this environment (`bash: command not found: dotnet`).
- No automated tests completed successfully here due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9d00f744832cabdad202cb605a71)