### PR TITLE
Alinha capacidades e operadores dos Dialect para DB2/SQLite/Oracle/SqlServer e regula uso de `<=>`

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -50,3 +50,23 @@
     - `CREATE TEMPORARY TABLE` (incluindo variantes com `AS SELECT`).
     - Definição de schema via API fluente.
     - Seed de dados e execução de consultas com mocks compatíveis com Dapper.
+
+
+- **SQLite**
+  - **Versões simuladas**: 3.
+  - **Funcionalidades por versão**
+    - `WITH`/CTE: disponível (>= 3).
+    - `ON DUPLICATE KEY UPDATE`: não suportado (SQLite usa `ON CONFLICT`).
+    - Operador null-safe `<=>`: não suportado.
+    - Operadores JSON `->` e `->>`: suportados pelo parser do dialeto.
+
+- **DB2**
+  - **Versões simuladas**: 8, 9, 10, 11.
+  - **Funcionalidades por versão**
+    - `WITH`/CTE: disponível (>= 8).
+    - `MERGE`: disponível (>= 9).
+    - `FETCH FIRST`: suportado.
+    - `LIMIT/OFFSET`: não suportado pelo dialeto DB2.
+    - `ON DUPLICATE KEY UPDATE`: não suportado.
+    - Operador null-safe `<=>`: não suportado.
+    - Operadores JSON `->` e `->>`: não suportados.

--- a/src/DbSqlLikeMem.Db2.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/SqlExpressionParserTests.cs
@@ -265,12 +265,10 @@ public sealed class SqlExpressionParserTests(
     /// </summary>
     [Theory]
     [MemberDataDb2Version]
-    public void Backtick_Identifier_ShouldParse(int version)
+    public void Backtick_Identifier_ShouldThrow(int version)
     {
-        var ast = SqlExpressionParser.ParseWhere("`DeletedDtt` IS NULL", new Db2Dialect(version));
-        var n = Assert.IsType<IsNullExpr>(ast);
-        var id = Assert.IsType<IdentifierExpr>(n.Expr);
-        Assert.Equal("DeletedDtt", id.Name);
+        Assert.ThrowsAny<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseWhere("`DeletedDtt` IS NULL", new Db2Dialect(version)));
     }
 
     /// <summary>
@@ -279,12 +277,20 @@ public sealed class SqlExpressionParserTests(
     /// </summary>
     [Theory]
     [MemberDataDb2Version]
-    public void DoubleQuoted_String_ShouldParse(int version)
+    public void DoubleQuoted_Identifier_ShouldParse(int version)
     {
         var ast = SqlExpressionParser.ParseWhere("name = \"John\"", new Db2Dialect(version));
         var eq = Assert.IsType<BinaryExpr>(ast);
-        var lit = Assert.IsType<LiteralExpr>(eq.Right);
-        Assert.Equal("John", lit.Value);
+        var id = Assert.IsType<IdentifierExpr>(eq.Right);
+        Assert.Equal("John", id.Name);
+    }
+
+    [Theory]
+    [MemberDataDb2Version]
+    public void NullSafe_Operator_ShouldThrow(int version)
+    {
+        Assert.ThrowsAny<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseWhere("a <=> b", new Db2Dialect(version)));
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Db2/Db2DbVersions.cs
+++ b/src/DbSqlLikeMem.Db2/Db2DbVersions.cs
@@ -7,9 +7,9 @@ internal static class Db2DbVersions
     /// </summary>
     public static IEnumerable<int> Versions()
     {
-        yield return 3;
-        yield return 4;
-        yield return 5;
         yield return 8;
+        yield return 9;
+        yield return 10;
+        yield return 11;
     }
 }

