### PR TITLE
Add CRUD performance smoke tests for MySQL, PostgreSQL, Oracle and SQL Server mocks

### DIFF
--- a/src/DbSqlLikeMem.MySql.Test/Performance/MySqlPerformanceTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Performance/MySqlPerformanceTests.cs
@@ -1,0 +1,97 @@
+namespace DbSqlLikeMem.MySql.Test.Performance;
+
+public sealed class MySqlPerformanceTests : XUnitTestBase
+{
+    private readonly MySqlConnectionMock _connection;
+
+    public MySqlPerformanceTests(ITestOutputHelper helper) : base(helper)
+    {
+        var db = new MySqlDbMock();
+        db.AddTable("Users", new ColumnDictionary
+        {
+            { "Id", new(0, DbType.Int32, false) },
+            { "Name", new(1, DbType.String, false) },
+            { "Email", new(2, DbType.String, true) }
+        });
+
+        _connection = new MySqlConnectionMock(db);
+        _connection.Open();
+    }
+
+    [Fact]
+    [Trait("Category", "Performance")]
+    public void Should_report_crud_baseline_metrics()
+    {
+        const int totalRows = 2000;
+        const int sampledReads = 1000;
+
+        using var command = new MySqlCommandMock(_connection);
+
+        var insertElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"INSERT INTO Users (Id, Name, Email) VALUES ({i}, 'User {i}', 'user{i}@mail.com')";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        var readElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= sampledReads; i++)
+            {
+                var userId = (i % totalRows) + 1;
+                command.CommandText = $"SELECT Id, Name, Email FROM Users WHERE Id = {userId}";
+                using var reader = command.ExecuteReader();
+                Assert.True(reader.Read());
+            }
+        });
+
+        var updateElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"UPDATE Users SET Name = 'Updated {i}' WHERE Id = {i}";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        var deleteElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"DELETE FROM Users WHERE Id = {i}";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        Console.WriteLine($"[MySql][Performance] Inserts: {totalRows} in {insertElapsedMs}ms ({OpsPerSecond(totalRows, insertElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[MySql][Performance] Reads: {sampledReads} in {readElapsedMs}ms ({OpsPerSecond(sampledReads, readElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[MySql][Performance] Updates: {totalRows} in {updateElapsedMs}ms ({OpsPerSecond(totalRows, updateElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[MySql][Performance] Deletes: {totalRows} in {deleteElapsedMs}ms ({OpsPerSecond(totalRows, deleteElapsedMs):F2} ops/s)");
+
+        Assert.Empty(_connection.GetTable("users"));
+    }
+
+    private static long Measure(Action action)
+    {
+        var watch = Stopwatch.StartNew();
+        action();
+        watch.Stop();
+        return watch.ElapsedMilliseconds;
+    }
+
+    private static double OpsPerSecond(int operationCount, long elapsedMs)
+    {
+        if (elapsedMs <= 0)
+            return operationCount;
+
+        return operationCount / (elapsedMs / 1000d);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        _connection.Dispose();
+        base.Dispose(disposing);
+    }
+}

