### PR TITLE
Adota Strategy para regras de geração por banco de dados

### DIFF
--- a/src/DbSqlLikeMem.MySqlConsoleGenerator/DbSqlLikeMem.MySqlConsoleGenerator.csproj
+++ b/src/DbSqlLikeMem.MySqlConsoleGenerator/DbSqlLikeMem.MySqlConsoleGenerator.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DbSqlLikeMem.VisualStudioExtension.Core\DbSqlLikeMem.VisualStudioExtension.Core.csproj" />
     <ProjectReference Include="..\DbSqlLikeMem.MySql\DbSqlLikeMem.MySql.csproj" />
   </ItemGroup>
 

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GenerationRuleSetTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GenerationRuleSetTests.cs
@@ -1,0 +1,18 @@
+namespace DbSqlLikeMem.VisualStudioExtension.Core.Test;
+
+public sealed class GenerationRuleSetTests
+{
+    [Fact]
+    public void MapDbType_UsesMySqlStrategyWhenDatabaseTypeIsMySql()
+    {
+        var type = GenerationRuleSet.MapDbType("bit", null, 8, "Mask", "MySql");
+        Assert.Equal("UInt64", type);
+    }
+
+    [Fact]
+    public void MapDbType_UsesDefaultStrategyWhenDatabaseTypeIsSqlServer()
+    {
+        var type = GenerationRuleSet.MapDbType("tinyint", null, 1, "IsEnabled", "SqlServer");
+        Assert.Equal("Byte", type);
+    }
+}

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/ClassGenerator.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/ClassGenerator.cs
@@ -1,7 +1,4 @@
 using DbSqlLikeMem.VisualStudioExtension.Core.Models;
-using System.Globalization;
-using System.Text;
-
 namespace DbSqlLikeMem.VisualStudioExtension.Core.Generation;
 
 public sealed class ClassGenerator
@@ -41,7 +38,7 @@ public sealed class ClassGenerator
             ? "{NamePascal}{Type}Factory.cs"
             : fileNamePattern;
 
-        var namePascal = ToPascalCase(dbObject.Name);
+        var namePascal = GenerationRuleSet.ToPascalCase(dbObject.Name);
         var typeName = dbObject.Type.ToString();
 
         return safePattern
