### PR TITLE
Fix Oracle invalid DELETE test to actually omit FROM

### DIFF
--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleDeleteStrategyTests.cs
@@ -103,7 +103,7 @@ public sealed class OracleCommandDeleteTests(
         table.Add(RowUsers(1, "John"));
 
         using var conn = NewConn(threadSafe: false, db);
-        using var cmd = new OracleCommandMock(conn) { CommandText = "DELETE FROM users WHERE id = 1" };
+        using var cmd = new OracleCommandMock(conn) { CommandText = "DELETE users WHERE id = 1" };
 
         // Pode ser InvalidOperationException ou outra, depende do seu pipeline.
         var ex = Assert.ThrowsAny<Exception>(() => cmd.ExecuteNonQuery());


### PR DESCRIPTION
### Motivation
- Make the test `ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara` actually exercise invalid DELETE syntax without `FROM` so it reliably asserts that an exception is thrown for malformed SQL.

### Description
- Change the `CommandText` used in `ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara` to `"DELETE users WHERE id = 1"` so the test truly omits `FROM`, leaving other DELETE tests unchanged.

### Testing
- Attempted to run the targeted test with `dotnet test src/DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj --filter "FullyQualifiedName~OracleCommandDeleteTests.ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara"`, but the environment does not have `dotnet` installed so the test run failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab08ab0f0832c83793be7baf77fd6)