--- a/src/DbSqlLikeMem.Npgsql.Test/Performance/PostgreSqlPerformanceTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Performance/PostgreSqlPerformanceTests.cs
@@ -1,0 +1,97 @@
+namespace DbSqlLikeMem.Npgsql.Test.Performance;
+
+public sealed class PostgreSqlPerformanceTests : XUnitTestBase
+{
+    private readonly NpgsqlConnectionMock _connection;
+
+    public PostgreSqlPerformanceTests(ITestOutputHelper helper) : base(helper)
+    {
+        var db = new NpgsqlDbMock();
+        db.AddTable("Users", new ColumnDictionary
+        {
+            { "Id", new(0, DbType.Int32, false) },
+            { "Name", new(1, DbType.String, false) },
+            { "Email", new(2, DbType.String, true) }
+        });
+
+        _connection = new NpgsqlConnectionMock(db);
+        _connection.Open();
+    }
+
+    [Fact]
+    [Trait("Category", "Performance")]
+    public void Should_report_crud_baseline_metrics()
+    {
+        const int totalRows = 2000;
+        const int sampledReads = 1000;
+
+        using var command = new NpgsqlCommandMock(_connection);
+
+        var insertElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"INSERT INTO Users (Id, Name, Email) VALUES ({i}, 'User {i}', 'user{i}@mail.com')";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        var readElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= sampledReads; i++)
+            {
+                var userId = (i % totalRows) + 1;
+                command.CommandText = $"SELECT Id, Name, Email FROM Users WHERE Id = {userId}";
+                using var reader = command.ExecuteReader();
+                Assert.True(reader.Read());
+            }
+        });
+
+        var updateElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"UPDATE Users SET Name = 'Updated {i}' WHERE Id = {i}";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        var deleteElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"DELETE FROM Users WHERE Id = {i}";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        Console.WriteLine($"[PostgreSql][Performance] Inserts: {totalRows} in {insertElapsedMs}ms ({OpsPerSecond(totalRows, insertElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[PostgreSql][Performance] Reads: {sampledReads} in {readElapsedMs}ms ({OpsPerSecond(sampledReads, readElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[PostgreSql][Performance] Updates: {totalRows} in {updateElapsedMs}ms ({OpsPerSecond(totalRows, updateElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[PostgreSql][Performance] Deletes: {totalRows} in {deleteElapsedMs}ms ({OpsPerSecond(totalRows, deleteElapsedMs):F2} ops/s)");
+
+        Assert.Empty(_connection.GetTable("Users"));
+    }
+
+    private static long Measure(Action action)
+    {
+        var watch = Stopwatch.StartNew();
+        action();
+        watch.Stop();
+        return watch.ElapsedMilliseconds;
+    }
+
+    private static double OpsPerSecond(int operationCount, long elapsedMs)
+    {
+        if (elapsedMs <= 0)
+            return operationCount;
+
+        return operationCount / (elapsedMs / 1000d);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        _connection.Dispose();
+        base.Dispose(disposing);
+    }
+}

--- a/src/DbSqlLikeMem.Oracle.Test/Performance/OraclePerformanceTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Performance/OraclePerformanceTests.cs
@@ -1,0 +1,97 @@
+namespace DbSqlLikeMem.Oracle.Test.Performance;
+
+public sealed class OraclePerformanceTests : XUnitTestBase
+{
+    private readonly OracleConnectionMock _connection;
+
+    public OraclePerformanceTests(ITestOutputHelper helper) : base(helper)
+    {
+        var db = new OracleDbMock();
+        db.AddTable("Users", new ColumnDictionary
+        {
+            { "Id", new(0, DbType.Int32, false) },
+            { "Name", new(1, DbType.String, false) },
+            { "Email", new(2, DbType.String, true) }
+        });
+
+        _connection = new OracleConnectionMock(db);
+        _connection.Open();
+    }
+
+    [Fact]
+    [Trait("Category", "Performance")]
+    public void Should_report_crud_baseline_metrics()
+    {
+        const int totalRows = 2000;
+        const int sampledReads = 1000;
+
+        using var command = new OracleCommandMock(_connection);
+
+        var insertElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"INSERT INTO Users (Id, Name, Email) VALUES ({i}, 'User {i}', 'user{i}@mail.com')";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        var readElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= sampledReads; i++)
+            {
+                var userId = (i % totalRows) + 1;
+                command.CommandText = $"SELECT Id, Name, Email FROM Users WHERE Id = {userId}";
+                using var reader = command.ExecuteReader();
+                Assert.True(reader.Read());
+            }
+        });
+
+        var updateElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"UPDATE Users SET Name = 'Updated {i}' WHERE Id = {i}";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        var deleteElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"DELETE FROM Users WHERE Id = {i}";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        Console.WriteLine($"[Oracle][Performance] Inserts: {totalRows} in {insertElapsedMs}ms ({OpsPerSecond(totalRows, insertElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[Oracle][Performance] Reads: {sampledReads} in {readElapsedMs}ms ({OpsPerSecond(sampledReads, readElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[Oracle][Performance] Updates: {totalRows} in {updateElapsedMs}ms ({OpsPerSecond(totalRows, updateElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[Oracle][Performance] Deletes: {totalRows} in {deleteElapsedMs}ms ({OpsPerSecond(totalRows, deleteElapsedMs):F2} ops/s)");
+
+        Assert.Empty(_connection.GetTable("Users"));
+    }
+
+    private static long Measure(Action action)
+    {
+        var watch = Stopwatch.StartNew();
+        action();
+        watch.Stop();
+        return watch.ElapsedMilliseconds;
+    }
+
+    private static double OpsPerSecond(int operationCount, long elapsedMs)
+    {
+        if (elapsedMs <= 0)
+            return operationCount;
+
+        return operationCount / (elapsedMs / 1000d);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        _connection.Dispose();
+        base.Dispose(disposing);
+    }
+}

