### PR TITLE
Fix DB2 Dapper tests to use DB2-compliant quoted identifiers

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.Db2.Test/DapperUserTests2.cs
@@ -132,7 +132,7 @@ public sealed class DapperUserTests2(
 
         using var command = new Db2CommandMock(connection)
         {
-            CommandText = "SELECT * FROM `Users1`; SELECT * FROM `Users2`;"
+            CommandText = "SELECT * FROM \"Users1\"; SELECT * FROM \"Users2\";"
         };
 
         // Act
@@ -190,8 +190,8 @@ public sealed class DapperUserTests2(
 
         const string sql = @"
                 SELECT U.*, UT.TenantId 
-                FROM `User` U
-                JOIN `UserTenant` UT ON U.Id = UT.UserId
+                FROM \"User\" U
+                JOIN \"UserTenant\" UT ON U.Id = UT.UserId
                 WHERE U.Id = @Id";
 
         using var command = new Db2CommandMock(connection)


### PR DESCRIPTION
### Motivation
- Tests for the DB2 dialect were using MySQL-style backtick identifiers which the DB2 parser rejects, causing tokenization errors (InvalidOperationException) when parsing the test SQL.

### Description
- Replaced MySQL-style backticks with DB2-compatible double quotes in the test SQL strings in `src/DbSqlLikeMem.Db2.Test/DapperUserTests2.cs`, updating both the multi-result-set query and the JOIN query so the tests keep the same intent but use valid DB2 identifier quoting.

### Testing
- Attempted to run the affected tests with `dotnet test src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj --filter "FullyQualifiedName~DapperUserTests2.QueryMultipleShouldReturnMultipleUserResultSets|FullyQualifiedName~DapperUserTests2.QueryWithJoinShouldReturnJoinedData"` but the command could not run because the `dotnet` CLI is not installed in this environment (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d056fa724832c81dd5af7ef2369b3)