### PR TITLE
Allow DB2 DELETE syntax without FROM keyword

### DIFF
--- a/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
@@ -130,9 +130,6 @@ public class Db2CommandMock(
             return ExecuteDropView(sqlRaw);
         }
 
-        if (IsDeleteMissingFrom(sqlRaw))
-            throw new InvalidOperationException("Invalid DELETE statement: expected FROM keyword.");
-
         // 3. Parse via AST para comandos DML (Insert, Update, Delete)
         var query = SqlQueryParser.Parse(sqlRaw, connection.Db.Dialect);
 
@@ -146,20 +143,6 @@ public class Db2CommandMock(
             SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
             _ => throw new NotSupportedException($"Tipo de query não suportado em ExecuteNonQuery: {query.GetType().Name}")
         };
-    }
-
-    private static bool IsDeleteMissingFrom(string sqlRaw)
-    {
-        if (!sqlRaw.StartsWith("delete ", StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        if (sqlRaw.StartsWith("delete from ", StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        return !System.Text.RegularExpressions.Regex.IsMatch(
-            sqlRaw,
-            @"^\s*delete\s+[^\s]+\s+from\s+",
-            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
     }
 
     private int ExecuteDropView(string sqlRaw)


### PR DESCRIPTION
### Motivation
- DB2 test cases using `DELETE users WHERE ...` were being rejected by a pre-parse validation in the DB2 command mock, causing an `InvalidOperationException` for valid DB2-style delete statements and preventing the parser/executor from handling parameterized `IN` lists.

### Description
- Removed the pre-parse `DELETE` validation in `Db2CommandMock.ExecuteNonQuery` and deleted the unused `IsDeleteMissingFrom` helper in `src/DbSqlLikeMem.Db2/Db2CommandMock.cs`, allowing `DELETE` statements without `FROM` to be parsed and executed by the existing SQL parser/executor.

### Testing
- Attempted to run the targeted test with `dotnet test src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj --filter "Delete_WithInParameterList_ShouldDeleteMatchingRows"`, but `dotnet` is not available in this environment so the test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698abf2c5128832cb6c0b17643ac972f)