### PR TITLE
Scope .NET Standard 2.0 to core package and keep providers on modern TFMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This project lets you test data access code without a real database by using pro
 
 ## Requirements
 
-- .NET 8.0 (see `Directory.Build.props`)
+- Bibliotecas de provider: .NET Framework 4.8, .NET 6.0 e .NET 8.0.
+- Núcleo `DbSqlLikeMem`: .NET Standard 2.0 + .NET Framework 4.8, .NET 6.0 e .NET 8.0.
 
 ## Supported Providers
 

--- a/src/DbSqlLikeMem/DbSqlLikeMem.csproj
+++ b/src/DbSqlLikeMem/DbSqlLikeMem.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net48;net6.0;net8.0</TargetFrameworks>
 		<Description>In-memory SQL-like database engine for unit tests.</Description>
 	</PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,7 @@
 <Project>
 
 	<PropertyGroup>
-		<!--<TargetFrameworks>net8.0;net10.0</TargetFrameworks>-->
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>true</IsPackable>


### PR DESCRIPTION
### Motivation

- Providers depend on external ADO.NET drivers that commonly require modern TFMs, so applying `netstandard2.0` globally risks breaking provider packages. 
- The core library benefits from wider compatibility, so moving `netstandard2.0` to only the core package preserves broad usability without forcing providers to target older TFMs.

### Description

- Added `netstandard2.0;net48;net6.0;net8.0` to the core project by updating `src/DbSqlLikeMem/DbSqlLikeMem.csproj` to target the core library for `netstandard2.0` and modern frameworks. 
- Kept provider/test/default targets in `src/Directory.Build.props` as `net48;net6.0;net8.0` so provider packages are not forced onto `netstandard2.0`.
- Updated `README.md` Requirements to document the split: providers target `.NET Framework 4.8, .NET 6.0, .NET 8.0` while the core `DbSqlLikeMem` multi-targets including `.NET Standard 2.0`.

### Testing

- Inspected package references with `rg "<PackageReference" -n src/**/*.csproj` to gather the list of dependencies and verify which projects reference which packages, and the search completed successfully. 
- Verified presence and scope of TFMs with `rg "<TargetFrameworks>|<TargetFramework>" -n src/Directory.Build.props src/**/*.csproj`, confirming the core and Directory.Build changes were applied. 
- Attempted `dotnet build src/DbSqlLikeMem.slnx` to validate multi-target builds but the `dotnet` CLI is not available in the environment (`bash: command not found: dotnet`), so builds could not be executed here. 
- Attempted to fetch NuGet `.nuspec` files to validate package TFM support but outbound requests failed with `Tunnel connection failed: 403 Forbidden`, preventing automated compatibility verification against upstream package metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698abcd81d20832c927dcd99d8dba83a)