@@ -53,57 +50,4 @@ public sealed class ClassGenerator
             .Replace("{DatabaseName}", connection.DatabaseName, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string ToPascalCase(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return "Object";
-        }
-
-        var parts = value
-            .Split(['_', '-', '.', ' '], StringSplitOptions.RemoveEmptyEntries)
-            .Select(Capitalize)
-            .Where(static part => !string.IsNullOrWhiteSpace(part));
-
-        var joined = string.Concat(parts);
-        if (!string.IsNullOrWhiteSpace(joined))
-        {
-            return joined;
-        }
-
-        var filtered = new string(value.Where(char.IsLetterOrDigit).ToArray());
-        return string.IsNullOrWhiteSpace(filtered) ? "Object" : Capitalize(filtered);
-    }
-
-    private static string Capitalize(string part)
-    {
-        if (string.IsNullOrWhiteSpace(part))
-        {
-            return string.Empty;
-        }
-
-        var normalized = new StringBuilder(part.Length);
-        foreach (var ch in part)
-        {
-            if (char.IsLetterOrDigit(ch))
-            {
-                normalized.Append(ch);
-            }
-        }
-
-        if (normalized.Length == 0)
-        {
-            return string.Empty;
-        }
-
-        var cleaned = normalized.ToString();
-        if (cleaned.Length == 1)
-        {
-            return cleaned.ToUpperInvariant();
-        }
-
-        return string.Concat(
-            char.ToUpper(cleaned[0], CultureInfo.InvariantCulture),
-            cleaned[1..]);
-    }
 }

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/DefaultGenerationRuleStrategy.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/DefaultGenerationRuleStrategy.cs
@@ -1,0 +1,52 @@
+namespace DbSqlLikeMem.VisualStudioExtension.Core.Generation;
+
+internal sealed class DefaultGenerationRuleStrategy : IGenerationRuleStrategy
+{
+    public string MapDbType(GenerationTypeContext context)
+    {
+        var normalizedType = context.DataType.ToLowerInvariant();
+
+        var looksGuid =
+            (normalizedType is "binary" or "varbinary") && context.CharMaxLen == 16
+            || (normalizedType is "char" && context.CharMaxLen == 36
+                && (context.ColumnName.EndsWith("guid", StringComparison.OrdinalIgnoreCase)
+                    || context.ColumnName.EndsWith("uuid", StringComparison.OrdinalIgnoreCase)));
+
+        if (looksGuid)
+        {
+            return "Guid";
+        }
+
+        return normalizedType switch
+        {
+            "tinyint" => "Byte",
+            "smallint" => "Int16",
+            "mediumint" => "Int32",
+            "int" or "integer" => "Int32",
+            "bigint" => "Int64",
+
+            "bit" => "Boolean",
+
+            "decimal" or "numeric" => "Decimal",
+            "double" => "Double",
+            "float" or "real" => "Single",
+
+            "date" => "Date",
+            "datetime" or "timestamp" => "DateTime",
+            "time" => "Time",
+
+            "year" => "Int32",
+
+            "char" or "nchar" or "varchar" or "nvarchar" or "text" or "tinytext" or "mediumtext" or "longtext" or "json" or "enum" or "set"
+                => "String",
+
+            "binary" or "varbinary" or "blob" or "tinyblob" or "mediumblob" or "longblob" or "bytea"
+                => "Binary",
+
+            "uniqueidentifier" or "uuid" => "Guid",
+            "bool" or "boolean" => "Boolean",
+
+            _ => "Object"
+        };
+    }
+}

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/GenerationRuleSet.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/GenerationRuleSet.cs
@@ -1,0 +1,132 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DbSqlLikeMem.VisualStudioExtension.Core.Generation;
+
+public static partial class GenerationRuleSet
+{
+    public static string ToPascalCase(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "Object";
+        }
+
+        var parts = value
+            .Split(['_', '-', '.', ' '], StringSplitOptions.RemoveEmptyEntries)
+            .Select(Capitalize)
+            .Where(static part => !string.IsNullOrWhiteSpace(part));
+
+        var joined = string.Concat(parts);
+        if (!string.IsNullOrWhiteSpace(joined))
+        {
+            return joined;
+        }
+
+        var filtered = new string(value.Where(char.IsLetterOrDigit).ToArray());
+        return string.IsNullOrWhiteSpace(filtered) ? "Object" : Capitalize(filtered);
+    }
+
+    public static string MapDbType(
+        string dataType,
+        long? charMaxLen,
+        int? numPrecision,
+        string columnName,
+        string? databaseType = null)
+    {
+        var strategy = GenerationRuleStrategyResolver.Resolve(databaseType);
+        return strategy.MapDbType(new GenerationTypeContext(dataType, charMaxLen, numPrecision, columnName));
+    }
+
+    public static bool IsSimpleLiteralDefault(string value)
+    {
+        var normalized = value.Trim();
+        if (Regex.IsMatch(normalized, @"\(\s*\)$")) return false;
+        if (normalized.Equals("current_timestamp", StringComparison.OrdinalIgnoreCase)) return false;
+        if (normalized.Equals("null", StringComparison.OrdinalIgnoreCase)) return false;
+        return true;
+    }
+
+    public static string FormatDefaultLiteral(string value, string dbType)
+    {
+        if (dbType == "Boolean")
+        {
+            return value.Contains("'0'", StringComparison.InvariantCultureIgnoreCase) ? "false" : "true";
+        }
+
+        if (!IsNumericDbType(dbType))
+        {
+            return Literal(value.Trim('(', ')', '\''));
+        }
+
+        return value.Trim('(', ')', ' ');
+    }
+
+    public static string[] TryParseEnumValues(string columnType)
+    {
+        var match = Regex.Match(columnType, @"^(enum|set)\((.*)\)$", RegexOptions.IgnoreCase);
+        if (!match.Success)
+        {
+            return [];
+        }
+
+        return Regex.Matches(match.Groups[2].Value, @"'((?:\\'|[^'])*)'")
+            .Select(static m => m.Groups[1].Value.Replace("\\'", "'", StringComparison.Ordinal))
+            .ToArray();
+    }
+
+    public static bool TryConvertIfIsNull(string sqlExpr, out string code)
+    {
+        var match = IsNullExpressionRegex().Match(sqlExpr);
+        if (!match.Success)
+        {
+            code = string.Empty;
+            return false;
+        }
+
+        var column = match.Groups["col"].Value;
+        var value = match.Groups["val"].Value;
+        code = $"(row, tb) => !row.TryGetValue(tb.Columns[{Literal(column)}].Index, out var dtDel) || dtDel is null ? (byte?){value} : null";
+        return true;
+    }
+
+    public static string Literal(string value)
+        => $"\"{value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)}\"";
+
+    private static bool IsNumericDbType(string dbType)
+        => dbType is "Byte" or "Int16" or "Int32" or "Int64" or "Decimal" or "Double" or "Single" or "UInt64";
+
+    private static string Capitalize(string part)
+    {
+        if (string.IsNullOrWhiteSpace(part))
+        {
+            return string.Empty;
+        }
+
+        var normalized = new StringBuilder(part.Length);
+        foreach (var ch in part)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                normalized.Append(ch);
+            }
+        }
+
+        if (normalized.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var cleaned = normalized.ToString();
+        if (cleaned.Length == 1)
+        {
+            return cleaned.ToUpperInvariant();
+        }
+
+        return string.Concat(char.ToUpper(cleaned[0], CultureInfo.InvariantCulture), cleaned[1..]);
+    }
+
+    [GeneratedRegex(@"if\s*\(\s*\(\s*`(?<col>\w+)`\s+is\s+null\s*\)\s*,\s*(?<val>[^,]+)\s*,\s*null\s*\)", RegexOptions.IgnoreCase)]
+    private static partial Regex IsNullExpressionRegex();
+}

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/GenerationRuleStrategyResolver.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/GenerationRuleStrategyResolver.cs
@@ -1,0 +1,17 @@
+namespace DbSqlLikeMem.VisualStudioExtension.Core.Generation;
+
+public static class GenerationRuleStrategyResolver
+{
+    private static readonly IGenerationRuleStrategy Default = new DefaultGenerationRuleStrategy();
+    private static readonly IGenerationRuleStrategy MySql = new MySqlGenerationRuleStrategy();
+
+    public static IGenerationRuleStrategy Resolve(string? databaseType)
+        => Normalize(databaseType) switch
+        {
+            "mysql" => MySql,
+            _ => Default
+        };
+
+    private static string Normalize(string? databaseType)
+        => (databaseType ?? string.Empty).Trim().ToLowerInvariant();
+}

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/IGenerationRuleStrategy.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/IGenerationRuleStrategy.cs
@@ -1,0 +1,12 @@
+namespace DbSqlLikeMem.VisualStudioExtension.Core.Generation;
+
+public interface IGenerationRuleStrategy
+{
+    string MapDbType(GenerationTypeContext context);
+}
+
+public readonly record struct GenerationTypeContext(
+    string DataType,
+    long? CharMaxLen,
+    int? NumPrecision,
+    string ColumnName);

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/MySqlGenerationRuleStrategy.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/MySqlGenerationRuleStrategy.cs
@@ -1,0 +1,18 @@
+namespace DbSqlLikeMem.VisualStudioExtension.Core.Generation;
+
+internal sealed class MySqlGenerationRuleStrategy : IGenerationRuleStrategy
+{
+    private static readonly DefaultGenerationRuleStrategy Fallback = new();
+
+    public string MapDbType(GenerationTypeContext context)
+    {
+        var normalizedType = context.DataType.ToLowerInvariant();
+
+        return normalizedType switch
+        {
+            "tinyint" => (context.NumPrecision == 1 || context.CharMaxLen == 1) ? "Boolean" : "Byte",
+            "bit" => (context.NumPrecision == 1) ? "Boolean" : "UInt64",
+            _ => Fallback.MapDbType(context)
+        };
+    }
+}

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlDatabaseMetadataProvider.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlDatabaseMetadataProvider.cs
@@ -70,6 +70,7 @@ public sealed class SqlDatabaseMetadataProvider(ISqlQueryExecutor queryExecutor)
                 IsIdentity = ReadBoolFlexible(r, "IsIdentity") || ReadString(r, "Extra").Contains("identity", StringComparison.OrdinalIgnoreCase) || ReadString(r, "Extra").Contains("auto_increment", StringComparison.OrdinalIgnoreCase),
                 DefaultValue = ReadString(r, "DefaultValue"),
                 CharMaxLen = ReadNullableLong(r, "CharMaxLen"),
