### PR TITLE
Add basic CAST parsing and unified date arithmetic (DATE_ADD/DATEADD/TIMESTAMPADD/DATE modifiers)

### DIFF
--- a/docs/providers-and-features.md
+++ b/docs/providers-and-features.md
@@ -44,6 +44,23 @@
 - Operador null-safe `<=>`: não suportado.
 - Operadores JSON `->` e `->>`: não suportados.
 
+
+## Fase 3 — recursos analíticos (SQLite/DB2)
+
+Decisões de compatibilidade implementadas para cobrir os cenários de relatório mais comuns:
+
+- `ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)`: habilitado no executor AST para todos os dialetos que passam por `AstQueryExecutorBase`, incluindo SQLite e DB2.
+- Subquery correlacionada em `SELECT` list: avaliada como subconsulta escalar com acesso ao `outer row` (primeira célula da primeira linha; `null` se vazio).
+- `CAST` string->número (casos básicos): suporte para `SIGNED`/`UNSIGNED`/`INT*` e `DECIMAL`/`NUMERIC` com parsing `InvariantCulture` e fallback previsível (`0`/`0m` em `CAST`, `null` em `TRY_CAST`).
+- Operações de data: comportamento unificado para `DATE_ADD`, `DATEADD` e `TIMESTAMPADD`; adicionalmente, `DATE(...)`/`DATETIME(...)` aceitam modificadores SQLite simples como `'+1 day'`.
+
+### Limitações conhecidas (próxima fase)
+
+- Window functions além de `ROW_NUMBER` (ex.: `RANK`, `DENSE_RANK`, `LAG`, frames `ROWS/RANGE`) ainda não foram implementadas.
+- `CAST` numérico ainda não cobre formatações locais complexas, notação científica avançada e tipos de alta precisão específicos por provedor.
+- Data/time cobre unidades comuns (`year/month/day/hour/minute/second`), mas não trata timezone explícito, calendário ISO avançado nem regras específicas de cada engine real.
+- Subquery escalar retorna sempre a primeira célula da primeira linha, sem erro para múltiplas linhas (comportamento simplificado de mock).
+
 ## Regras candidatas para extrair do parser para os Dialects
 
 Para deixar o parser mais fiel por banco/versão, estas regras costumam dar bom ganho quando saem de `if` no parser e passam a ser capacidade do dialeto:

--- a/src/DbSqlLikeMem.Db2.Test/Db2AdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2AdvancedSqlGapTests.cs
@@ -89,6 +89,23 @@ ORDER BY id").ToList();
             [.. rows.Select(r => (DateTime)r.d)]);
     }
 
+
+
+    [Fact]
+    public void TimestampAdd_Day_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id, TIMESTAMPADD(DAY, 1, created) AS d
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([
+            new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Local),
+            new DateTime(2020, 1, 3, 0, 0, 0, DateTimeKind.Local),
+            new DateTime(2020, 1, 4, 0, 0, 0, DateTimeKind.Local)],
+            [.. rows.Select(r => (DateTime)r.d)]);
+    }
+
     /// <summary>
     /// EN: Tests Cast_StringToInt_ShouldWork behavior.
     /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteAdvancedSqlGapTests.cs
@@ -89,6 +89,23 @@ ORDER BY id").ToList();
             [.. rows.Select(r => (DateTime)r.d)]);
     }
 
+
+
+    [Fact]
+    public void Date_Function_WithModifier_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id, DATE(created, '+1 day') AS d
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([
+            new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Local),
+            new DateTime(2020, 1, 3, 0, 0, 0, DateTimeKind.Local),
+            new DateTime(2020, 1, 4, 0, 0, 0, DateTimeKind.Local)],
+            [.. rows.Select(r => (DateTime)r.d)]);
+    }
+
     /// <summary>
     /// EN: Tests Cast_StringToInt_ShouldWork behavior.
     /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.

--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -1924,8 +1924,10 @@ internal abstract class AstQueryExecutorBase(
                     if (v is long l) return (int)l;
                     if (v is int i) return i;
                     if (v is decimal d) return (int)d;
-                    if (int.TryParse(v!.ToString(), out var ix)) return ix;
-                    if (long.TryParse(v!.ToString(), out var lx)) return (int)lx;
+                    var text = v!.ToString()?.Trim() ?? string.Empty;
+                    if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ix)) return ix;
+                    if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var lx)) return (int)lx;
+                    if (decimal.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out var dx)) return (int)dx;
                     return 0;
                 }
 
