### PR TITLE
Fix Oracle create-view IF NOT EXISTS test parameterization

### DIFF
--- a/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewParserTests.cs
@@ -82,11 +82,12 @@ SELECT * FROM v_users;
     /// EN: Tests Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec behavior.
     /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec.
     /// </summary>
-    [Theory]
-    [MemberDataOracleVersion]
-    public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec(int version)
+    [Fact]
+    public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec()
     {
         const string sql = "CREATE VIEW IF NOT EXISTS v AS SELECT 1;";
-        Assert.ThrowsAny<Exception>(() => SqlQueryParser.ParseMulti(sql, new OracleDialect(version)).ToList());
+
+        foreach (var version in OracleDbVersions.Versions())
+            Assert.ThrowsAny<Exception>(() => SqlQueryParser.ParseMulti(sql, new OracleDialect(version)).ToList());
     }
 }


### PR DESCRIPTION
### Motivation
- The parameterized test `Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec` was failing test discovery with "expected 1 parameter value, but 0 provided", so the test needed to be reworked to preserve coverage while avoiding the runner error.

### Description
- Replaced the `[Theory]`/`[MemberDataOracleVersion]` signature with a `[Fact]` and added an internal `foreach` over `OracleDbVersions.Versions()` to assert rejection for each version in `src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewParserTests.cs`.

### Testing
- Attempted to run the targeted test with `dotnet test`, but the `dotnet` CLI is not installed in this environment (the command failed with `bash: command not found: dotnet`), so automated test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab0a16700832ca66e3b03810db0a7)