### PR TITLE
Add automated technical backlog generator for SQL gap tests

### DIFF
--- a/docs/gap-tests-technical-backlog.md
+++ b/docs/gap-tests-technical-backlog.md
@@ -1,0 +1,91 @@
+# Backlog técnico automatizado a partir de *GapTests
+
+Fonte automática: varredura dos arquivos `*SqlCompatibilityGapTests.cs` e `*AdvancedSqlGapTests.cs` por provider.
+
+## Priorização
+
+Prioridade calculada por cobertura de providers + risco de regressão - esforço estimado.
+
+## Épico: Parser
+
+| Prioridade | Título | Provider(s) | Esforço | Risco de regressão | Dependências técnicas |
+|---|---|---|---|---|---|
+| P0 | Cast StringToInt | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Alto | AST + precedência de operadores |
+| P0 | Regexp Operator | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | AST + precedência de operadores |
+| P0 | Union | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | AST + precedência de operadores; Normalização de schemas em set operators |
+| P1 | Where OR | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | AST + precedência de operadores |
+| P1 | Cte With | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | G | Médio | AST + precedência de operadores; Suporte a CTE no parser + binding |
+| P1 | Union Inside SubSelect | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | G | Médio | AST + precedência de operadores; Normalização de schemas em set operators |
+| P2 | Where ParenthesesGrouping | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Baixo | AST + precedência de operadores |
+| P2 | Where Precedence AND ShouldBindStrongerThan OR | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Baixo | AST + precedência de operadores |
+
+## Épico: Executor
+
+| Prioridade | Título | Provider(s) | Esforço | Risco de regressão | Dependências técnicas |
+|---|---|---|---|---|---|
+| P0 | CorrelatedSubquery InSelectList | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Escopo de aliases em subquery correlata |
+| P0 | Distinct ShouldBeConsistent | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | Planejador de execução em memória |
+| P0 | GroupBy Having ShouldSupportAggregates | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | Planejador de execução em memória; Pipeline de agregação + HAVING |
+| P1 | Join ComplexOn WithOr | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória |
+| P1 | OrderBy Field Function | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | Planejador de execução em memória |
+| P1 | OrderBy ShouldSupportAlias And Ordinal | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | Planejador de execução em memória |
+| P2 | Select Expressions Arithmetic | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | Planejador de execução em memória |
+| P2 | Window RowNumber PartitionBy | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+
+## Épico: Funções SQL
+
+| Prioridade | Título | Provider(s) | Esforço | Risco de regressão | Dependências técnicas |
+|---|---|---|---|---|---|
+| P0 | DateAdd IntervalDay | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | Registro/catálogo de funções por provider |
+| P0 | Functions COALESCE | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | Registro/catálogo de funções por provider |
+| P0 | Functions CONCAT | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | Registro/catálogo de funções por provider |
+| P1 | Functions IFNULL | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | Registro/catálogo de funções por provider |
+| P1 | Select Expressions CASE WHEN | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | Registro/catálogo de funções por provider |
+| P1 | Select Expressions IF | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | Registro/catálogo de funções por provider |
+| P2 | Select Expressions IIF ShouldWork AsAliasForIF | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | Registro/catálogo de funções por provider |
+
+## Épico: Tipagem/Collation
+
+| Prioridade | Título | Provider(s) | Esforço | Risco de regressão | Dependências técnicas |
+|---|---|---|---|---|---|
+| P0 | Collation CaseSensitivity ShouldFollowColumnCollation | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Alto | Matriz de coerção de tipos; Comparador com collation configurável |
+| P0 | Typing ImplicitCasts And Collation ShouldMatchMySqlDefault | MySQL, Oracle, PostgreSQL, SQL Server | G | Alto | Matriz de coerção de tipos; Comparador com collation configurável |
+| P0 | Typing ImplicitCasts And Collation ShouldMatchDb2Default | DB2 | G | Alto | Matriz de coerção de tipos; Comparador com collation configurável |
+| P1 | Typing ImplicitCasts And Collation ShouldMatchSqliteDefault | SQLite | G | Alto | Matriz de coerção de tipos; Comparador com collation configurável |
+
+## Formato alternativo (checklist para GitHub Projects/Jira)
+
+### Parser
+- [ ] **Cast StringToInt**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Alto`  Dependências: AST + precedência de operadores
+- [ ] **Regexp Operator**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: AST + precedência de operadores
+- [ ] **Union**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: AST + precedência de operadores; Normalização de schemas em set operators
+- [ ] **Where OR**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: AST + precedência de operadores
+- [ ] **Cte With**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Médio`  Dependências: AST + precedência de operadores; Suporte a CTE no parser + binding
+- [ ] **Union Inside SubSelect**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Médio`  Dependências: AST + precedência de operadores; Normalização de schemas em set operators
+- [ ] **Where ParenthesesGrouping**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Baixo`  Dependências: AST + precedência de operadores
+- [ ] **Where Precedence AND ShouldBindStrongerThan OR**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Baixo`  Dependências: AST + precedência de operadores
+
+### Executor
+- [ ] **CorrelatedSubquery InSelectList**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Escopo de aliases em subquery correlata
+- [ ] **Distinct ShouldBeConsistent**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Planejador de execução em memória
+- [ ] **GroupBy Having ShouldSupportAggregates**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: Planejador de execução em memória; Pipeline de agregação + HAVING
+- [ ] **Join ComplexOn WithOr**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória
+- [ ] **OrderBy Field Function**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: Planejador de execução em memória
+- [ ] **OrderBy ShouldSupportAlias And Ordinal**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: Planejador de execução em memória
+- [ ] **Select Expressions Arithmetic**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Planejador de execução em memória
+- [ ] **Window RowNumber PartitionBy**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+
+### Funções SQL
+- [ ] **DateAdd IntervalDay**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: Registro/catálogo de funções por provider
+- [ ] **Functions COALESCE**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Registro/catálogo de funções por provider
+- [ ] **Functions CONCAT**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Registro/catálogo de funções por provider
+- [ ] **Functions IFNULL**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Registro/catálogo de funções por provider
+- [ ] **Select Expressions CASE WHEN**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: Registro/catálogo de funções por provider
+- [ ] **Select Expressions IF**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Registro/catálogo de funções por provider
+- [ ] **Select Expressions IIF ShouldWork AsAliasForIF**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Registro/catálogo de funções por provider
+
+### Tipagem/Collation
+- [ ] **Collation CaseSensitivity ShouldFollowColumnCollation**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Alto`  Dependências: Matriz de coerção de tipos; Comparador com collation configurável
+- [ ] **Typing ImplicitCasts And Collation ShouldMatchMySqlDefault**  `providers: MySQL, Oracle, PostgreSQL, SQL Server` · `esforço: G` · `risco: Alto`  Dependências: Matriz de coerção de tipos; Comparador com collation configurável
+- [ ] **Typing ImplicitCasts And Collation ShouldMatchDb2Default**  `providers: DB2` · `esforço: G` · `risco: Alto`  Dependências: Matriz de coerção de tipos; Comparador com collation configurável
+- [ ] **Typing ImplicitCasts And Collation ShouldMatchSqliteDefault**  `providers: SQLite` · `esforço: G` · `risco: Alto`  Dependências: Matriz de coerção de tipos; Comparador com collation configurável

