### PR TITLE
Fix SqlServer invalid DELETE test to omit FROM

### DIFF
--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs
@@ -102,7 +102,7 @@ public sealed class SqlServerCommandDeleteTests(
         table.Add(RowUsers(1, "John"));
 
         using var conn = NewConn(threadSafe: false, db);
-        using var cmd = new SqlServerCommandMock(conn) { CommandText = "DELETE FROM users WHERE id = 1" };
+        using var cmd = new SqlServerCommandMock(conn) { CommandText = "DELETE users WHERE id = 1" };
 
         // Pode ser InvalidOperationException ou outra, depende do seu pipeline.
         var ex = Assert.ThrowsAny<Exception>(() => cmd.ExecuteNonQuery());


### PR DESCRIPTION
### Motivation
- The test `ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara` intended to verify behavior for an invalid `DELETE` statement missing `FROM`, but its `CommandText` used valid SQL and therefore did not throw as expected.

### Description
- Update `ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara` in `src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs` to use the invalid SQL `DELETE users WHERE id = 1` so the test actually omits `FROM`.
- Restored the other `DELETE FROM` usages so only the intended test uses the malformed statement.
- Committed the change with message `Fix SqlServer invalid DELETE test case`.

### Testing
- Attempted to run the specific test with `dotnet test --filter ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara`, but the command failed because `dotnet` is not installed in this environment (command not found).
- Verified the local patch with `git diff` and committed successfully, but no automated test run completed due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab7306c44832c9368a6a340d0ac1a)