### PR TITLE
Add project-specific README files for NuGet packages

### DIFF
--- a/src/DbSqlLikeMem.Db2/README.md
+++ b/src/DbSqlLikeMem.Db2/README.md
@@ -1,0 +1,28 @@
+# DbSqlLikeMem.Db2
+
+**`DbSqlLikeMem.Db2`** leva o ecossistema DbSqlLikeMem ao universo IBM DB2, ajudando sua equipe a validar regras de acesso a dados em memória.
+
+## Diferenciais
+
+- Simulação voltada ao provider DB2
+- Execução de testes mais rápida e previsível
+- Excelente para validar comportamento de consultas sem banco real
+
+## Instalação
+
+```bash
+dotnet add package DbSqlLikeMem.Db2
+```
+
+## Exemplo rápido
+
+```csharp
+using DbSqlLikeMem.Db2;
+
+var conn = new Db2ConnectionMock(new Db2DbMock());
+conn.Open();
+```
+
+## Evolução colaborativa
+
+A comunidade é fundamental para ampliar cobertura DB2. Compartilhe scripts SQL reais, abra issues e envie PRs com testes para acelerar a evolução do pacote.

--- a/src/DbSqlLikeMem.MySql/README.md
+++ b/src/DbSqlLikeMem.MySql/README.md
@@ -1,0 +1,29 @@
+# DbSqlLikeMem.MySql
+
+Teste seu código MySQL sem subir servidor: **`DbSqlLikeMem.MySql`** traz mocks de conexão/comando e comportamento SQL em memória para cenários de teste mais rápidos e baratos.
+
+## Destaques
+
+- Simulação focada no ecossistema MySQL
+- APIs familiares de ADO.NET
+- Fluxo compatível com Dapper
+- Excelente para pipelines CI com execução paralela
+
+## Instalação
+
+```bash
+dotnet add package DbSqlLikeMem.MySql
+```
+
+## Exemplo rápido
+
+```csharp
+using DbSqlLikeMem.MySql;
+
+var conn = new MySqlConnectionMock(new MySqlDbMock());
+conn.Open();
+```
+
+## Faça parte da evolução
+
+Se você encontrou um caso de SQL MySQL que ainda não está coberto, abra uma issue com o script de exemplo. PRs com testes são o melhor caminho para evoluirmos juntos.

--- a/src/DbSqlLikeMem.Npgsql/README.md
+++ b/src/DbSqlLikeMem.Npgsql/README.md
@@ -1,0 +1,28 @@
+# DbSqlLikeMem.Npgsql
+
+**`DbSqlLikeMem.Npgsql`** oferece um ambiente de teste em memória para aplicações que usam PostgreSQL com Npgsql.
+
+## Principais ganhos
+
+- Menos fricção para testar queries PostgreSQL
+- Sem custo de infraestrutura para cada execução
+- Maior produtividade para times que usam Dapper/ADO.NET
+
+## Instalação
+
+```bash
+dotnet add package DbSqlLikeMem.Npgsql
+```
+
+## Exemplo rápido
+
+```csharp
+using DbSqlLikeMem.Npgsql;
+
+var conn = new NpgsqlConnectionMock(new NpgsqlDbMock());
+conn.Open();
+```
+
+## Como ajudar
+
+A evolução de compatibilidade PostgreSQL depende de casos reais. Abra issues com exemplos e participe com PRs para cobrir novos comandos e comportamentos.

--- a/src/DbSqlLikeMem.Oracle/README.md
+++ b/src/DbSqlLikeMem.Oracle/README.md
@@ -1,0 +1,29 @@
+# DbSqlLikeMem.Oracle
+
+Com **`DbSqlLikeMem.Oracle`**, você pode testar fluxos de acesso Oracle de forma confiável e sem dependência de ambiente externo.
+
+## Benefícios
+
+- Simulação em memória para cenários Oracle
+- Facilidade para testar regras de acesso a dados
+- Redução do tempo de execução em pipelines
+- Melhor experiência para TDD/BDD em projetos com Oracle
+
+## Instalação
+
+```bash
+dotnet add package DbSqlLikeMem.Oracle
+```
+
+## Exemplo rápido
+
+```csharp
+using DbSqlLikeMem.Oracle;
+
+var conn = new OracleConnectionMock(new OracleDbMock());
+conn.Open();
+```
+
+## Comunidade
+
+Queremos construir o melhor mock Oracle para .NET, juntos. Traga exemplos, gaps de compatibilidade e PRs com testes de regressão.

--- a/src/DbSqlLikeMem.SqlServer/README.md
+++ b/src/DbSqlLikeMem.SqlServer/README.md
@@ -1,0 +1,30 @@
+# DbSqlLikeMem.SqlServer
+
+Leve a experiência de testes SQL Server para memória com **`DbSqlLikeMem.SqlServer`**.
+
+Ideal para validar repositórios, serviços e queries sem depender de infraestrutura pesada.
+
+## Por que este pacote?
+
+- Foco em comportamento de SQL Server para testes unitários/integrados
+- Mock de conexão, comando, transação e leitura de dados
+- Feedback rápido para times que trabalham com T-SQL
+
+## Instalação
+
+```bash
+dotnet add package DbSqlLikeMem.SqlServer
+```
+
+## Exemplo rápido
+
+```csharp
+using DbSqlLikeMem.SqlServer;
+
+var conn = new SqlServerConnectionMock(new SqlServerDbMock());
+conn.Open();
+```
+
+## Contribua
+
+Ajude a ampliar compatibilidade T-SQL com cenários reais, testes e documentação. Toda contribuição conta para tornar o pacote mais útil para a comunidade .NET.

