### PR TITLE
Enhance PostgreSQL ON CONFLICT parser support

### DIFF
--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
@@ -25,4 +25,39 @@ public sealed class NpgsqlDialectFeatureParserTests
 
         Assert.IsType<SqlSelectQuery>(parsed);
     }
+
+    [Theory]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_OnConstraint_DoUpdate_ShouldParse(int version)
+    {
+        var sql = @"INSERT INTO users (id, name)
+VALUES (1, 'a')
+ON CONFLICT ON CONSTRAINT users_pkey
+DO UPDATE SET name = EXCLUDED.name";
+
+        var parsed = SqlQueryParser.Parse(sql, new NpgsqlDialect(version));
+
+        var ins = Assert.IsType<SqlInsertQuery>(parsed);
+        Assert.True(ins.HasOnDuplicateKeyUpdate);
+        Assert.Single(ins.OnDupAssigns);
+        Assert.Equal("name", ins.OnDupAssigns[0].Col);
+    }
+
+    [Theory]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_TargetWhere_UpdateWhere_Returning_ShouldParse(int version)
+    {
+        var sql = @"INSERT INTO users (id, name)
+VALUES (1, 'a')
+ON CONFLICT (id) WHERE id > 0
+DO UPDATE SET name = EXCLUDED.name
+WHERE users.id = EXCLUDED.id
+RETURNING id";
+
+        var parsed = SqlQueryParser.Parse(sql, new NpgsqlDialect(version));
+
+        var ins = Assert.IsType<SqlInsertQuery>(parsed);
+        Assert.True(ins.HasOnDuplicateKeyUpdate);
+        Assert.Single(ins.OnDupAssigns);
+    }
 }


### PR DESCRIPTION
### Motivation
- Improve SQL parser compatibility with PostgreSQL-specific `INSERT ... ON CONFLICT` variants to better support provider-specific behaviors used by the mock engine.
- Keep AST backward-compatible while accepting more valid Postgres syntax forms so higher-level strategies can rely on the parser not to error on valid SQL.

### Description
- Add `ParsePostgreSqlOnConflictTarget()` helper to recognize `ON CONFLICT ON CONSTRAINT <name>`, parenthesized target lists and optional `WHERE` predicates for the conflict target.
- Extend `ParseOnDuplicated()` to accept `ON CONFLICT ... DO UPDATE SET ...`, optional `DO UPDATE ... WHERE ...`, and optional trailing `RETURNING ...` (consumed by the parser even though `INSERT` AST does not yet expose `RETURNING`).
- Add parser tests in `src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs` that cover `ON CONFLICT ON CONSTRAINT ... DO UPDATE` and a full upsert with target `WHERE`, update `WHERE`, and `RETURNING`.
- Modified files: `src/DbSqlLikeMem/Parser/SqlQueryParser.cs` and `src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs`.

### Testing
- Added unit tests in `NpgsqlDialectFeatureParserTests` for the new `ON CONFLICT` variants (tests added but not previously present).
- Attempted to run `dotnet test src/DbSqlLikeMem.Npgsql.Test/DbSqlLikeMem.Npgsql.Test.csproj --filter NpgsqlDialectFeatureParserTests` but the environment lacks the `dotnet` CLI (`bash: command not found: dotnet`), so tests were not executed here.
- Repository changes were committed locally with the message `Enhance PostgreSQL ON CONFLICT parser support`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bcefb7cf4832c860bf8a2c3fd76ec)