### PR TITLE
Reject unsupported CREATE VIEW IF NOT EXISTS syntax

### DIFF
--- a/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
@@ -712,14 +712,11 @@ internal sealed class SqlQueryParser
     {
         ExpectWord("VIEW");
 
-        // IF NOT EXISTS (not official MySQL syntax, but we accept for mocks)
+        // IF NOT EXISTS is not supported for CREATE VIEW in the mocked dialects.
         var ifNotExists = false;
         if (IsWord(Peek(), "IF"))
         {
-            Consume(); // IF
-            ExpectWord("NOT");
-            ExpectWord("EXISTS");
-            ifNotExists = true;
+            throw new InvalidOperationException("CREATE VIEW IF NOT EXISTS is not supported.");
         }
 
         // view name


### PR DESCRIPTION
### Motivation
- Parser tests for multiple dialects expect `CREATE VIEW IF NOT EXISTS` to be rejected, and a DB2 parser test failed because no exception was thrown when this syntax was encountered.

### Description
- Update `SqlQueryParser.ParseCreateView` to immediately throw `InvalidOperationException` when `IF` is seen after `CREATE VIEW`, and clarify the comment that `IF NOT EXISTS` is unsupported for CREATE VIEW in the mocked dialects. (file: `src/DbSqlLikeMem/Parser/SqlQueryParser.cs`)

### Testing
- Attempted to run the specific failing test with `dotnet test src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj --filter "Db2CreateViewParserTests.Parse_CreateView_IfNotExists_ShouldBeRejected_ByDb2Spec"`, but the run failed because `dotnet` is not available in this environment (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab637bd58832cbff410a482f1724f)