### PR TITLE
Use Dapper Guid type-map for DB2 tests (remove Db2ParameterMock)

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Assembly.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Assembly.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿using Dapper;
+using System.Data;
+using System.Runtime.CompilerServices;
 
 internal static class TestBootstrap
 {
@@ -6,5 +8,6 @@ internal static class TestBootstrap
     internal static void Init()
     {
         Db2AstQueryExecutorRegister.Register();
+        SqlMapper.AddTypeMap(typeof(Guid), DbType.String);
     }
 }


### PR DESCRIPTION
### Motivation
- The DB2 provider rejects `DbType.Guid` when Dapper assigns it to `DB2Parameter`, and the change avoids introducing a new `Db2ParameterMock` type. 
- The goal is to keep the standard `IBM.Data.Db2.DB2Parameter` usage while preventing the unsupported `Guid` mapping in test runs.

### Description
- Removed the custom `Db2ParameterMock` and restored code to use `DB2Parameter` in `Db2CommandMock` (now `CreateDbParameter` returns `new DB2Parameter()`).
- Updated `Db2DataParameterCollectionMock` and `Db2ValueHelper` to operate with `DB2Parameter` types again, restoring original mock behavior without a new parameter class.
- Added a test assembly bootstrap (`src/DbSqlLikeMem.Db2.Test/Assembly.cs`) that calls `SqlMapper.AddTypeMap(typeof(Guid), DbType.String)` to instruct Dapper to treat `Guid` parameters as `DbType.String` in DB2 tests.
- Deleted the previous `Db2ParameterMock` file and amended the test bootstrap to register the Dapper type map alongside `Db2AstQueryExecutorRegister.Register()`.

### Testing
- Attempted to run the focused test with `dotnet test src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj --filter "FullyQualifiedName~DapperUserTests.InsertUserShouldAddUserToTable"`, but the environment lacks `dotnet` so the command failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aac69cc34832c8573e6985ada0dec)