### PR TITLE
Fix sqlite create-view rejection test parameter mismatch

### DIFF
--- a/src/DbSqlLikeMem.Sqlite.Test/Views/SqliteCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Views/SqliteCreateViewParserTests.cs
@@ -81,11 +81,10 @@ SELECT * FROM v_users;
     /// EN: Tests Parse_CreateView_IfNotExists_ShouldBeRejected_BySqliteSpec behavior.
     /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_BySqliteSpec.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
-    public void Parse_CreateView_IfNotExists_ShouldBeRejected_BySqliteSpec(int version)
+    [Fact]
+    public void Parse_CreateView_IfNotExists_ShouldBeRejected_BySqliteSpec()
     {
         const string sql = "CREATE VIEW IF NOT EXISTS v AS SELECT 1;";
-        Assert.ThrowsAny<Exception>(() => SqlQueryParser.ParseMulti(sql, new SqliteDialect(version)).ToList());
+        Assert.ThrowsAny<Exception>(() => SqlQueryParser.ParseMulti(sql, new SqliteDialect(8)).ToList());
     }
 }


### PR DESCRIPTION
### Motivation
- Fix a failing xUnit test that reported `The test method expected 1 parameter value, but 0 parameter values were provided` by removing an incorrect parameterized data binding for a test that does not require version variation.

### Description
- Convert `Parse_CreateView_IfNotExists_ShouldBeRejected_BySqliteSpec` from a parameterized `[Theory]` with `[MemberDataSqliteVersion]` to a non-parameterized `[Fact]`, remove the `int version` parameter, and instantiate the dialect with a concrete `new SqliteDialect(8)` in the assertion.

### Testing
- Attempted to run the targeted unit test with `dotnet test ... --filter "FullyQualifiedName~Parse_CreateView_IfNotExists_ShouldBeRejected_BySqliteSpec"`, but the command failed because `dotnet` is not installed in this environment (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab739f668832ca31095c48678aa76)