### PR TITLE
Adjust SQLite stored procedure tests for output parameter limitation

### DIFF
--- a/src/DbSqlLikeMem.Sqlite.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/StoredProcedureExecutionTests.cs
@@ -9,15 +9,23 @@ public sealed class StoredProcedureExecutionTests(
 {
     // helper: cria parâmetro SQLite do seu mock (ajuste o tipo se necessário)
     private static SqliteParameter P(string name, object? value, DbType dbType, ParameterDirection dir = ParameterDirection.Input)
-        => new()
+    {
+        var parameter = new SqliteParameter
         {
             ParameterName = name.StartsWith('@')
                 ? name
                 : "@" + name,
             Value = value ?? DBNull.Value,
             DbType = dbType,
-            Direction = dir
         };
+
+        // Microsoft.Data.Sqlite does not support Output/InputOutput directions.
+        // For SQLite mock tests, OUT validation is done by parameter presence.
+        if (dir == ParameterDirection.Input)
+            parameter.Direction = dir;
+
+        return parameter;
+    }
 
     /// <summary>
     /// EN: Tests ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs behavior.

--- a/src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs
@@ -29,7 +29,7 @@ public sealed class StoredProcedureSignatureTests(
             CommandText = "sp_demo"
         };
         cmd.Parameters.Add(new SqliteParameter { ParameterName = "tenantId", DbType = DbType.Int32, Value = 10 });
-        cmd.Parameters.Add(new SqliteParameter { ParameterName = "resultCode", DbType = DbType.Int32, Direction = ParameterDirection.Output, Value = DBNull.Value });
+        cmd.Parameters.Add(new SqliteParameter { ParameterName = "resultCode", DbType = DbType.Int32, Value = DBNull.Value });
 
         var n = cmd.ExecuteNonQuery();
         Assert.Equal(0, n);


### PR DESCRIPTION
### Motivation
- `Microsoft.Data.Sqlite` does not support `ParameterDirection.Output`/`InputOutput`, which caused `ArgumentException` when tests created output parameters. 

### Description
- Change the test helper `P(...)` in `src/DbSqlLikeMem.Sqlite.Test/StoredProcedureExecutionTests.cs` to only set `Direction` when it is `Input`, avoiding unsupported assignments to `SqliteParameter`. 
- Update `src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs` to add the OUT parameter without `Direction = ParameterDirection.Output`, preserving test intent while working around provider limitations. 
- The change keeps procedure validation/population behavior via the existing `DbStoredProcedureStrategy` logic that validates presence of OUT params and populates defaults. 

### Testing
- Attempted to run targeted tests with `dotnet test src/DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj --filter "StoredProcedureExecutionTests|StoredProcedureSignatureTests"`, but the command failed due to the environment missing the `dotnet` runtime (`bash: command not found: dotnet`).
- No automated tests executed successfully in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aac2349ac832c841d416e27158dc1)