--- a/src/DbSqlLikeMem.Db2/Db2Dialect.cs
+++ b/src/DbSqlLikeMem.Db2/Db2Dialect.cs
@@ -9,7 +9,7 @@ internal sealed class Db2Dialect : SqlDialectBase
         ) : base(
         name: DialectName,
         version: version,
-        keywords: ["REGEXP"],
+        keywords: [],
         binOps:
         [
             new KeyValuePair<string, SqlBinaryOp>("AND", SqlBinaryOp.And),
@@ -21,59 +21,57 @@ internal sealed class Db2Dialect : SqlDialectBase
             new KeyValuePair<string, SqlBinaryOp>(">=", SqlBinaryOp.GreaterOrEqual),
             new KeyValuePair<string, SqlBinaryOp>("<", SqlBinaryOp.Less),
             new KeyValuePair<string, SqlBinaryOp>("<=", SqlBinaryOp.LessOrEqual),
-            new KeyValuePair<string, SqlBinaryOp>("<=>", SqlBinaryOp.NullSafeEq),
         ],
         operators:
         [
-            "<=>", "->>", "->",
-            ">=", "<=", "<>", "!=", "==",
-            "&&", "||"
+            ">=", "<=", "<>", "!="
         ])
     { }
 
  
     internal const int WithCteMinVersion = 8;
-    internal const int MergeMinVersion = int.MaxValue;
+    internal const int MergeMinVersion = 9;
     
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool AllowsBacktickIdentifiers => true;
+    public override bool AllowsBacktickIdentifiers => false;
     
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool AllowsDoubleQuoteIdentifiers => false; // keep tokenizer behavior: " as string
+    public override bool AllowsDoubleQuoteIdentifiers => true;
     
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override SqlIdentifierEscapeStyle IdentifierEscapeStyle => SqlIdentifierEscapeStyle.backtick;
+    public override SqlIdentifierEscapeStyle IdentifierEscapeStyle => SqlIdentifierEscapeStyle.double_quote;
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool IsStringQuote(char ch) => ch is '\'' or '"';
+    public override bool IsStringQuote(char ch) => ch == '\'';
     
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override SqlStringEscapeStyle StringEscapeStyle => SqlStringEscapeStyle.backslash;
+    public override SqlStringEscapeStyle StringEscapeStyle => SqlStringEscapeStyle.doubled_quote;
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsHashLineComment => true;
+    public override bool SupportsHashLineComment => false;
 
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsLimitOffset => true;
+    public override bool SupportsLimitOffset => false;
+    public override bool SupportsFetchFirst => true;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsOnDuplicateKeyUpdate => true;
+    public override bool SupportsOnDuplicateKeyUpdate => false;
 
     /// <summary>
     /// Auto-generated summary.
@@ -83,20 +81,21 @@ internal sealed class Db2Dialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsDeleteTargetAlias => true;
+    public override bool SupportsDeleteTargetAlias => false;
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public override bool SupportsWithCte => Version >= WithCteMinVersion;
+    public override bool SupportsMerge => Version >= MergeMinVersion;
     
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsNullSafeEq => true;
+    public override bool SupportsNullSafeEq => false;
     
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsJsonArrowOperators => true;
+    public override bool SupportsJsonArrowOperators => false;
 }

--- a/src/DbSqlLikeMem.Db2/Models/Db2DbMock.cs
+++ b/src/DbSqlLikeMem.Db2/Models/Db2DbMock.cs
@@ -14,7 +14,7 @@ public class Db2DbMock
     /// </summary>
     public Db2DbMock(
         int? version = null
-        ): base(version ?? 8)
+        ): base(version ?? 11)
     {
         Dialect = new Db2Dialect(Version);
     }

--- a/src/DbSqlLikeMem.Oracle/OracleDialect.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDialect.cs
@@ -23,8 +23,7 @@ internal sealed class OracleDialect : SqlDialectBase
         ],
         operators:
         [
-            ">=", "<=", "<>", "!=", "==",
-            "&&", "||"
+            ">=", "<=", "<>", "!=", "||"
         ])
     { }
 