--- a/src/DbSqlLikeMem.Sqlite/README.md
+++ b/src/DbSqlLikeMem.Sqlite/README.md
@@ -1,0 +1,28 @@
+# DbSqlLikeMem.Sqlite
+
+Com **`DbSqlLikeMem.Sqlite`**, você testa comportamentos inspirados em SQLite sem abrir arquivo físico nem depender de banco externo.
+
+## Para quem é
+
+- Times que desejam testes leves e rápidos
+- Projetos que usam SQLite no desktop, mobile ou serviços
+- Equipes que valorizam execução determinística no CI
+
+## Instalação
+
+```bash
+dotnet add package DbSqlLikeMem.Sqlite
+```
+
+## Exemplo rápido
+
+```csharp
+using DbSqlLikeMem.Sqlite;
+
+var conn = new SqliteConnectionMock(new SqliteDbMock());
+conn.Open();
+```
+
+## Contribuindo
+
+Contribua com melhorias de compatibilidade, exemplos de uso e documentação para tornar o pacote ainda mais atrativo para novos mantenedores e usuários.

--- a/src/DbSqlLikeMem/README.md
+++ b/src/DbSqlLikeMem/README.md
@@ -1,0 +1,36 @@
+# DbSqlLikeMem
+
+A base do ecossistema **DbSqlLikeMem**: um motor SQL-like em memória para você testar acesso a dados em C# com mais velocidade, previsibilidade e confiança.
+
+## O que este pacote entrega
+
+- Estruturas de banco em memória (schema, tabelas, colunas, índices)
+- Parser e executor SQL para cenários comuns de testes
+- Helpers de seed e construção de dados
+- Integração amigável com ADO.NET/Dapper
+
+## Quando usar
+
+Use `DbSqlLikeMem` quando quiser:
+
+- reduzir custo de testes que hoje dependem de banco real
+- criar cenários de QA de forma reproduzível
+- validar regras de query e transformação de dados com ciclo rápido
+
+## Instalação
+
+```bash
+dotnet add package DbSqlLikeMem
+```
+
+## Próximo passo
+
+Escolha também um pacote de provedor (MySql, SqlServer, Oracle, Npgsql, Sqlite ou Db2) para simular o dialeto do seu sistema.
+
+## Contribuindo
+
+Contribuições são super bem-vindas 💙
+
+- Abra issues com exemplos reais de SQL
+- Envie PR com testes cobrindo o comportamento esperado
+- Ajude a melhorar documentação e exemplos para novos usuários

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,28 @@
+# DbSqlLikeMem Packages
+
+Bem-vindo ao ecossistema **DbSqlLikeMem** 🚀
+
+Este diretório reúne os projetos empacotáveis em NuGet para executar testes de integração/unidade com banco **em memória**, mantendo a experiência de SQL e ADO.NET próxima do mundo real.
+
+## Pacotes principais
+
+- `DbSqlLikeMem` (core)
+- `DbSqlLikeMem.MySql`
+- `DbSqlLikeMem.SqlServer`
+- `DbSqlLikeMem.Oracle`
+- `DbSqlLikeMem.Npgsql`
+- `DbSqlLikeMem.Sqlite`
+- `DbSqlLikeMem.Db2`
+
+Cada projeto possui seu próprio `README.md` com proposta de valor, exemplos e orientações de contribuição.
+
+## Por que usar?
+
+- Testes rápidos e determinísticos
+- Sem necessidade de container de banco para cada cenário
+- Cobertura SQL por dialeto
+- Compatível com fluxos comuns de ADO.NET e Dapper
+
+## Quer contribuir?
+
+A comunidade é parte central da evolução do projeto. Abra uma issue, proponha melhorias de compatibilidade SQL e envie PRs com cenários reais de produção.


### PR DESCRIPTION
### Motivation
- Melhorar a descoberta e apresentação dos pacotes empacotáveis (NuGet) do ecossistema `DbSqlLikeMem` para atrair usuários e contribuidores.
- Fornecer material de onboarding com exemplos de uso e instruções de instalação por provedor para reduzir a barreira de adoção.
- Centralizar informação de contribuição para incentivar PRs com testes e exemplos reais por dialeto.

### Description
- Adicionados README: `src/README.md` (hub do ecossistema) e READMEs por pacote em `src/DbSqlLikeMem/README.md`, `src/DbSqlLikeMem.MySql/README.md`, `src/DbSqlLikeMem.SqlServer/README.md`, `src/DbSqlLikeMem.Oracle/README.md`, `src/DbSqlLikeMem.Npgsql/README.md`, `src/DbSqlLikeMem.Sqlite/README.md` e `src/DbSqlLikeMem.Db2/README.md` contendo proposta de valor, snippets de instalação, exemplos rápidos e convite à contribuição (conteúdo em PT-BR).
- Conteúdo focado em atratividade e adoção, incluindo comandos de instalação (`dotnet add package ...`) e exemplos mínimos de criação de `ConnectionMock` para cada provider.
- Mudança é apenas documentação e não altera código-fonte ou build outputs.

### Testing
- Tentativa de build automatizado com `dotnet build src/DbSqlLikeMem.slnx -v minimal` falhou porque o comando `dotnet` não está disponível no ambiente (`bash: command not found: dotnet`).
- Verificações locais básicas realizadas: arquivos criados no diretório `src/` e commit realizado com sucesso (`git commit` gerou alteração de 8 arquivos adicionados).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab7d5f350832cab31439621c90c9b)