### PR TITLE
Fix Npgsql create-view IF NOT EXISTS rejection test binding

### DIFF
--- a/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewParserTests.cs
@@ -81,10 +81,10 @@ SELECT * FROM v_users;
     /// EN: Tests Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec behavior.
     /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec.
     /// </summary>
-    [Theory]
-    [MemberDataNpgsqlVersion]
-    public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec(int version)
+    [Fact]
+    public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec()
     {
+        var version = NpgsqlDbVersions.Versions().First();
         const string sql = "CREATE VIEW IF NOT EXISTS v AS SELECT 1;";
         Assert.ThrowsAny<Exception>(() => SqlQueryParser.ParseMulti(sql, new NpgsqlDialect(version)).ToList());
     }


### PR DESCRIPTION
### Motivation
- Resolve a test discovery/runtime failure where the test expected a theory parameter but no member data was provided, causing `The test method expected 1 parameter value, but 0 parameter values were provided.`

### Description
- Convert `Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec` from a parameterized `[Theory]` with `[MemberDataNpgsqlVersion]` to a non-parameterized `[Fact]` and select a concrete version with `NpgsqlDbVersions.Versions().First()`, removing the unused `int version` parameter.

### Testing
- Attempted to run `dotnet test` for the specific test, but the command failed in this environment because `dotnet` is not installed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab08104bc832cb2413c3cc649ccb0)