### PR TITLE
Target Db2 test project to x64 to fix architecture mismatch

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj
+++ b/src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
+		<PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
### Motivation
- The Db2 test project emitted MSB3270 warnings because the project targeted MSIL while the referenced `IBM.Data.Db2.dll` is AMD64, so the test project should target x64 to avoid runtime/packaging issues.

### Description
- Added `<PlatformTarget>x64</PlatformTarget>` to `src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj` to align the test assembly architecture with the DB2 provider.

### Testing
- Attempted `dotnet build src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj -c Debug` but `dotnet` is not available in this environment (`bash: command not found: dotnet`), so the change could not be built here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aaaafad7c832c97489284ec654d5c)