### PR TITLE
Add DROP VIEW support to SQL parser and command execution

### DIFF
--- a/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
@@ -134,6 +134,7 @@ public class Db2CommandMock(
             SqlUpdateQuery updateQ => connection.ExecuteUpdateSmart(updateQ, Parameters, connection.Db.Dialect),
             SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery cv => connection.ExecuteCreateView(cv, Parameters, connection.Db.Dialect),
+            SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
             _ => throw new NotSupportedException($"Tipo de query não suportado em ExecuteNonQuery: {query.GetType().Name}")
         };
@@ -193,6 +194,9 @@ public class Db2CommandMock(
 
                 case SqlCreateViewQuery cv:
                     connection.ExecuteCreateView(cv, Parameters, connection.Db.Dialect);
+                    break;
+                case SqlDropViewQuery dropViewQ:
+                    connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect);
                     break;
 
                 case SqlInsertQuery insertQ:

--- a/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
@@ -134,6 +134,7 @@ public class MySqlCommandMock(
             SqlUpdateQuery updateQ => connection.ExecuteUpdateSmart(updateQ, Parameters, connection.Db.Dialect),
             SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery cv => connection.ExecuteCreateView(cv, Parameters, connection.Db.Dialect),
+            SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
             _ => throw new NotSupportedException($"Tipo de query não suportado em ExecuteNonQuery: {query.GetType().Name}")
         };
@@ -194,6 +195,9 @@ public class MySqlCommandMock(
 
                 case SqlCreateViewQuery cv:
                     connection.ExecuteCreateView(cv, Parameters, connection.Db.Dialect);
+                    break;
+                case SqlDropViewQuery dropViewQ:
+                    connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect);
                     break;
 
                 case SqlInsertQuery insertQ:

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
@@ -109,6 +109,7 @@ public class NpgsqlCommandMock(
             SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
             SqlCreateTemporaryTableQuery tempQ => connection.ExecuteCreateTemporaryTableAsSelect(tempQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery viewQ => connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect),
+            SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
             _ => throw new NotSupportedException($"Tipo de query não suportado em ExecuteNonQuery: {query.GetType().Name}")
         };
@@ -173,6 +174,9 @@ public class NpgsqlCommandMock(
                     break;
                 case SqlCreateViewQuery viewQ:
                     connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect);
+                    break;
+                case SqlDropViewQuery dropViewQ:
+                    connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect);
                     break;
                 default:
                     throw new NotSupportedException($"Tipo de query não suportado em ExecuteReader: {query.GetType().Name}");

--- a/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
@@ -107,6 +107,7 @@ public class OracleCommandMock(
             SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
             SqlMergeQuery mergeQ => connection.ExecuteMerge(mergeQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery viewQ => connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect),
+            SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
             _ => throw new NotSupportedException($"Tipo de query não suportado em ExecuteNonQuery: {query.GetType().Name}")
         };
@@ -171,6 +172,9 @@ public class OracleCommandMock(
                     break;
                 case SqlCreateViewQuery viewQ:
                     connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect);
+                    break;
+                case SqlDropViewQuery dropViewQ:
+                    connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect);
                     break;
                 default:
                     throw new NotSupportedException($"Tipo de query não suportado em ExecuteReader: {query.GetType().Name}");

--- a/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
@@ -108,6 +108,7 @@ public class SqlServerCommandMock(
             SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
             SqlCreateTemporaryTableQuery tempQ => connection.ExecuteCreateTemporaryTableAsSelect(tempQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery viewQ => connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect),
+            SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
             SqlMergeQuery mergeQ => connection.ExecuteMerge(mergeQ, Parameters, connection.Db.Dialect),
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
             _ => throw new NotSupportedException($"Tipo de query não suportado em ExecuteNonQuery: {query.GetType().Name}")
@@ -173,6 +174,9 @@ public class SqlServerCommandMock(
                     break;
                 case SqlCreateViewQuery viewQ:
                     connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect);
+                    break;
+                case SqlDropViewQuery dropViewQ:
+                    connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect);
                     break;
                 case SqlMergeQuery mergeQ:
                     connection.ExecuteMerge(mergeQ, Parameters, connection.Db.Dialect);

--- a/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
@@ -134,6 +134,7 @@ public class SqliteCommandMock(
             SqlUpdateQuery updateQ => connection.ExecuteUpdateSmart(updateQ, Parameters, connection.Db.Dialect),
             SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery cv => connection.ExecuteCreateView(cv, Parameters, connection.Db.Dialect),
+            SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
             _ => throw new NotSupportedException($"Tipo de query não suportado em ExecuteNonQuery: {query.GetType().Name}")
         };
@@ -193,6 +194,9 @@ public class SqliteCommandMock(
 
                 case SqlCreateViewQuery cv:
                     connection.ExecuteCreateView(cv, Parameters, connection.Db.Dialect);
+                    break;
+                case SqlDropViewQuery dropViewQ:
+                    connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect);
                     break;
 
                 case SqlInsertQuery insertQ:

--- a/src/DbSqlLikeMem/Base/DbConnectionMockBase.cs
+++ b/src/DbSqlLikeMem/Base/DbConnectionMockBase.cs
@@ -278,6 +278,15 @@ public abstract class DbConnectionMockBase(
             out vw,
             schemaName ?? Database);
 
+    internal bool DropView(
+        string viewName,
+        bool ifExists,
+        string? schemaName = null)
+        => Db.DropView(
+            viewName,
+            ifExists,
+            schemaName ?? Database);
+
     #endregion
 
     #region Procedures

