### PR TITLE
Adjust NuGet publish workflow for multi-target framework support

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore
         run: dotnet restore src/DbSqlLikeMem.slnx


### PR DESCRIPTION
### Motivation

- The repository now targets multiple frameworks including `net48` and `net10.0`, so the CI publishing job must use an OS and SDK that can restore/pack those TFMs reliably.

### Description

- Updated `.github/workflows/nuget-publish.yml` to run the publish job on `windows-latest` so `net48` can be packed on the runner.
- Updated the `actions/setup-dotnet` `dotnet-version` from `8.0.x` to `10.0.x` so the workflow can evaluate and pack `net10.0` targets.

### Testing

- Ran `dotnet --info` locally and it failed in this environment (`dotnet: command not found`), so local CLI validation was not possible.
- Verified project TFMs and packaging settings by inspecting `src/Directory.Build.props` and relevant `*.csproj` files to confirm the presence of `net48` and `net10.0` targets (inspection succeeded).
- Inspected the workflow file with `nl -ba .github/workflows/nuget-publish.yml` and confirmed the runner and SDK lines were updated (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bbe84cdbc832c916da7c8f1192b93)