### PR TITLE
Add System.Text.Json package for netstandard2.1

### DIFF
--- a/src/DbSqlLikeMem/DbSqlLikeMem.csproj
+++ b/src/DbSqlLikeMem/DbSqlLikeMem.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="CsvHelper" Version="33.1.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'netstandard2.1'">
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 


### PR DESCRIPTION
### Motivation
- Fix compile errors (missing `System.Text.Json` APIs such as `JsonDocument`/`JsonValueKind`) in `AstQueryExecutorBase` when building the project for `netstandard2.1` by ensuring the JSON package is referenced for that target.

### Description
- Updated `src/DbSqlLikeMem/DbSqlLikeMem.csproj` to reference `System.Text.Json` for the condition `'(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'netstandard2.1'`, so JSON APIs resolve for `netstandard2.1` builds and no extra skills from `/opt/codex/skills` were required.

### Testing
- Attempted `dotnet build src/DbSqlLikeMem/DbSqlLikeMem.csproj -f netstandard2.1` but the environment lacks the `dotnet` CLI (`bash: command not found: dotnet`), so the build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6533a718832cbcabe963e188b133)