--- a/src/DbSqlLikeMem.SqlServer.Test/Performance/SqlServerPerformanceTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Performance/SqlServerPerformanceTests.cs
@@ -1,0 +1,97 @@
+namespace DbSqlLikeMem.SqlServer.Test.Performance;
+
+public sealed class SqlServerPerformanceTests : XUnitTestBase
+{
+    private readonly SqlServerConnectionMock _connection;
+
+    public SqlServerPerformanceTests(ITestOutputHelper helper) : base(helper)
+    {
+        var db = new SqlServerDbMock();
+        db.AddTable("Users", new ColumnDictionary
+        {
+            { "Id", new(0, DbType.Int32, false) },
+            { "Name", new(1, DbType.String, false) },
+            { "Email", new(2, DbType.String, true) }
+        });
+
+        _connection = new SqlServerConnectionMock(db);
+        _connection.Open();
+    }
+
+    [Fact]
+    [Trait("Category", "Performance")]
+    public void Should_report_crud_baseline_metrics()
+    {
+        const int totalRows = 2000;
+        const int sampledReads = 1000;
+
+        using var command = new SqlServerCommandMock(_connection);
+
+        var insertElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"INSERT INTO Users (Id, Name, Email) VALUES ({i}, 'User {i}', 'user{i}@mail.com')";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        var readElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= sampledReads; i++)
+            {
+                var userId = (i % totalRows) + 1;
+                command.CommandText = $"SELECT Id, Name, Email FROM Users WHERE Id = {userId}";
+                using var reader = command.ExecuteReader();
+                Assert.True(reader.Read());
+            }
+        });
+
+        var updateElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"UPDATE Users SET Name = 'Updated {i}' WHERE Id = {i}";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        var deleteElapsedMs = Measure(() =>
+        {
+            for (var i = 1; i <= totalRows; i++)
+            {
+                command.CommandText = $"DELETE FROM Users WHERE Id = {i}";
+                Assert.Equal(1, command.ExecuteNonQuery());
+            }
+        });
+
+        Console.WriteLine($"[SqlServer][Performance] Inserts: {totalRows} in {insertElapsedMs}ms ({OpsPerSecond(totalRows, insertElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[SqlServer][Performance] Reads: {sampledReads} in {readElapsedMs}ms ({OpsPerSecond(sampledReads, readElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[SqlServer][Performance] Updates: {totalRows} in {updateElapsedMs}ms ({OpsPerSecond(totalRows, updateElapsedMs):F2} ops/s)");
+        Console.WriteLine($"[SqlServer][Performance] Deletes: {totalRows} in {deleteElapsedMs}ms ({OpsPerSecond(totalRows, deleteElapsedMs):F2} ops/s)");
+
+        Assert.Empty(_connection.GetTable("Users"));
+    }
+
+    private static long Measure(Action action)
+    {
+        var watch = Stopwatch.StartNew();
+        action();
+        watch.Stop();
+        return watch.ElapsedMilliseconds;
+    }
+
+    private static double OpsPerSecond(int operationCount, long elapsedMs)
+    {
+        if (elapsedMs <= 0)
+            return operationCount;
+
+        return operationCount / (elapsedMs / 1000d);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        _connection.Dispose();
+        base.Dispose(disposing);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide lightweight baseline performance smoke tests to detect regressions and surface CRUD bottlenecks across all database mock implementations.
- Make it easy to run an isolated `Performance` category to compare throughput trends between `MySql`, `Npgsql`, `Oracle` and `SqlServer` providers.

### Description
- Added four new test classes: `MySqlPerformanceTests`, `PostgreSqlPerformanceTests`, `OraclePerformanceTests` and `SqlServerPerformanceTests` under the respective `Performance` folders (e.g. `src/DbSqlLikeMem.SqlServer.Test/Performance/SqlServerPerformanceTests.cs`).
- Each test executes a CRUD baseline workload (`2000` inserts, `1000` sampled reads, `2000` updates, `2000` deletes) while measuring durations with `Stopwatch` and reporting `ops/s` via a `Measure` helper method.
- Tests assert correctness during the workload and verify the table is empty after deletes, and they include the attribute `Trait("Category", "Performance")` for filtered runs.
- All test classes inherit from `XUnitTestBase` and dispose their mock connections when finished.

### Testing
- Attempted to run the performance tests with `dotnet test src/DbSqlLikeMem.slnx --filter "Category=Performance"` but the command could not be executed because `dotnet` is not available in the current environment (failure: `bash: command not found: dotnet`).
- No automated test execution completed in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9eebc2c4832c8a49253863c0e953)