### PR TITLE
Adicionar workflow GitHub Actions para build e publicação do VSIX do Visual Studio

### DIFF
--- a/.github/workflows/vsix-publish.yml
+++ b/.github/workflows/vsix-publish.yml
@@ -1,0 +1,101 @@
+name: Publish Visual Studio Extension (VSIX)
+
+on:
+  workflow_dispatch:
+    inputs:
+      vsix_project:
+        description: Caminho para o projeto VSIX (.csproj/.vsixproj)
+        required: false
+        default: src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
+      publish_manifest:
+        description: Caminho para o manifesto de publicação (PublishManifest.json)
+        required: false
+        default: eng/visualstudio/PublishManifest.json
+      publish:
+        description: Publicar no Marketplace
+        required: true
+        type: boolean
+        default: false
+  push:
+    tags:
+      - "vsix-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build VSIX
+        shell: pwsh
+        env:
+          VSIX_PROJECT: ${{ github.event.inputs.vsix_project || 'src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj' }}
+        run: |
+          if (-not (Test-Path $env:VSIX_PROJECT)) {
+            Write-Error "Projeto VSIX não encontrado: $env:VSIX_PROJECT"
+            Write-Host "Dica: ajuste o input 'vsix_project' no workflow_dispatch quando o projeto estiver pronto."
+            exit 1
+          }
+
+          msbuild $env:VSIX_PROJECT /restore /t:Build /p:Configuration=Release /p:DeployExtension=false
+
+      - name: Locate generated VSIX
+        id: locate_vsix
+        shell: pwsh
+        run: |
+          $vsix = Get-ChildItem -Path . -Recurse -Filter *.vsix |
+            Where-Object { $_.FullName -notmatch '\\bin\\.*\\TestResults\\|\\obj\\' } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+
+          if (-not $vsix) {
+            Write-Error "Nenhum arquivo .vsix foi encontrado após o build."
+            exit 1
+          }
+
+          "path=$($vsix.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "VSIX localizado em: $($vsix.FullName)"
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vsix-package
+          path: ${{ steps.locate_vsix.outputs.path }}
+
+      - name: Publish to Visual Studio Marketplace
+        if: ${{ github.event_name == 'push' || github.event.inputs.publish == 'true' }}
+        shell: pwsh
+        env:
+          VS_MARKETPLACE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          PUBLISH_MANIFEST: ${{ github.event.inputs.publish_manifest || 'eng/visualstudio/PublishManifest.json' }}
+        run: |
+          if (-not $env:VS_MARKETPLACE_TOKEN) {
+            Write-Error "Secret VS_MARKETPLACE_TOKEN não configurado."
+            exit 1
+          }
+
+          if (-not (Test-Path $env:PUBLISH_MANIFEST)) {
+            Write-Error "Manifesto de publicação não encontrado: $env:PUBLISH_MANIFEST"
+            exit 1
+          }
+
+          $vsixPublisher = Get-ChildItem "C:\Program Files\Microsoft Visual Studio" -Recurse -Filter VsixPublisher.exe -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+
+          if (-not $vsixPublisher) {
+            Write-Error "VsixPublisher.exe não encontrado no runner."
+            exit 1
+          }
+
+          & $vsixPublisher.FullName publish `
+            -payload "${{ steps.locate_vsix.outputs.path }}" `
+            -publishManifest $env:PUBLISH_MANIFEST `
+            -personalAccessToken $env:VS_MARKETPLACE_TOKEN

--- a/README.md
+++ b/README.md
@@ -191,6 +191,30 @@ dotnet pack src/DbSqlLikeMem.slnx -c Release -o ./artifacts
 dotnet nuget push "./artifacts/*.nupkg" --api-key "<SUA_API_KEY>" --source "https://api.nuget.org/v3/index.json"
 ```
 
+
+## Publicando a extensão do Visual Studio (VSIX)
+
+Quando o projeto VSIX estiver maduro, o repositório já fica preparado para publicar no Marketplace do Visual Studio com o workflow:
+
+- `.github/workflows/vsix-publish.yml`
+
+### Pré-requisitos
+
+1. Criar um Personal Access Token para publicação no Marketplace do Visual Studio.
+2. Salvar o token no GitHub como secret `VS_MARKETPLACE_TOKEN`.
+3. Ajustar os placeholders em `eng/visualstudio/PublishManifest.json` (`publisher`, `repo`, `identity.internalName`, etc.).
+4. Garantir que exista um projeto VSIX (por padrão o workflow usa `src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj`).
+
+### Como publicar
+
+- **Manual (recomendado para validação):**
+  - Execute o workflow **Publish Visual Studio Extension (VSIX)** via `workflow_dispatch`.
+  - Defina `publish = true` para realmente publicar.
+- **Automático por tag:**
+  - Crie uma tag no formato `vsix-v*` (ex.: `vsix-v1.0.0`).
+
+O pipeline compila o projeto VSIX, gera artifact com o `.vsix` e, quando habilitado, executa o `VsixPublisher.exe` para publicação.
+
 ## Contributing
 
 Contributions are welcome! If you want to help improve DbSqlLikeMem, please open an issue to discuss your idea or submit a pull request. Areas where help is especially valuable:

--- a/eng/visualstudio/PublishManifest.json
+++ b/eng/visualstudio/PublishManifest.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vsmarketplace/master/schemas/vsix-publish-manifest-schema.json",
+  "categories": [
+    "coding"
+  ],
+  "identity": {
+    "internalName": "DbSqlLikeMem"
+  },
+  "overview": "README.md",
+  "priceCategory": "free",
+  "publisher": "SEU_PUBLISHER",
+  "qna": true,
+  "repo": "https://github.com/SEU_ORG/DbSqlLikeMem",
+  "releaseNotes": "Release notes",
+  "tags": [
+    "database",
+    "sql",
+    "testing",
+    "visual studio"
+  ]
+}


### PR DESCRIPTION
### Motivation

- Preparar o repositório para publicar a extensão do Visual Studio (VSIX) quando o projeto estiver maduro, fornecendo um pipeline padrão e seguro. 
- Facilitar publicação manual e por tag, com validações e mensagens claras quando pré-requisitos estiverem ausentes. 

### Description

- Adiciona o workflow ` .github/workflows/vsix-publish.yml` que suporta `workflow_dispatch` (com inputs `vsix_project`, `publish_manifest`, `publish`) e acionamento por tags `vsix-v*`, realiza build via `msbuild`, localiza o `.vsix`, faz upload do artifact e publica opcionalmente ao Marketplace usando `VsixPublisher.exe` e o secret `VS_MARKETPLACE_TOKEN`. 
- Inclui um template de manifesto de publicação em `eng/visualstudio/PublishManifest.json` com placeholders (`publisher`, `repo`, `identity.internalName`) para serem ajustados antes da publicação real. 
- Atualiza o `README.md` com uma seção explicando pré-requisitos, como executar o workflow manualmente, e o fluxo de publicação por tag. 

### Testing

- Validei o JSON do manifesto com `python -m json.tool eng/visualstudio/PublishManifest.json`, que retornou com sucesso. 
- Executei `git diff --check` para verificar problemas de formatação/whitespace, sem erros reportados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc7c089b8832cacf43b1a9802619a)