@@ -1933,7 +1935,7 @@ internal abstract class AstQueryExecutorBase(
                     || type.StartsWith("NUMERIC", StringComparison.OrdinalIgnoreCase))
                 {
                     if (v is decimal dd) return dd;
-                    if (decimal.TryParse(v!.ToString(), out var dx)) return dx;
+                    if (decimal.TryParse(v!.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var dx)) return dx;
                     return 0m;
                 }
 
@@ -2064,9 +2066,8 @@ internal abstract class AstQueryExecutorBase(
         {
             var baseVal = EvalArg(0);
             if (IsNullish(baseVal)) return null;
-
-            // Accept DateTime only for now (enough for tests)
-            var dt = (DateTime)baseVal!;
+            if (!TryCoerceDateTime(baseVal, out var dt))
+                return null;
 
             var itExpr = fn.Args.Count > 1 ? fn.Args[1] : null;
             if (itExpr is null) return dt;
@@ -2079,19 +2080,26 @@ internal abstract class AstQueryExecutorBase(
                 var unit = ce.Args[1] is RawSqlExpr rx ? rx.Sql : Eval(ce.Args[1], row, group, ctes)?.ToString() ?? "DAY";
 
                 var n = Convert.ToInt32((nObj ?? 0m).ToDec());
-                if (unit.Equals("DAY", StringComparison.OrdinalIgnoreCase))
-                    return dt.AddDays(n);
-                if (unit.Equals("HOUR", StringComparison.OrdinalIgnoreCase))
-                    return dt.AddHours(n);
-                if (unit.Equals("MINUTE", StringComparison.OrdinalIgnoreCase))
-                    return dt.AddMinutes(n);
-                if (unit.Equals("SECOND", StringComparison.OrdinalIgnoreCase))
-                    return dt.AddSeconds(n);
-
-                return dt;
+                return ApplyDateDelta(dt, unit, n);
             }
 
             return dt;
+        }
+
+        if (fn.Name.Equals("TIMESTAMPADD", StringComparison.OrdinalIgnoreCase))
+        {
+            if (fn.Args.Count < 3)
+                return null;
+
+            var unit = GetDateAddUnit(fn.Args[0], row, group, ctes);
+            var amountObj = EvalArg(1);
+            var baseVal = EvalArg(2);
+            if (IsNullish(baseVal)) return null;
+            if (!TryCoerceDateTime(baseVal, out var dt))
+                return null;
+
+            var n = Convert.ToInt32((amountObj ?? 0m).ToDec());
+            return ApplyDateDelta(dt, unit, n);
         }
 
         if (fn.Name.Equals("DATEADD", StringComparison.OrdinalIgnoreCase))
@@ -2104,27 +2112,39 @@ internal abstract class AstQueryExecutorBase(
             var baseVal = EvalArg(2);
             if (IsNullish(baseVal)) return null;
 
-            var dt = baseVal switch
-            {
-                DateTime d => d,
-                DateTimeOffset dto => dto.DateTime,
-                _ => DateTime.Parse(
-                    baseVal!.ToString() ?? string.Empty,
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    System.Globalization.DateTimeStyles.AssumeLocal)
-            };
+            if (!TryCoerceDateTime(baseVal, out var dt))
+                return null;
 
             var n = Convert.ToInt32((amountObj ?? 0m).ToDec());
-            return unit switch
+            return ApplyDateDelta(dt, unit, n);
+        }
+
+        if ((fn.Name.Equals("DATE", StringComparison.OrdinalIgnoreCase)
+            || fn.Name.Equals("DATETIME", StringComparison.OrdinalIgnoreCase))
+            && fn.Args.Count >= 1)
+        {
+            var baseVal = EvalArg(0);
+            if (IsNullish(baseVal)) return null;
+            if (!TryCoerceDateTime(baseVal, out var dt))
+                return null;
+
+            // Minimal SQLite-like modifier support: '+N day|hour|minute|second|month|year'
+            for (int i = 1; i < fn.Args.Count; i++)
             {
-                "YEAR" or "YY" or "YYYY" => dt.AddYears(n),
-                "MONTH" or "MM" => dt.AddMonths(n),
-                "DAY" or "DD" or "D" => dt.AddDays(n),
-                "HOUR" or "HH" => dt.AddHours(n),
-                "MINUTE" or "MI" or "N" => dt.AddMinutes(n),
-                "SECOND" or "SS" or "S" => dt.AddSeconds(n),
-                _ => dt
-            };
+                var modifier = EvalArg(i)?.ToString();
+                if (string.IsNullOrWhiteSpace(modifier))
+                    continue;
+
+                if (!TryParseDateModifier(modifier!, out var unit, out var amount))
+                    continue;
+
+                dt = ApplyDateDelta(dt, unit, amount);
+            }
+
+            if (fn.Name.Equals("DATE", StringComparison.OrdinalIgnoreCase))
+                return dt.Date;
+
+            return dt;
         }
 
         
