### PR TITLE
Fix MySqlConsoleGenerator ColumnDef metadata generation

### DIFF
--- a/src/DbSqlLikeMem.MySqlConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.MySqlConsoleGenerator/Program.cs
@@ -190,7 +190,7 @@ SELECT COLUMN_NAME
                     CharMaxLen: rd["CHARACTER_MAXIMUM_LENGTH"] is DBNull ? null : Convert.ToInt64(rd["CHARACTER_MAXIMUM_LENGTH"], CultureInfo.InvariantCulture),
                     NumPrecision: rd["NUMERIC_PRECISION"] is DBNull ? null : Convert.ToInt32(rd["NUMERIC_PRECISION"], CultureInfo.InvariantCulture),
                     NumScale: rd["NUMERIC_SCALE"] is DBNull ? null : Convert.ToInt32(rd["NUMERIC_SCALE"], CultureInfo.InvariantCulture),
-                    Generated: rd["GENERATION_EXPRESSION"] is DbString ? null : rd.GetString("GENERATION_EXPRESSION")
+                    Generated: rd["GENERATION_EXPRESSION"] is DBNull ? null : rd.GetString("GENERATION_EXPRESSION")
                 );
                 cols.Add(col);
             }
@@ -317,6 +317,12 @@ SELECT KCU.COLUMN_NAME
                     isBool: string.Equals(dbType, "Boolean", StringComparison.OrdinalIgnoreCase));
                 w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DefaultValue = {literal};");
             }
+
+            if (c.CharMaxLen is > 0 and <= int.MaxValue)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].Size = {(int)c.CharMaxLen};");
+
+            if (c.NumScale is >= 0)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DecimalPlaces = {c.NumScale.Value};");
 
             // EnumValues, se enum(...)
             var enums = TryParseEnumValues(c.ColumnType);


### PR DESCRIPTION
### Motivation
- The MySQL table generator produced ColumnDef instances without populating size/scale metadata and had an incorrect null check for `GENERATION_EXPRESSION`, which caused missing or wrong column metadata in generated table files.

### Description
- Fixed reading of `GENERATION_EXPRESSION` by checking `DBNull` instead of the previously incorrect type check.
- Emit `Size` assignment for generated `ColumnDef` using `CHARACTER_MAXIMUM_LENGTH` when present.
- Emit `DecimalPlaces` assignment for generated `ColumnDef` using `NUMERIC_SCALE` when present.
- Changes applied to `src/DbSqlLikeMem.MySqlConsoleGenerator/Program.cs` in the table metadata loading and code generation sections.

### Testing
- Attempted to run `dotnet build src/DbSqlLikeMem.MySqlConsoleGenerator/DbSqlLikeMem.MySqlConsoleGenerator.csproj`, but the build could not be executed because `dotnet` is not available in the current environment (`command not found`), so no compile/test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698be704f468832c804d8d87fee22db3)