@@ -36,7 +35,7 @@ internal sealed class OracleDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool AllowsBracketIdentifiers => true;
+    public override bool AllowsBracketIdentifiers => false;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
@@ -44,7 +43,7 @@ internal sealed class OracleDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override SqlIdentifierEscapeStyle IdentifierEscapeStyle => SqlIdentifierEscapeStyle.bracket;
+    public override SqlIdentifierEscapeStyle IdentifierEscapeStyle => SqlIdentifierEscapeStyle.double_quote;
 
     /// <summary>
     /// Auto-generated summary.
@@ -58,7 +57,7 @@ internal sealed class OracleDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsTop => true;
+    public override bool SupportsTop => false;
 
     // OFFSET ... FETCH / FETCH FIRST entrou no Oracle 12c.
     /// <summary>
@@ -77,7 +76,7 @@ internal sealed class OracleDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsDeleteTargetAlias => true;
+    public override bool SupportsDeleteTargetAlias => false;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
@@ -23,8 +23,7 @@ internal sealed class SqlServerDialect : SqlDialectBase
         ],
         operators:
         [
-            ">=", "<=", "<>", "!=", "==",
-            "&&", "||"
+            ">=", "<=", "<>", "!="
         ])
     { }
 

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlExpressionParserTests.cs
@@ -287,6 +287,14 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("John", lit.Value);
     }
 
+    [Theory]
+    [MemberDataSqliteVersion]
+    public void NullSafe_Operator_ShouldThrow(int version)
+    {
+        Assert.ThrowsAny<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseWhere("a <=> b", new SqliteDialect(version)));
+    }
+
     /// <summary>
     /// EN: Tests Printer_ShouldBeStable_ForSimpleExpression behavior.
     /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.

--- a/src/DbSqlLikeMem.Sqlite/Models/SqliteDbMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/Models/SqliteDbMock.cs
@@ -14,7 +14,7 @@ public class SqliteDbMock
     /// </summary>
     public SqliteDbMock(
         int? version = null
-        ): base(version ?? 8)
+        ): base(version ?? 3)
     {
         Dialect = new SqliteDialect(Version);
     }

--- a/src/DbSqlLikeMem.Sqlite/SqliteDbVersions.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDbVersions.cs
@@ -8,8 +8,5 @@ internal static class SqliteDbVersions
     public static IEnumerable<int> Versions()
     {
         yield return 3;
-        yield return 4;
-        yield return 5;
-        yield return 8;
     }
 }

--- a/src/DbSqlLikeMem.Sqlite/SqliteDialect.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDialect.cs
@@ -21,18 +21,17 @@ internal sealed class SqliteDialect : SqlDialectBase
             new KeyValuePair<string, SqlBinaryOp>(">=", SqlBinaryOp.GreaterOrEqual),
             new KeyValuePair<string, SqlBinaryOp>("<", SqlBinaryOp.Less),
             new KeyValuePair<string, SqlBinaryOp>("<=", SqlBinaryOp.LessOrEqual),
-            new KeyValuePair<string, SqlBinaryOp>("<=>", SqlBinaryOp.NullSafeEq),
         ],
         operators:
         [
-            "<=>", "->>", "->",
+            "->>", "->",
             ">=", "<=", "<>", "!=", "==",
             "&&", "||"
         ])
     { }
 
  
-    internal const int WithCteMinVersion = 8;
+    internal const int WithCteMinVersion = 3;
     internal const int MergeMinVersion = int.MaxValue;
     /// <summary>
     /// Auto-generated summary.
@@ -41,11 +40,11 @@ internal sealed class SqliteDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool AllowsDoubleQuoteIdentifiers => false; // keep tokenizer behavior: " as string
+    public override bool AllowsDoubleQuoteIdentifiers => true;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override SqlIdentifierEscapeStyle IdentifierEscapeStyle => SqlIdentifierEscapeStyle.backtick;
+    public override SqlIdentifierEscapeStyle IdentifierEscapeStyle => SqlIdentifierEscapeStyle.double_quote;
 
     /// <summary>
     /// Auto-generated summary.
@@ -54,7 +53,7 @@ internal sealed class SqliteDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override SqlStringEscapeStyle StringEscapeStyle => SqlStringEscapeStyle.backslash;
+    public override SqlStringEscapeStyle StringEscapeStyle => SqlStringEscapeStyle.doubled_quote;
 
     /// <summary>
     /// Auto-generated summary.
