### PR TITLE
Fix PostgreSQL DELETE invalid-sql test to omit FROM clause

### DIFF
--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs
@@ -102,7 +102,7 @@ public sealed class PostgreSqlCommandDeleteTests(
         table.Add(RowUsers(1, "John"));
 
         using var conn = NewConn(threadSafe: false, db);
-        using var cmd = new NpgsqlCommandMock(conn) { CommandText = "DELETE FROM users WHERE id = 1" };
+        using var cmd = new NpgsqlCommandMock(conn) { CommandText = "DELETE users WHERE id = 1" };
 
         // Pode ser InvalidOperationException ou outra, depende do seu pipeline.
         var ex = Assert.ThrowsAny<Exception>(() => cmd.ExecuteNonQuery());


### PR DESCRIPTION
### Motivation
- The test `ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara` was meant to assert that a malformed DELETE (missing `FROM`) throws, but its fixture used a valid SQL string, so the test didn't exercise the intended error path.

### Description
- Update the `CommandText` in `src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs` for `ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara` to `"DELETE users WHERE id = 1"` so the SQL actually omits `FROM` and matches the test intent.

### Testing
- Attempted to run the targeted test with `dotnet test --filter "FullyQualifiedName~DbSqlLikeMem.Npgsql.Test.Strategy.PostgreSqlCommandDeleteTests.ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara"`, but the command could not run because `dotnet` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab0705714832c99ad5009f14c9d50)