@@ -2205,6 +2225,65 @@ internal abstract class AstQueryExecutorBase(
         }
 
         return unit!.Trim().ToUpperInvariant();
+    }
+
+    private static bool TryCoerceDateTime(object? baseVal, out DateTime dt)
+    {
+        dt = default;
+
+        if (baseVal is null || baseVal is DBNull)
+            return false;
+
+        switch (baseVal)
+        {
+            case DateTime d:
+                dt = d;
+                return true;
+            case DateTimeOffset dto:
+                dt = dto.DateTime;
+                return true;
+        }
+
+        return DateTime.TryParse(
+            baseVal.ToString(),
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeLocal,
+            out dt);
+    }
+
+    private static DateTime ApplyDateDelta(DateTime dt, string unit, int amount)
+    {
+        var normalized = unit.Trim().ToUpperInvariant();
+        return normalized switch
+        {
+            "YEAR" or "YEARS" or "YY" or "YYYY" => dt.AddYears(amount),
+            "MONTH" or "MONTHS" or "MM" => dt.AddMonths(amount),
+            "DAY" or "DAYS" or "DD" or "D" => dt.AddDays(amount),
+            "HOUR" or "HOURS" or "HH" => dt.AddHours(amount),
+            "MINUTE" or "MINUTES" or "MI" or "N" => dt.AddMinutes(amount),
+            "SECOND" or "SECONDS" or "SS" or "S" => dt.AddSeconds(amount),
+            _ => dt
+        };
+    }
+
+    private static bool TryParseDateModifier(string modifier, out string unit, out int amount)
+    {
+        unit = string.Empty;
+        amount = 0;
+
+        var m = Regex.Match(
+            modifier.Trim(),
+            @"^(?<amount>[+-]?\d+)\s*(?<unit>\w+)s?$",
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+        if (!m.Success)
+            return false;
+
+        if (!int.TryParse(m.Groups["amount"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out amount))
+            return false;
+
+        unit = m.Groups["unit"].Value;
+        return !string.IsNullOrWhiteSpace(unit);
     }
 
     private object? EvalCall(


### PR DESCRIPTION
### Motivation
- Implement a minimal set of advanced SQL features commonly used in analytical/reporting queries (CAST string→number, date arithmetic and SQLite date modifiers) while keeping parser changes to a minimum. 
- Provide predictable, provider-aware behavior for SQLite and DB2 test scenarios so the advanced gap tests can be satisfied incrementally.

### Description
- Improved `CAST(... AS ...)` evaluation to trim input and parse numeric strings using `InvariantCulture`, adding decimal→int fallback and more robust `DECIMAL` parsing in `AstQueryExecutorBase`.
- Unified date arithmetic handling by centralizing logic and adding helpers `TryCoerceDateTime`, `ApplyDateDelta`, and `TryParseDateModifier`, and added support for `TIMESTAMPADD(unit, n, base)`, `DATEADD(unit, n, base)` and `DATE_ADD(base, INTERVAL n UNIT)` semantics.
- Added minimal SQLite-like `DATE(...)` / `DATETIME(...)` modifier support (e.g. `DATE(created, '+1 day')`) to cover common modifiers used in tests.
- Added two gap tests to cover the new behaviors (`TIMESTAMPADD(DAY, 1, created)` for DB2 and `DATE(created, '+1 day')` for SQLite) and updated `docs/providers-and-features.md` with compatibility decisions and known limitations.

### Testing
- Attempted to run `dotnet test src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj --filter Db2AdvancedSqlGapTests -v minimal`, but the `dotnet` CLI is not available in this environment so automated tests could not be executed (failed: `dotnet: command not found`).
- No automated tests were run locally due to the missing .NET SDK; changes were validated via static inspection and diff review only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d0b0ac49c832cbeed0b8817688934)