### PR TITLE
Fix nullability and XML documentation warnings in core library

### DIFF
--- a/src/DbSqlLikeMem/Compatibility/RangeIndexPolyfill.cs
+++ b/src/DbSqlLikeMem/Compatibility/RangeIndexPolyfill.cs
@@ -8,6 +8,11 @@ public readonly struct Index : IEquatable<Index>
 {
     private readonly int _value;
 
+    /// <summary>
+    /// Initializes a new index value.
+    /// </summary>
+    /// <param name="value">Zero-based index value.</param>
+    /// <param name="fromEnd">True to count from the end, false to count from the start.</param>
     public Index(int value, bool fromEnd = false)
     {
         if (value < 0)
@@ -16,14 +21,31 @@ public readonly struct Index : IEquatable<Index>
         _value = fromEnd ? ~value : value;
     }
 
+    /// <summary>
+    /// Gets the first position in a sequence.
+    /// </summary>
     public static Index Start => new(0);
 
+    /// <summary>
+    /// Gets the position after the last element in a sequence.
+    /// </summary>
     public static Index End => new(0, fromEnd: true);
 
+    /// <summary>
+    /// Gets the underlying non-negative index value.
+    /// </summary>
     public int Value => _value < 0 ? ~_value : _value;
 
+    /// <summary>
+    /// Gets whether this index is measured from the end.
+    /// </summary>
     public bool IsFromEnd => _value < 0;
 
+    /// <summary>
+    /// Resolves this index to an absolute offset for a collection length.
+    /// </summary>
+    /// <param name="length">The collection length.</param>
+    /// <returns>The resolved absolute offset.</returns>
     public int GetOffset(int length)
     {
         var offset = IsFromEnd ? length - Value : Value;
@@ -33,18 +55,30 @@ public readonly struct Index : IEquatable<Index>
         return offset;
     }
 
+    /// <inheritdoc />
     public override bool Equals(object? obj)
         => obj is Index other && Equals(other);
 
+    /// <summary>
+    /// Determines whether this index equals another index.
+    /// </summary>
+    /// <param name="other">Other index to compare.</param>
+    /// <returns>True when both indexes represent the same value.</returns>
     public bool Equals(Index other)
         => _value == other._value;
 
+    /// <inheritdoc />
     public override int GetHashCode()
         => _value;
 
+    /// <summary>
+    /// Converts an integer into an index from the start.
+    /// </summary>
+    /// <param name="value">Zero-based index value.</param>
     public static implicit operator Index(int value)
         => new(value);
 
+    /// <inheritdoc />
     public override string ToString()
         => IsFromEnd ? $"^{Value}" : Value.ToString();
 }
@@ -54,24 +88,53 @@ public readonly struct Index : IEquatable<Index>
 /// </summary>
 public readonly struct Range : IEquatable<Range>
 {
+    /// <summary>
+    /// Initializes a new range with start and end indexes.
+    /// </summary>
+    /// <param name="start">Start index, inclusive.</param>
+    /// <param name="end">End index, exclusive.</param>
     public Range(Index start, Index end)
     {
         Start = start;
         End = end;
     }
 
+    /// <summary>
+    /// Gets the start index of the range.
+    /// </summary>
     public Index Start { get; }
 
+    /// <summary>
+    /// Gets the end index of the range.
+    /// </summary>
     public Index End { get; }
 
+    /// <summary>
+    /// Gets a range that covers all elements.
+    /// </summary>
     public static Range All => new(Index.Start, Index.End);
 
+    /// <summary>
+    /// Creates a range from the provided start index to the end.
+    /// </summary>
+    /// <param name="start">Start index, inclusive.</param>
+    /// <returns>A range that starts at <paramref name="start"/> and goes to the end.</returns>
     public static Range StartAt(Index start)
         => new(start, Index.End);
 
+    /// <summary>
+    /// Creates a range from the beginning to the provided end index.
+    /// </summary>
+    /// <param name="end">End index, exclusive.</param>
+    /// <returns>A range that starts at the beginning and ends at <paramref name="end"/>.</returns>
     public static Range EndAt(Index end)
         => new(Index.Start, end);
 
+    /// <summary>
+    /// Resolves this range into absolute offset and length for a collection size.
+    /// </summary>
+    /// <param name="length">The collection length.</param>
+    /// <returns>Tuple with resolved offset and length.</returns>
     public (int Offset, int Length) GetOffsetAndLength(int length)
     {
         var start = Start.GetOffset(length);
@@ -83,15 +146,23 @@ public readonly struct Range : IEquatable<Range>
         return (start, end - start);
     }
 
+    /// <inheritdoc />
     public override bool Equals(object? obj)
         => obj is Range other && Equals(other);
 
+    /// <summary>
+    /// Determines whether this range equals another range.
+    /// </summary>
+    /// <param name="other">Other range to compare.</param>
+    /// <returns>True when both ranges have equal start and end indexes.</returns>
     public bool Equals(Range other)
         => Start.Equals(other.Start) && End.Equals(other.End);
 
+    /// <inheritdoc />
     public override int GetHashCode()
         => (Start, End).GetHashCode();
 
+    /// <inheritdoc />
     public override string ToString()
         => $"{Start}..{End}";
 }

--- a/src/DbSqlLikeMem/Models/DbMock.cs
+++ b/src/DbSqlLikeMem/Models/DbMock.cs
@@ -97,7 +97,7 @@ public abstract class DbMock
     /// <returns>EN: True if the schema exists. PT: True se o schema existir.</returns>
     public bool TryGetValue(
         string key,
-        out ISchemaMock? value
+        out ISchemaMock value
     )
     {
         if (base.TryGetValue(key, out var v) && v != null)
@@ -105,7 +105,7 @@ public abstract class DbMock
             value = (ISchemaMock)v;
             return true;
         }
-        value = null;
+        value = null!;
         return false;
     }
 


### PR DESCRIPTION
### Motivation
- Eliminate compiler warnings `CS8767` and multiple `CS1591` warnings that appear during build.
- Ensure the `DbMock` API matches the `IReadOnlyDictionary<string, ISchemaMock>` nullability contract to avoid incorrect nullability diagnostics.
- Provide XML documentation for the NET48 `Index`/`Range` polyfill to satisfy public API documentation checks.

### Description
- Adjusted `DbMock.TryGetValue` signature to `out ISchemaMock value` and used `value = null!` on the failure path to align with the implemented interface nullability.
- Added XML documentation comments to all public members (constructors, properties, methods, and operators) in `src/DbSqlLikeMem/Compatibility/RangeIndexPolyfill.cs` to remove `CS1591` warnings.
- Changes applied to `src/DbSqlLikeMem/Models/DbMock.cs` and `src/DbSqlLikeMem/Compatibility/RangeIndexPolyfill.cs`.

### Testing
- Attempted to run `dotnet build src/DbSqlLikeMem/DbSqlLikeMem.csproj -c Debug`, which failed because the `dotnet` CLI is not available in this environment (command not found), so build could not be validated here.
- No other automated tests were executed in this environment due to tool availability constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6607b344832c8f50b63d59cb4f87)