+                NumPrecision = ReadNullableInt(r, "NumPrecision"),
                 NumScale = ReadNullableInt(r, "NumScale"),
                 ColumnType = ReadString(r, "ColumnType"),
                 Generated = ReadString(r, "Generated")
@@ -86,7 +87,8 @@ public sealed class SqlDatabaseMetadataProvider(ISqlQueryExecutor queryExecutor)
                 c.CharMaxLen?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
                 c.NumScale?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
                 Escape(c.ColumnType),
-                Escape(c.Generated)
+                Escape(c.Generated),
+                c.NumPrecision?.ToString(CultureInfo.InvariantCulture) ?? string.Empty
             ]));
 
         return string.Join(";", cols);

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlMetadataQueryFactory.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlMetadataQueryFactory.cs
@@ -73,7 +73,7 @@ ORDER BY SchemaName, ObjectType, ObjectName;
 SELECT COLUMN_NAME AS ColumnName, DATA_TYPE AS DataType, ORDINAL_POSITION AS Ordinal,
        IS_NULLABLE AS IsNullable, EXTRA AS Extra,
        COLUMN_DEFAULT AS DefaultValue, CHARACTER_MAXIMUM_LENGTH AS CharMaxLen,
-       NUMERIC_SCALE AS NumScale, COLUMN_TYPE AS ColumnType,
+       NUMERIC_PRECISION AS NumPrecision, NUMERIC_SCALE AS NumScale, COLUMN_TYPE AS ColumnType,
        GENERATION_EXPRESSION AS Generated
 FROM INFORMATION_SCHEMA.COLUMNS
 WHERE TABLE_SCHEMA = @schemaName AND TABLE_NAME = @objectName
