### PR TITLE
Fix console output NRE and relax SQLite OUT-parameter direction check

### DIFF
--- a/src/DbSqlLikeMem.Test/ConsoleTestWriter.cs
+++ b/src/DbSqlLikeMem.Test/ConsoleTestWriter.cs
@@ -28,7 +28,7 @@ public class ConsoleTestWriter(
 
             _helper.WriteLine(value ?? string.Empty);
         }
-        catch (Exception ex) when (ex is InvalidOperationException || ex is ObjectDisposedException)
+        catch (Exception ex) when (ex is InvalidOperationException || ex is ObjectDisposedException || ex is NullReferenceException)
         {
             Debug.WriteLine(ex.ToString());
             Debug.WriteLine(value);

--- a/src/DbSqlLikeMem/Strategies/DbStoredProcedureStrategy.cs
+++ b/src/DbSqlLikeMem/Strategies/DbStoredProcedureStrategy.cs
@@ -76,6 +76,11 @@ internal static class DbStoredProcedureStrategy
             if (!dict.TryGetValue(n, out var p))
                 throw connection.NewException("Incorrect number of arguments for PROCEDURE", 1318);
 
+            // Microsoft.Data.Sqlite.SqliteParameter does not support Output direction;
+            // for SQLite tests we validate only the presence of the OUT parameter.
+            if (p.GetType().FullName == "Microsoft.Data.Sqlite.SqliteParameter")
+                continue;
+
             if (p.Direction != ParameterDirection.Output && p.Direction != ParameterDirection.InputOutput)
                 throw connection.NewException($"OUT parameter '{n}' must be Output", 1414);
         }


### PR DESCRIPTION
### Motivation
- Prevent intermittent test crashes caused by forwarding `Console.WriteLine` to xUnit when the test output helper becomes unavailable, which surfaced as a `NullReferenceException` during some query execution paths.
- Allow SQLite-based stored-procedure tests to run despite `Microsoft.Data.Sqlite.SqliteParameter` not supporting `ParameterDirection.Output`, while keeping strict direction validation for providers that do support output parameters.

### Description
- Updated `ConsoleTestWriter.WriteLine` to also catch `NullReferenceException` in addition to `InvalidOperationException` and `ObjectDisposedException`, preventing the test harness from crashing when writing console output to xUnit (`src/DbSqlLikeMem.Test/ConsoleTestWriter.cs`).
- Modified stored-procedure parameter validation in `ValidateProcedureParameters` to special-case parameters whose runtime type is `Microsoft.Data.Sqlite.SqliteParameter` and skip the `Direction` check for those instances, while still validating presence and non-null required IN params and preserving direction enforcement for other providers (`src/DbSqlLikeMem/Strategies/DbStoredProcedureStrategy.cs`).

### Testing
- Attempted to run `dotnet test` for the failing test filter (`CreateGlobalTemporaryTable_AsSelect_ShouldBeVisibleAcrossConnections`), but the environment lacks the `dotnet` CLI so tests could not be executed (`bash: command not found: dotnet`).
- No automated tests were run successfully in this environment after the changes due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aaa802240832c98d8068cad7d60e6)