@@ -69,7 +68,7 @@ internal sealed class SqliteDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsOnDuplicateKeyUpdate => true;
+    public override bool SupportsOnDuplicateKeyUpdate => false;
 
     /// <summary>
     /// Auto-generated summary.
@@ -78,7 +77,7 @@ internal sealed class SqliteDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsDeleteTargetAlias => true;
+    public override bool SupportsDeleteTargetAlias => false;
 
     /// <summary>
     /// Auto-generated summary.
@@ -87,7 +86,7 @@ internal sealed class SqliteDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsNullSafeEq => true;
+    public override bool SupportsNullSafeEq => false;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>

--- a/src/DbSqlLikeMem/Parser/SqlExpressionParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlExpressionParser.cs
@@ -1159,13 +1159,15 @@ internal sealed class SqlExpressionParser(
         // Dialect can define extra operators (ex: MySQL <=>).
         if (_dialect.TryMapBinaryOperator(op, out bop))
         {
+            if (bop == SqlBinaryOp.NullSafeEq)
+                return _dialect.SupportsNullSafeEq;
+
             return bop is SqlBinaryOp.Eq
                 or SqlBinaryOp.Neq
                 or SqlBinaryOp.Greater
                 or SqlBinaryOp.GreaterOrEqual
                 or SqlBinaryOp.Less
-                or SqlBinaryOp.LessOrEqual
-                or SqlBinaryOp.NullSafeEq;
+                or SqlBinaryOp.LessOrEqual;
         }
 
         bop = default;


### PR DESCRIPTION
### Motivation
- Corrigir inconsistências entre as implementações de `SqlDialect` e o comportamento real esperado por cada banco (operadores, styles de quoting e features por versão). 
- Garantir que operadores e gates de funcionalidade (ex.: `<=>`, `WITH`/CTE, `MERGE`, `FETCH FIRST`) só sejam aceitos quando o dialeto/versão declara suporte.

### Description
- Ajusta flags e mapas de operadores nos dialetos: `Db2Dialect`, `SqliteDialect`, `OracleDialect` e `SqlServerDialect` (remoção de operadores não-nativos como `==`/`&&`, remoção de `<=>` para DB2/SQLite, alteração de `AllowsDoubleQuoteIdentifiers`/`AllowsBracketIdentifiers`/`IdentifierEscapeStyle`, alteração de `SupportsTop`/`SupportsFetchFirst`/`SupportsLimitOffset`/`SupportsOnDuplicateKeyUpdate`/`SupportsDeleteTargetAlias` etc.).
- Atualiza versões simuladas e defaults em `Db2DbVersions`, `SqliteDbVersions`, `Db2DbMock` e `SqliteDbMock` para refletir as versões suportadas e defaults reais (`DB2: 8,9,10,11` default `11`; `SQLite: 3` default `3`).
- Endurece o parser em `SqlExpressionParser.TryMapComparisonOp` para que `SqlBinaryOp.NullSafeEq` (`<=>`) seja aceito somente se `ISqlDialect.SupportsNullSafeEq` for `true`.
- Atualiza/expande testes de parser em `src/.../SqlExpressionParserTests.cs` (DB2/SQLite) para validar comportamento de quoting e rejeição do operador `<=>` quando não suportado, e atualiza `Features.md` com notas de SQLite/DB2.

### Testing
- Executado `git diff --check` para checar diferenças e estilo, que passou sem erros.
- Tentativa de executar testes com `dotnet test src/DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj --no-restore` falhou no ambiente atual porque o comando `dotnet` não está disponível (ambiente sem SDK); nenhum `dotnet` test foi concluído aqui.
- Vários runs de busca/inspeção (`rg`, `sed`, `nl`) e revisão de arquivos fonte foram realizados para validar alterações e consistência entre dialetos e testes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bba70e13c832ca0290ef905788a21)