### PR TITLE
Fix MySQL DELETE without FROM handling in command mock

### DIFF
--- a/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
@@ -130,7 +130,7 @@ public class MySqlCommandMock(
             return ExecuteDropView(sqlRaw);
         }
 
-        if (IsDeleteMissingFrom(sqlRaw))
+        if (!connection.Db.Dialect.SupportsDeleteWithoutFrom && IsDeleteMissingFrom(sqlRaw))
             throw new InvalidOperationException("Invalid DELETE statement: expected FROM keyword.");
 
         // 3. Parse via AST para comandos DML (Insert, Update, Delete)


### PR DESCRIPTION
### Motivation
- A test (`Delete_WithInParameterList_ShouldDeleteMatchingRows`) failed because `MySqlCommandMock.ExecuteNonQuery` rejected MySQL-style `DELETE table WHERE ...` statements even though the MySQL dialect declares `SupportsDeleteWithoutFrom = true`.

### Description
- Updated `MySqlCommandMock.ExecuteNonQuery` to only enforce the `DELETE ... FROM ...` requirement when `connection.Db.Dialect.SupportsDeleteWithoutFrom` is `false`, so MySQL-style deletes like `DELETE users WHERE id IN @ids` are accepted (changed file: `src/DbSqlLikeMem.MySql/MySqlCommandMock.cs`).

### Testing
- Attempted to run the focused test with `dotnet test src/DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj --filter "Delete_WithInParameterList_ShouldDeleteMatchingRows"`, but the run failed because the `dotnet` CLI is not available in this environment (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698abf3cc198832cb2cd6447cb6dd6d8)