### PR TITLE
Add System.Text.Json package for net48 to fix JSON compile errors

### DIFF
--- a/src/DbSqlLikeMem/DbSqlLikeMem.csproj
+++ b/src/DbSqlLikeMem/DbSqlLikeMem.csproj
@@ -16,6 +16,10 @@
 		<PackageReference Include="CsvHelper" Version="33.1.0" />
 	</ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<InternalsVisibleTo Include="DbSqlLikeMem.Db2" />
 		<InternalsVisibleTo Include="DbSqlLikeMem.Db2.Test" />


### PR DESCRIPTION
### Motivation

- Corrigir erros de compilação em `AstQueryExecutorBase.cs` causados pela ausência do namespace `System.Text.Json` ao compilar para `net48`.

### Description

- Adiciona referência condicional ao pacote `System.Text.Json` (versão `8.0.5`) para o target `net48` em `src/DbSqlLikeMem/DbSqlLikeMem.csproj`.

### Testing

- Tentei executar `dotnet build src/DbSqlLikeMem/DbSqlLikeMem.csproj -f net48`, mas o CLI `dotnet` não está disponível no ambiente, portanto o build não pôde ser validado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b646fdf2c832c83dd8fa17bbc77fa)