### PR TITLE
Lower Npgsql WITH/CTE minimum version to 6

### DIFF
--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
@@ -33,7 +33,9 @@ internal sealed class NpgsqlDialect : SqlDialectBase
     { }
 
 
-    internal const int WithCteMinVersion = 8;
+    // NOTE: in this project the Npgsql "version" axis starts at 6 and
+    // parser feature tests expect WITH/CTE support across all tested versions.
+    internal const int WithCteMinVersion = 6;
     internal const int MergeMinVersion = 15;
     /// <summary>
     /// Auto-generated summary.


### PR DESCRIPTION
### Motivation
- A parser test (`ParseWithCte_AsMaterialized_ShouldParse`) failed for Npgsql v6 because `SupportsWithCte` was gated by `WithCteMinVersion = 8`, causing a `NotSupportedException` for `WITH/CTE` on v6.

### Description
- Lowered `WithCteMinVersion` from `8` to `6` in `src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs` and added a short comment documenting that the project's Npgsql version axis starts at 6 and parser tests expect `WITH/CTE` support.

### Testing
- Attempted to run the targeted unit test with `dotnet test ... --filter "NpgsqlDialectFeatureParserTests.ParseWithCte_AsMaterialized_ShouldParse"`, but the run could not be executed because `dotnet` is not available in the environment, so automated tests could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d0a139614832c843da7e71be2b3bd)