### PR TITLE
Fix SQL Server DELETE test to accept optional FROM syntax

### DIFF
--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs
@@ -91,22 +91,26 @@ public sealed class SqlServerCommandDeleteTests(
     }
 
     /// <summary>
-    /// EN: Tests ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara behavior.
-    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara.
+    /// EN: Tests ExecuteNonQuery_DELETE_sem_FROM_remove_1_linha behavior.
+    /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sem_FROM_remove_1_linha.
     /// </summary>
     [Fact]
-    public void ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara()
+    public void ExecuteNonQuery_DELETE_sem_FROM_remove_1_linha()
     {
         var db = new SqlServerDbMock();
         var table = NewUsersTable(db);
         table.Add(RowUsers(1, "John"));
+        table.Add(RowUsers(2, "Mary"));
 
         using var conn = NewConn(threadSafe: false, db);
         using var cmd = new SqlServerCommandMock(conn) { CommandText = "DELETE users WHERE id = 1" };
 
-        // Pode ser InvalidOperationException ou outra, depende do seu pipeline.
-        var ex = Assert.ThrowsAny<Exception>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("delete", ex.Message, StringComparison.OrdinalIgnoreCase);
+        var affected = cmd.ExecuteNonQuery();
+
+        Assert.Equal(1, affected);
+        Assert.Single(table);
+        Assert.Equal(2, table[0][0]);
+        Assert.Equal(1, conn.Metrics.Deletes);
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- The SQL Server dialect implementation accepts `DELETE` statements without the `FROM` keyword, so the existing test that expected an exception for `DELETE users WHERE ...` was incorrect.

### Description
- Updated the test in `src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs` to assert successful deletion for `DELETE users WHERE id = 1` instead of expecting an exception.
- Renamed the test to `ExecuteNonQuery_DELETE_sem_FROM_remove_1_linha` and updated the bilingual XML comments to match the corrected behavior.
- Adjusted the test setup by adding a second row and replaced the exception assertion with assertions that verify the number of affected rows, the remaining table contents, and that `conn.Metrics.Deletes` is incremented.

### Testing
- Attempted to run `dotnet test src/DbSqlLikeMem.SqlServer.Test/DbSqlLikeMem.SqlServer.Test.csproj --filter "FullyQualifiedName~SqlServerCommandDeleteTests"`, but the command failed because the environment does not have the `dotnet` CLI (`dotnet: command not found`).
- No unit tests were executed due to the missing `dotnet` tool in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698abafe66cc832c8125fe7d8c1219a4)