### PR TITLE
Improve NuGet publish workflow diagnostics for missing API key

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -30,4 +30,13 @@ jobs:
       - name: Publish to NuGet.org
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push "./artifacts/*.nupkg" --api-key "$NUGET_API_KEY" --source "https://api.nuget.org/v3/index.json" --skip-duplicate
+        run: |
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "::error::NUGET_API_KEY is empty. Configure it as a Repository secret or attach the job to a GitHub Environment that defines this secret."
+            exit 1
+          fi
+
+          dotnet nuget push "./artifacts/*.nupkg" \
+            --api-key "$NUGET_API_KEY" \
+            --source "https://api.nuget.org/v3/index.json" \
+            --skip-duplicate


### PR DESCRIPTION
### Motivation
- The NuGet push step was failing with HTTP 401 because `NUGET_API_KEY` was empty at runtime, producing an ambiguous authentication error instead of surfacing the real cause.

### Description
- Add a fail-fast check in `.github/workflows/nuget-publish.yml` that verifies `NUGET_API_KEY` is set and emits a clear `::error::` message and exits if it is empty.
- Preserve the existing `dotnet nuget push` invocation so publishing proceeds unchanged when the secret is present.

### Testing
- Inspected the updated workflow with `nl -ba .github/workflows/nuget-publish.yml | sed -n '20,80p'` to verify the new validation block, which matched expectations and succeeded.
- Ran `git diff --check` to ensure there are no repository patch issues, which returned no problems.
- Ran `git status --short` to confirm the workflow file was the only change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab96fc598832c95f8f7e8a7ec95e8)