--- a/src/DbSqlLikeMem/Models/DbMock.cs
+++ b/src/DbSqlLikeMem/Models/DbMock.cs
@@ -309,6 +309,25 @@ public abstract class DbMock
             && vw != null;
     }
 
+
+    internal bool DropView(
+        string viewName,
+        bool ifExists,
+        string? schemaName = null)
+    {
+        ArgumentNullException.ThrowIfNull(viewName);
+        var sc = GetSchemaName(schemaName);
+        var schema = (SchemaMock)this[sc];
+
+        if (schema.Views.Remove(viewName.NormalizeName()))
+            return true;
+
+        if (ifExists)
+            return false;
+
+        throw new InvalidOperationException($"View '{viewName}' does not exist.");
+    }
+
     #endregion
 
     #region Procedures

--- a/src/DbSqlLikeMem/Parser/SqlQueryAst.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryAst.cs
@@ -83,6 +83,11 @@ internal sealed record SqlCreateViewQuery : SqlQueryBase
     internal SqlSelectQuery Select { get; init; } = null!;
 }
 
+internal sealed record SqlDropViewQuery : SqlQueryBase
+{
+    internal bool IfExists { get; init; }
+}
+
 internal sealed record SqlMergeQuery : SqlQueryBase
 {
     internal SqlTableSource? Source { get; init; } // opcional (pode deixar null por enquanto)

--- a/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
@@ -44,6 +44,8 @@ internal sealed class SqlQueryParser
             result = q.ParseDelete();
         else if (IsWord(first, "CREATE"))
             result = q.ParseCreate();
+        else if (IsWord(first, "DROP"))
+            result = q.ParseDrop();
         else if (IsWord(first, "MERGE"))
         {
             // Para MySQL, MERGE simplesmente não existe (é sintaxe inválida para o dialeto).
@@ -779,6 +781,32 @@ internal sealed class SqlQueryParser
             Table = viewName,
             ColumnNames = colNames,
             Select = sel
+        };
+    }
+
+    private SqlQueryBase ParseDrop()
+    {
+        ExpectWord("DROP");
+
+        if (!IsWord(Peek(), "VIEW"))
+            throw new InvalidOperationException("Apenas DROP VIEW é suportado no mock no momento.");
+
+        Consume(); // VIEW
+
+        var ifExists = false;
+        if (IsWord(Peek(), "IF"))
+        {
+            Consume();
+            ExpectWord("EXISTS");
+            ifExists = true;
+        }
+
+        var viewName = ParseTableSource();
+
+        return new SqlDropViewQuery
+        {
+            IfExists = ifExists,
+            Table = viewName
         };
     }
 

--- a/src/DbSqlLikeMem/Strategies/DbSelectIntoAndInsertSelectStrategies.cs
+++ b/src/DbSqlLikeMem/Strategies/DbSelectIntoAndInsertSelectStrategies.cs
@@ -27,6 +27,34 @@ internal static class DbSelectIntoAndInsertSelectStrategies
         return 0;
     }
 
+
+    /// <summary>
+    /// Auto-generated summary.
+    /// </summary>
+    public static int ExecuteDropView(
+        this DbConnectionMockBase connection,
+        SqlDropViewQuery query,
+        DbParameterCollection pars,
+        ISqlDialect dialect)
+    {
+        _ = pars;
+        _ = dialect;
+        if (!connection.Db.ThreadSafe)
+            return ExecuteDropViewImpl(connection, query);
+        lock (connection.Db.SyncRoot)
+            return ExecuteDropViewImpl(connection, query);
+    }
+
+    private static int ExecuteDropViewImpl(
+        DbConnectionMockBase connection,
+        SqlDropViewQuery query)
+    {
+        var viewName = query.Table?.Name;
+        ArgumentException.ThrowIfNullOrWhiteSpace(viewName);
+        connection.DropView(viewName, query.IfExists, query.Table?.DbName);
+        return 0;
+    }
+
     /// <summary>
     /// Auto-generated summary.
     /// </summary>


### PR DESCRIPTION
### Motivation
- `DROP` statements were not parsed, causing calls like `DROP VIEW vdrop;` to throw `InvalidOperationException` in view engine tests.  
- Implement minimal `DROP VIEW` support so tests that create and then drop views can remove view definitions from the mock DB state.

### Description
- Added a new AST node `SqlDropViewQuery` to represent `DROP VIEW` statements and implemented `ParseDrop()` in `SqlQueryParser` to parse `DROP VIEW` with optional `IF EXISTS`.  
- Implemented view removal in the in-memory DB via `DbMock.DropView(...)` and exposed it through `DbConnectionMockBase.DropView(...)`.  
- Added an execution strategy `ExecuteDropView(...)` in `DbSelectIntoAndInsertSelectStrategies` that performs thread-safe deletion of the view.  
- Wired handling for `SqlDropViewQuery` into all command mocks so both `ExecuteNonQuery` and multi-statement `ExecuteReader` flows (Oracle, Sqlite, SqlServer, Npgsql, MySql, Db2) call the new strategy; `DROP` currently only supports `DROP VIEW`.

### Testing
- Verified code paths and references with `rg` searches for `ParseDrop`, `SqlDropViewQuery`, `ExecuteDropView` and `DropView(...)`, which returned the updated parser, AST, strategy and command mock usages.  
- Attempted to run the targeted test with `dotnet test src/DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj --filter "OracleCreateViewEngineTests.DropView_ShouldRemoveDefinition"` but `dotnet` is not available in the execution environment so the test could not be executed here.  
- Static inspection and local runs of the repository commands (searches and file edits) indicate the new `DROP VIEW` control flow is integrated across the parser, model and command layers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab0935310832ca4f3d3b8ec00a38f)