--- a/scripts/generate_gap_backlog.py
+++ b/scripts/generate_gap_backlog.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEST_PATTERN = "src/*/*GapTests.cs"
+OUTPUT_PATH = REPO_ROOT / "docs" / "gap-tests-technical-backlog.md"
+
+
+@dataclass(frozen=True)
+class ItemMeta:
+    title: str
+    epic: str
+    effort: str
+    risk: str
+    dependencies: str
+
+
+PROVIDER_LABELS = {
+    "Db2": "DB2",
+    "MySql": "MySQL",
+    "Oracle": "Oracle",
+    "PostgreSql": "PostgreSQL",
+    "Sqlite": "SQLite",
+    "SqlServer": "SQL Server",
+}
+
+EPIC_PRIORITY = [
+    "Parser",
+    "Executor",
+    "Funções SQL",
+    "Tipagem/Collation",
+]
+
+
+def to_title(test_name: str) -> str:
+    base = test_name.removesuffix("_ShouldWork").replace("_", " ")
+    return base
+
+
+def infer_meta(test_name: str) -> ItemMeta:
+    lowered = test_name.lower()
+
+    if any(k in lowered for k in ["where_", "cte_", "union_", "regexp", "cast_"]):
+        epic = "Parser"
+    elif any(k in lowered for k in ["join_", "groupby", "orderby", "window_", "correlatedsubquery", "distinct"]):
+        epic = "Executor"
+    elif any(k in lowered for k in ["functions_", "dateadd", "if_", "iif", "concat", "coalesce", "ifnull", "field_function", "case_when"]):
+        epic = "Funções SQL"
+    elif any(k in lowered for k in ["typing_", "collation", "implicitcasts"]):
+        epic = "Tipagem/Collation"
+    else:
+        epic = "Executor"
+
+    if any(k in lowered for k in ["window_", "correlatedsubquery", "cte_", "union_inside", "join_complexon", "typing_"]):
+        effort = "G"
+    elif any(k in lowered for k in ["groupby", "orderby", "dateadd", "regexp", "cast_", "parentheses", "precedence", "case_when", "union_"]):
+        effort = "M"
+    else:
+        effort = "P"
+
+    if any(k in lowered for k in ["typing_", "collation", "cast_", "window_", "correlatedsubquery", "join_complexon"]):
+        risk = "Alto"
+    elif any(k in lowered for k in ["groupby", "orderby", "union", "cte", "case_when", "regexp", "dateadd"]):
+        risk = "Médio"
+    else:
+        risk = "Baixo"
+
+    deps: List[str] = []
+    if epic == "Parser":
+        deps.append("AST + precedência de operadores")
+    if epic == "Executor":
+        deps.append("Planejador de execução em memória")
+    if epic == "Funções SQL":
+        deps.append("Registro/catálogo de funções por provider")
+    if epic == "Tipagem/Collation":
+        deps.append("Matriz de coerção de tipos")
+
+    if "window_" in lowered:
+        deps.append("Engine de funções de janela")
+    if "correlatedsubquery" in lowered:
+        deps.append("Escopo de aliases em subquery correlata")
+    if "groupby" in lowered or "having" in lowered:
+        deps.append("Pipeline de agregação + HAVING")
+    if "cte_" in lowered:
+        deps.append("Suporte a CTE no parser + binding")
+    if "union" in lowered:
+        deps.append("Normalização de schemas em set operators")
+    if "typing_" in lowered or "collation" in lowered:
+        deps.append("Comparador com collation configurável")
+
+    return ItemMeta(
+        title=to_title(test_name),
+        epic=epic,
+        effort=effort,
+        risk=risk,
+        dependencies="; ".join(dict.fromkeys(deps)),
+    )
+
+
+def score(meta: ItemMeta, providers_count: int) -> int:
+    risk_score = {"Alto": 3, "Médio": 2, "Baixo": 1}[meta.risk]
+    effort_penalty = {"P": 0, "M": 1, "G": 2}[meta.effort]
+    return (providers_count * 2) + risk_score - effort_penalty
+
+
+def collect_tests() -> Dict[str, set[str]]:
+    grouped: Dict[str, set[str]] = defaultdict(set)
+    for path in sorted(REPO_ROOT.glob(TEST_PATTERN)):
+        provider_key = path.stem.replace("AdvancedSqlGapTests", "").replace("SqlCompatibilityGapTests", "")
+        provider = PROVIDER_LABELS.get(provider_key, provider_key)
+        content = path.read_text(encoding="utf-8")
+        tests = re.findall(r"public void (\w+)\(", content)
+        for test in tests:
+            grouped[test].add(provider)
+    return grouped
+
+
+def render_markdown(grouped: Dict[str, set[str]]) -> str:
+    items = []
+    for test_name, providers in grouped.items():
+        meta = infer_meta(test_name)
+        items.append((test_name, meta, sorted(providers), score(meta, len(providers))))
+
+    by_epic: Dict[str, List[tuple]] = defaultdict(list)
+    for row in items:
+        by_epic[row[1].epic].append(row)
+
+    lines: List[str] = []
+    lines.append("# Backlog técnico automatizado a partir de *GapTests")
+    lines.append("")
+    lines.append("Fonte automática: varredura dos arquivos `*SqlCompatibilityGapTests.cs` e `*AdvancedSqlGapTests.cs` por provider.")
+    lines.append("")
+    lines.append("## Priorização")
+    lines.append("")
+    lines.append("Prioridade calculada por cobertura de providers + risco de regressão - esforço estimado.")
+    lines.append("")
+
+    for epic in EPIC_PRIORITY:
+        rows = sorted(by_epic.get(epic, []), key=lambda x: (-x[3], x[1].title))
+        if not rows:
+            continue
+        lines.append(f"## Épico: {epic}")
+        lines.append("")
+        lines.append("| Prioridade | Título | Provider(s) | Esforço | Risco de regressão | Dependências técnicas |")
+        lines.append("|---|---|---|---|---|---|")
+        for idx, (_raw, meta, providers, _s) in enumerate(rows, start=1):
+            p = "P0" if idx <= 3 else ("P1" if idx <= 6 else "P2")
+            provider_list = ", ".join(providers)
+            lines.append(f"| {p} | {meta.title} | {provider_list} | {meta.effort} | {meta.risk} | {meta.dependencies} |")
+        lines.append("")
+
+    lines.append("## Formato alternativo (checklist para GitHub Projects/Jira)")
+    lines.append("")
+    for epic in EPIC_PRIORITY:
+        rows = sorted(by_epic.get(epic, []), key=lambda x: (-x[3], x[1].title))
+        if not rows:
+            continue
+        lines.append(f"### {epic}")
+        for _raw, meta, providers, _s in rows:
+            lines.append(
+                f"- [ ] **{meta.title}**  "+
+                f"`providers: {', '.join(providers)}` · `esforço: {meta.effort}` · "
+                f"`risco: {meta.risk}`  "+
+                f"Dependências: {meta.dependencies}"
+            )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> None:
+    grouped = collect_tests()
+    markdown = render_markdown(grouped)
+    OUTPUT_PATH.write_text(markdown, encoding="utf-8")
+    print(f"Backlog gerado em: {OUTPUT_PATH.relative_to(REPO_ROOT)}")
+    print(f"Total de itens únicos: {len(grouped)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide an automated, repeatable way to extract technical backlog items from `*SqlCompatibilityGapTests.cs` and `*AdvancedSqlGapTests.cs` across providers.
- Prioritize and group gaps by epic (Parser / Executor / Funções SQL / Tipagem/Collation) using provider coverage, estimated effort and regression risk.
- Produce Markdown output ready to paste into GitHub Projects or Jira so backlog stays synchronized with test suite changes.

### Description
- Add `scripts/generate_gap_backlog.py`, a script that scans `src/*/*GapTests.cs`, collects test names per provider, infers epic/effort/risk/dependencies, computes a simple priority score and renders a Markdown backlog.
- Add generated output file `docs/gap-tests-technical-backlog.md` with grouped tables per epic and an alternative checklist format suitable for GitHub Projects/Jira.
- Implement provider label mapping, heuristic inference rules for epic/effort/risk, dependency suggestions, and a scoring function based on provider coverage, risk and effort.
- No external skill was used during generation; the script is self-contained and deterministic given the repository test files.

### Testing
- Ran `python scripts/generate_gap_backlog.py` which created `docs/gap-tests-technical-backlog.md` and reported `Total de itens únicos: 27`, and the run completed successfully. 
- Verified test discovery with `rg --files | rg 'SqlCompatibilityGapTests|AdvancedSqlGapTests'`, which located all provider gap-test files successfully. 
- Inspected the generated Markdown (`docs/gap-tests-technical-backlog.md`) to confirm grouping, columns and checklist formatting render as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d0b15a8c4832c9f9fe48b2fee6ab3)