### PR TITLE
Adjust provider package versions by target framework

### DIFF
--- a/src/DbSqlLikeMem.MySql/DbSqlLikeMem.MySql.csproj
+++ b/src/DbSqlLikeMem.MySql/DbSqlLikeMem.MySql.csproj
@@ -3,8 +3,19 @@
 		<Description>MySQL provider for the DbSqlLikeMem in-memory SQL-like database.</Description>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="MySql.Data" Version="8.4.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="MySql.Data" Version="9.2.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="MySql.Data" Version="9.6.0" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="xunit" Version="2.9.3" />
 	</ItemGroup>
 

--- a/src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj
+++ b/src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj
@@ -3,8 +3,19 @@
 		<Description>PostgreSQL (Npgsql) provider for the DbSqlLikeMem in-memory SQL-like database.</Description>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Npgsql" Version="6.0.12" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Npgsql" Version="7.0.6" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Npgsql" Version="8.0.6" />
+	</ItemGroup>
+
 	<ItemGroup>
-		<PackageReference Include="Npgsql" Version="10.0.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 	</ItemGroup>
 

--- a/src/DbSqlLikeMem.Oracle/DbSqlLikeMem.Oracle.csproj
+++ b/src/DbSqlLikeMem.Oracle/DbSqlLikeMem.Oracle.csproj
@@ -3,8 +3,15 @@
 		<Description>Oracle provider for the DbSqlLikeMem in-memory SQL-like database.</Description>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Oracle.ManagedDataAccess" Version="23.5.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' != 'net48'">
 		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.26.100" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="xunit" Version="2.9.3" />
 	</ItemGroup>
 

--- a/src/DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj
+++ b/src/DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj
@@ -3,8 +3,19 @@
 		<Description>SQL Server provider for the DbSqlLikeMem in-memory SQL-like database.</Description>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="xunit" Version="2.9.3" />
 	</ItemGroup>
 

--- a/src/DbSqlLikeMem.Sqlite/DbSqlLikeMem.Sqlite.csproj
+++ b/src/DbSqlLikeMem.Sqlite/DbSqlLikeMem.Sqlite.csproj
@@ -3,8 +3,19 @@
 		<Description>SQLite provider for the DbSqlLikeMem in-memory SQL-like database.</Description>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.28" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.20" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.11" />
+	</ItemGroup>
+
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 	</ItemGroup>
 


### PR DESCRIPTION
### Motivation
- Multi-target build used a single driver package version that could be incompatible with some target frameworks, causing restore/build issues across `net48`, `net6.0`, and `net8.0`.
- The change aligns provider package versions with the intended runtime support for each TFM to improve restore and build compatibility.

### Description
- Replaced monolithic `PackageReference` entries with conditional `ItemGroup` entries keyed on `$(TargetFramework)` in provider projects `src/DbSqlLikeMem.{Npgsql,Sqlite,SqlServer,MySql,Oracle}/DbSqlLikeMem.*.csproj`.
- Set framework-specific driver versions: Npgsql (`net48` 6.0.12, `net6.0` 7.0.6, `net8.0` 8.0.6), Microsoft.Data.Sqlite (`net48` 6.0.28, `net6.0` 7.0.20, `net8.0` 8.0.11), Microsoft.Data.SqlClient (`net48`/`net6.0` 5.2.2, `net8.0` 6.1.4), MySql.Data (`net48` 8.4.0, `net6.0` 9.2.0, `net8.0` 9.6.0), and Oracle (`net48` `Oracle.ManagedDataAccess` 23.5.1, others `Oracle.ManagedDataAccess.Core` 23.26.100).
- Kept shared test dependency (`xunit`) untouched and preserved `ProjectReference` and `InternalsVisibleTo` entries.

### Testing
- Verified file diffs with `git diff` and committed the changes successfully, producing a commit for the five modified provider project files. 
- Attempted `dotnet restore DbSqlLikeMem.sln` but it failed in this environment because the `dotnet` CLI is not installed, so package restore/build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b20aa5524832c9ebdea6efb4f0c9a)