### PR TITLE
perf: reduzir alocações na normalização SQL e execução multi-statement (MySQL)

### DIFF
--- a/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
@@ -179,12 +179,13 @@ public class MySqlCommandMock(
 
 
         // Parse Multiplo (ex: "SELECT 1; SELECT 2;" ou "CREATE TEMPORARY TABLE ...; SELECT ...")
-        var queries = SqlQueryParser.ParseMulti(sql, connection.Db.Dialect).ToList();
-
         var tables = new List<TableResultMock>();
+        var hasAnyQuery = false;
 
-        foreach (var q in queries)
+        foreach (var q in SqlQueryParser.ParseMulti(sql, connection.Db.Dialect))
         {
+            hasAnyQuery = true;
+
             switch (q)
             {
                 case SqlCreateTemporaryTableQuery ct:
@@ -216,7 +217,7 @@ public class MySqlCommandMock(
             }
         }
 
-        if (tables.Count == 0 && queries.Count > 0)
+        if (tables.Count == 0 && hasAnyQuery)
             throw new InvalidOperationException("ExecuteReader foi chamado, mas nenhuma query SELECT foi encontrada.");
 
         connection.Metrics.Selects += tables.Sum(t => t.Count);

--- a/src/DbSqlLikeMem/Extensions/SqlStringExtencions.cs
+++ b/src/DbSqlLikeMem/Extensions/SqlStringExtencions.cs
@@ -7,12 +7,37 @@ internal static class SqlStringExtencions
     /// </summary>
     public static string NormalizeString(this string str)
     {
-        var s = str.Replace("\n", " ", StringComparison.Ordinal)
-              .Replace("\r", " ", StringComparison.Ordinal)
-              .Replace("\t", " ", StringComparison.Ordinal);
-        while (s.Contains("  ", StringComparison.Ordinal))
-            s = s.Replace("  ", " ", StringComparison.Ordinal);
-        return s.Trim();
+        ArgumentNullException.ThrowIfNull(str);
+
+        if (str.Length == 0)
+            return string.Empty;
+
+        var sb = new System.Text.StringBuilder(str.Length);
+        var pendingSpace = false;
+
+        for (var i = 0; i < str.Length; i++)
+        {
+            var ch = str[i];
+            var isWhitespace = ch is ' ' or '\n' or '\r' or '\t';
+
+            if (isWhitespace)
+            {
+                if (sb.Length > 0)
+                    pendingSpace = true;
+
+                continue;
+            }
+
+            if (pendingSpace)
+            {
+                sb.Append(' ');
+                pendingSpace = false;
+            }
+
+            sb.Append(ch);
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- Reduzir alocação de memória e pressão do GC no caminho quente de manipulação de SQL ao normalizar strings e ao executar múltiplos statements MySQL.
- Evitar materialização desnecessária da lista de queries ao processar múltiplos statements para diminuir overhead em cenários com muitas execuções.

### Description
- Substitui o encadeamento de `Replace` + loop `Contains`/`Replace` em `NormalizeString` por uma passagem única usando `StringBuilder`, preservando comportamento de colapso de espaços e tratamento de whitespace, e adicionando checagem de `null`/vazio (`ArgumentNullException.ThrowIfNull` e retorno para string vazia).
- Altera `MySqlCommandMock` para iterar `SqlQueryParser.ParseMulti(...)` diretamente em streaming ao invés de materializar com `.ToList()`, adicionando a flag `hasAnyQuery` para manter a validação que lança se houver statements mas nenhum `SELECT`.
- Mantém a semântica existente ao tratar `CREATE TEMPORARY TABLE`, `CREATE VIEW`, `INSERT`, `UPDATE`, `DELETE` e `SELECT`, apenas reduzindo alocações intermediárias.

### Testing
- Tentativa de executar teste direcionado com `dotnet test src/DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj --filter "FullyQualifiedName~Should_report_crud_baseline_metrics" -v minimal` falhou pois `dotnet` não está disponível no ambiente (`command not found`).
- Nenhum teste automatizado foi executado com sucesso no ambiente atual devido à ausência do SDK .NET.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa30ef620832c9bf555d246ee05cd)