@@ -83,7 +83,7 @@ ORDER BY ORDINAL_POSITION;
 SELECT c.name AS ColumnName, t.name AS DataType, c.column_id AS Ordinal,
        c.is_nullable AS IsNullable, c.is_identity AS IsIdentity,
        OBJECT_DEFINITION(c.default_object_id) AS DefaultValue,
-       c.max_length AS CharMaxLen, c.scale AS NumScale,
+       c.max_length AS CharMaxLen, c.precision AS NumPrecision, c.scale AS NumScale,
        '' AS ColumnType, '' AS Generated
 FROM sys.columns c
 JOIN sys.types t ON t.user_type_id = c.user_type_id
@@ -98,6 +98,7 @@ SELECT column_name AS ColumnName, data_type AS DataType, ordinal_position AS Ord
        CASE WHEN column_default LIKE 'nextval(%' THEN 'identity' ELSE '' END AS Extra,
        column_default AS DefaultValue,
        character_maximum_length AS CharMaxLen,
+       numeric_precision AS NumPrecision,
        numeric_scale AS NumScale,
        udt_name AS ColumnType,
        '' AS Generated
@@ -111,6 +112,7 @@ SELECT COLUMN_NAME AS ColumnName, DATA_TYPE AS DataType, COLUMN_ID AS Ordinal,
        '' AS Extra,
        DATA_DEFAULT AS DefaultValue,
        CHAR_LENGTH AS CharMaxLen,
+       DATA_PRECISION AS NumPrecision,
        DATA_SCALE AS NumScale,
        DATA_TYPE AS ColumnType,
        '' AS Generated
@@ -124,6 +126,7 @@ SELECT name AS ColumnName, type AS DataType, cid AS Ordinal,
        CASE WHEN pk = 1 THEN 'pk' ELSE '' END AS Extra,
        dflt_value AS DefaultValue,
        NULL AS CharMaxLen,
+       NULL AS NumPrecision,
        NULL AS NumScale,
        type AS ColumnType,
        '' AS Generated
@@ -136,6 +139,7 @@ SELECT RTRIM(COLNAME) AS ColumnName, RTRIM(TYPENAME) AS DataType, COLNO AS Ordin
        CASE IDENTITY WHEN 'Y' THEN 'identity' ELSE '' END AS Extra,
        DEFAULT AS DefaultValue,
        LENGTH AS CharMaxLen,
+       SCALE AS NumPrecision,
        SCALE AS NumScale,
        RTRIM(TYPENAME) AS ColumnType,
        '' AS Generated


### PR DESCRIPTION
### Motivation
- Tornar as regras de mapeamento de tipos independentes do fluxo principal e fáceis de estender para novos bancos, atendendo ao feedback arquitetural para reduzir acoplamento e duplicação.

### Description
- Introduzido o padrão Strategy com `IGenerationRuleStrategy` e `GenerationTypeContext` para encapsular regras por banco e um `GenerationRuleStrategyResolver` para resolver a estratégia por `databaseType`.
- Implementadas as estratégias `DefaultGenerationRuleStrategy` (comportamento genérico) e `MySqlGenerationRuleStrategy` (comportamento MySQL específico) e refatorado `GenerationRuleSet.MapDbType` para delegar à strategy.
- `StructuredClassContentFactory.Build` agora aceita o parâmetro opcional `databaseType` e usa `GenerationRuleSet` para mapear tipos, literais, enums e conversões; o gerador de console MySQL passa explicitamente `databaseType: "MySql"` para preservar o comportamento anterior.
- Ajustes na extração/serialização de metadados para incluir `NumPrecision` e remoção/centralização de helpers duplicados (ex.: PascalCase, literal formatting) em `GenerationRuleSet`.

### Testing
- Adicionados testes unitários `GenerationRuleSetTests` e uma variação em `StructuredClassContentFactoryTests` que valida comportamento distinto para `SqlServer` vs `MySql` (novos testes presentes no código da PR). 
- Tentativa de executar `dotnet test src/DbSqlLikeMem.VisualStudioExtension.Core.Test/DbSqlLikeMem.VisualStudioExtension.Core.Test.csproj` falhou no ambiente porque `dotnet` não está instalado, portanto os testes não foram executados aqui.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d04e4bcd0832cbe057ced0ca37080)