### PR TITLE
Fix XML documentation warnings (CS1591/CS1587) in metadata factory and tests

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Db2AdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2AdvancedSqlGapTests.cs
@@ -42,11 +42,11 @@ public sealed class Db2AdvancedSqlGapTests : XUnitTestBase
     /// EN: Tests Window_RowNumber_PartitionBy_ShouldWork behavior.
     /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -62,11 +62,11 @@ ORDER BY tenantid, id").ToList();
     /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -82,11 +82,11 @@ ORDER BY u.id").ToList();
     /// EN: Tests DateAdd_IntervalDay_ShouldWork behavior.
     /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void DateAdd_IntervalDay_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -103,11 +103,11 @@ ORDER BY id").ToList();
 
 
 
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void TimestampAdd_Day_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -126,11 +126,11 @@ ORDER BY id").ToList();
     /// EN: Tests Cast_StringToInt_ShouldWork behavior.
     /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Cast_StringToInt_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT CAST('42' AS SIGNED) AS v").ToList();
@@ -142,11 +142,11 @@ ORDER BY id").ToList();
     /// EN: Tests Regexp_Operator_ShouldWork behavior.
     /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Regexp_Operator_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name REGEXP '^J' ORDER BY id").ToList();
@@ -157,11 +157,11 @@ ORDER BY id").ToList();
     /// EN: Tests OrderBy_Field_Function_ShouldWork behavior.
     /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void OrderBy_Field_Function_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users ORDER BY FIELD(id, 3, 1, 2)").ToList();
@@ -172,11 +172,11 @@ ORDER BY id").ToList();
     /// EN: Tests Collation_CaseSensitivity_ShouldFollowColumnCollation behavior.
     /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {
         // Example expectation in DB2: behavior depends on column collation.

--- a/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
@@ -10,12 +10,12 @@ public sealed class Db2DialectFeatureParserTests
     /// EN: Tests ParseSelect_WithRecursive_ShouldBeRejected behavior.
     /// PT: Testa o comportamento de ParseSelect_WithRecursive_ShouldBeRejected.
     /// </summary>
-    [Theory]
-    [MemberDataDb2Version]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataDb2Version]
     public void ParseSelect_WithRecursive_ShouldBeRejected(int version)
     {
         var sql = "WITH RECURSIVE cte(n) AS (SELECT 1 FROM SYSIBM.SYSDUMMY1) SELECT n FROM cte";
@@ -33,12 +33,12 @@ public sealed class Db2DialectFeatureParserTests
     /// EN: Tests ParseInsert_OnConflict_ShouldBeRejected behavior.
     /// PT: Testa o comportamento de ParseInsert_OnConflict_ShouldBeRejected.
     /// </summary>
-    [Theory]
-    [MemberDataDb2Version]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataDb2Version]
     public void ParseInsert_OnConflict_ShouldBeRejected(int version)
     {
         var sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO NOTHING";
@@ -50,12 +50,12 @@ public sealed class Db2DialectFeatureParserTests
     /// EN: Tests ParseSelect_WithMySqlIndexHints_ShouldBeRejected behavior.
     /// PT: Testa o comportamento de ParseSelect_WithMySqlIndexHints_ShouldBeRejected.
     /// </summary>
-    [Theory]
-    [MemberDataDb2Version]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataDb2Version]
     public void ParseSelect_WithMySqlIndexHints_ShouldBeRejected(int version)
     {
         var sql = "SELECT id FROM users USE INDEX (idx_users_id)";
@@ -64,12 +64,12 @@ public sealed class Db2DialectFeatureParserTests
     }
 
 
-    [Theory]
-    [MemberDataDb2Version]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataDb2Version]
     public void ParseUnsupportedSql_ShouldUseStandardNotSupportedMessage(int version)
     {
         var ex = Assert.Throws<NotSupportedException>(() =>
@@ -79,12 +79,12 @@ public sealed class Db2DialectFeatureParserTests
         Assert.Contains("db2", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Theory]
-    [MemberDataDb2Version]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataDb2Version]
     public void ParseSelect_UnionOrderBy_ShouldParseAsUnion(int version)
     {
         var sql = "SELECT id FROM users WHERE id = 1 UNION SELECT id FROM users WHERE id = 2 ORDER BY id";
@@ -97,12 +97,12 @@ public sealed class Db2DialectFeatureParserTests
         Assert.False(union.AllFlags[0]);
     }
 
-    [Theory]
-    [MemberDataDb2Version]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataDb2Version]
     public void ParseSelect_WithCteSimple_ShouldParse(int version)
     {
         var sql = "WITH u AS (SELECT id FROM users) SELECT id FROM u";

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlExpressionParserTests.cs
@@ -14,12 +14,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions behavior.
     /// PT: Testa o comportamento de ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions.
     /// </summary>
-    [Theory]
-    [MemberDataBySqliteVersion(nameof(WhereExpressions_Supported))]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataBySqliteVersion(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
     {
         Console.WriteLine("Where: @\"" + whereExpr + "\"");
@@ -93,12 +93,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests ParseWhere_ShouldThrow_ForUnsupportedExpressions behavior.
     /// PT: Testa o comportamento de ParseWhere_ShouldThrow_ForUnsupportedExpressions.
     /// </summary>
-    [Theory]
-    [MemberDataBySqliteVersion(nameof(WhereExpressions_Unsupported))]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataBySqliteVersion(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
     {
         Console.WriteLine("Where: @\"" + whereExpr + "\"");
@@ -130,12 +130,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests Precedence_OR_ShouldBindLooserThan_AND behavior.
     /// PT: Testa o comportamento de Precedence_OR_ShouldBindLooserThan_AND.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
     {
         // id = 1 OR id = 2 AND name = 'Bob'
@@ -162,12 +162,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests Parentheses_ShouldOverridePrecedence behavior.
     /// PT: Testa o comportamento de Parentheses_ShouldOverridePrecedence.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void Parentheses_ShouldOverridePrecedence(int version)
     {
         // (id = 1 OR id = 2) AND email IS NULL
@@ -187,12 +187,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests Not_ShouldWork behavior.
     /// PT: Testa o comportamento de Not_ShouldWork.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void Not_ShouldWork(int version)
     {
         var ast = SqlExpressionParser.ParseWhere("NOT (id = 1 OR id = 2)", new SqliteDialect(version));
@@ -208,12 +208,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests IsNotNull_ShouldProduce_IsNullExpr_Negated behavior.
     /// PT: Testa o comportamento de IsNotNull_ShouldProduce_IsNullExpr_Negated.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
     {
         var ast = SqlExpressionParser.ParseWhere("email IS NOT NULL", new SqliteDialect(version));
@@ -225,12 +225,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests In_ShouldParse_List behavior.
     /// PT: Testa o comportamento de In_ShouldParse_List.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void In_ShouldParse_List(int version)
     {
         var ast = SqlExpressionParser.ParseWhere("u.id IN (1,2,3)", new SqliteDialect(version));
@@ -242,12 +242,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests Like_ShouldParse behavior.
     /// PT: Testa o comportamento de Like_ShouldParse.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void Like_ShouldParse(int version)
     {
         var ast = SqlExpressionParser.ParseWhere("name LIKE '%oh%'", new SqliteDialect(version));
@@ -259,12 +259,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests Identifier_WithAliasDotColumn_ShouldParse behavior.
     /// PT: Testa o comportamento de Identifier_WithAliasDotColumn_ShouldParse.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
     {
         var ast = SqlExpressionParser.ParseWhere("u.id = o.userId", new SqliteDialect(version));
@@ -285,12 +285,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests Parameter_Tokens_ShouldParse behavior.
     /// PT: Testa o comportamento de Parameter_Tokens_ShouldParse.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void Parameter_Tokens_ShouldParse(int version)
     {
         var d = new SqliteDialect(version);
@@ -303,12 +303,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests Backtick_Identifier_ShouldParse behavior.
     /// PT: Testa o comportamento de Backtick_Identifier_ShouldParse.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void Backtick_Identifier_ShouldParse(int version)
     {
         var ast = SqlExpressionParser.ParseWhere("`DeletedDtt` IS NULL", new SqliteDialect(version));
@@ -321,12 +321,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests DoubleQuoted_String_ShouldParse behavior.
     /// PT: Testa o comportamento de DoubleQuoted_String_ShouldParse.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void DoubleQuoted_String_ShouldParse(int version)
     {
         var ast = SqlExpressionParser.ParseWhere("name = \"John\"", new SqliteDialect(version));
@@ -335,12 +335,12 @@ public sealed class SqlExpressionParserTests(
         Assert.Equal("John", lit.Value);
     }
 
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void NullSafe_Operator_ShouldThrow(int version)
     {
         Assert.ThrowsAny<InvalidOperationException>(() =>
@@ -351,12 +351,12 @@ public sealed class SqlExpressionParserTests(
     /// EN: Tests Printer_ShouldBeStable_ForSimpleExpression behavior.
     /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.
     /// </summary>
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)
     {
         var ast = SqlExpressionParser.ParseWhere("a = 1 AND b = 2", new SqliteDialect(version));

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
@@ -6,12 +6,12 @@ namespace DbSqlLikeMem.Sqlite.Test.Parser;
 /// </summary>
 public sealed class SqliteDialectFeatureParserTests
 {
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void ParseInsert_OnConflict_DoUpdate_ShouldParse(int version)
     {
         var sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE SET name = 'b'";
@@ -23,12 +23,12 @@ public sealed class SqliteDialectFeatureParserTests
         Assert.Single(ins.OnDupAssigns);
     }
 
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void ParseWithCte_AsNotMaterialized_ShouldParse(int version)
     {
         var sql = "WITH x AS NOT MATERIALIZED (SELECT 1 AS id) SELECT id FROM x";
@@ -37,12 +37,12 @@ public sealed class SqliteDialectFeatureParserTests
 
         Assert.IsType<SqlSelectQuery>(parsed);
     }
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void ParseSelect_WithMySqlIndexHints_ShouldBeRejected(int version)
     {
         var sql = "SELECT id FROM users USE INDEX (idx_users_id)";
@@ -51,12 +51,12 @@ public sealed class SqliteDialectFeatureParserTests
     }
 
 
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void ParseUnsupportedSql_ShouldUseStandardNotSupportedMessage(int version)
     {
         var ex = Assert.Throws<NotSupportedException>(() =>
@@ -66,12 +66,12 @@ public sealed class SqliteDialectFeatureParserTests
         Assert.Contains("sqlite", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Theory]
-    [MemberDataSqliteVersion]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Theory]
+    [MemberDataSqliteVersion]
     public void ParseSelect_UnionOrderBy_ShouldParseAsUnion(int version)
     {
         var sql = "SELECT id FROM users WHERE id = 1 UNION SELECT id FROM users WHERE id = 2 ORDER BY id";

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteAdvancedSqlGapTests.cs
@@ -42,11 +42,11 @@ public sealed class SqliteAdvancedSqlGapTests : XUnitTestBase
     /// EN: Tests Window_RowNumber_PartitionBy_ShouldWork behavior.
     /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -62,11 +62,11 @@ ORDER BY tenantid, id").ToList();
     /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -82,11 +82,11 @@ ORDER BY u.id").ToList();
     /// EN: Tests DateAdd_IntervalDay_ShouldWork behavior.
     /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void DateAdd_IntervalDay_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -103,11 +103,11 @@ ORDER BY id").ToList();
 
 
 
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Date_Function_WithModifier_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -126,11 +126,11 @@ ORDER BY id").ToList();
     /// EN: Tests Cast_StringToInt_ShouldWork behavior.
     /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Cast_StringToInt_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT CAST('42' AS SIGNED) AS v").ToList();
@@ -142,11 +142,11 @@ ORDER BY id").ToList();
     /// EN: Tests Regexp_Operator_ShouldWork behavior.
     /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Regexp_Operator_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name REGEXP '^J' ORDER BY id").ToList();
@@ -157,11 +157,11 @@ ORDER BY id").ToList();
     /// EN: Tests OrderBy_Field_Function_ShouldWork behavior.
     /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void OrderBy_Field_Function_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users ORDER BY FIELD(id, 3, 1, 2)").ToList();
@@ -172,11 +172,11 @@ ORDER BY id").ToList();
     /// EN: Tests Collation_CaseSensitivity_ShouldFollowColumnCollation behavior.
     /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
     /// </summary>
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {
         // Example expectation in SQLite: behavior depends on column collation.

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ClassGenerationPlannerTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ClassGenerationPlannerTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Test;
 /// </summary>
 public class ClassGenerationPlannerTests
 {
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void BuildPlan_WithoutConfiguration_RequiresConfiguration()
     {
         var planner = new ClassGenerationPlanner();
@@ -25,11 +25,11 @@ public class ClassGenerationPlannerTests
         Assert.Contains(DatabaseObjectType.Table, plan.MissingMappings);
     }
 
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void BuildPlan_WithPartialMappings_ReturnsMissingTypes()
     {
         var planner = new ClassGenerationPlanner();

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ClassGeneratorTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ClassGeneratorTests.cs
@@ -6,6 +6,10 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Test;
 /// </summary>
 public class ClassGeneratorTests
 {
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
     [Theory]
     [InlineData("MySql")]
     [InlineData("SqlServer")]
@@ -13,10 +17,6 @@ public class ClassGeneratorTests
     [InlineData("Oracle")]
     [InlineData("Sqlite")]
     [InlineData("Db2")]
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
-    /// </summary>
     public async Task GenerateAsync_WithoutPattern_UsesConsoleLikeRule_ForAllDatabaseTypes(string databaseType)
     {
         var outputDir = Path.Combine(Path.GetTempPath(), $"dbsql-{Guid.NewGuid():N}");
@@ -50,11 +50,11 @@ public class ClassGeneratorTests
         }
     }
 
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public async Task GenerateAsync_ReplacesPatternTokensIncludingDatabaseContext()
     {
         var outputDir = Path.Combine(Path.GetTempPath(), $"dbsql-{Guid.NewGuid():N}");

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GeneratedClassSnapshotReaderTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GeneratedClassSnapshotReaderTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Test;
 /// </summary>
 public sealed class GeneratedClassSnapshotReaderTests
 {
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public async Task ReadAsync_ParsesMetadataAndCheckerDetectsDifference()
     {
         var file = Path.Combine(Path.GetTempPath(), $"dbsql-snapshot-{Guid.NewGuid():N}.cs");

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GenerationRuleSetTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GenerationRuleSetTests.cs
@@ -6,22 +6,22 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Test;
 /// </summary>
 public sealed class GenerationRuleSetTests
 {
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void MapDbType_UsesMySqlStrategyWhenDatabaseTypeIsMySql()
     {
         var type = GenerationRuleSet.MapDbType("bit", null, 8, "Mask", "MySql");
         Assert.Equal("UInt64", type);
     }
 
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void MapDbType_UsesDefaultStrategyWhenDatabaseTypeIsSqlServer()
     {
         var type = GenerationRuleSet.MapDbType("tinyint", null, 1, "IsEnabled", "SqlServer");

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ObjectConsistencyCheckerTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ObjectConsistencyCheckerTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Test;
 /// </summary>
 public class ObjectConsistencyCheckerTests
 {
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public async Task CheckAsync_WhenObjectMissing_ReturnsMissingStatus()
     {
         var checker = new ObjectConsistencyChecker();
@@ -25,11 +25,11 @@ public class ObjectConsistencyCheckerTests
         Assert.Equal(ObjectHealthStatus.MissingInDatabase, result.Status);
     }
 
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public async Task CheckAsync_WhenPropertiesDifferent_ReturnsDifferentStatus()
     {
         var checker = new ObjectConsistencyChecker();

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ObjectFilterServiceTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ObjectFilterServiceTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Test;
 /// </summary>
 public class ObjectFilterServiceTests
 {
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Filter_Equals_ReturnsExactMatches()
     {
         var service = new ObjectFilterService();
@@ -26,11 +26,11 @@ public class ObjectFilterServiceTests
         Assert.Equal("User", result.Single().Name);
     }
 
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Filter_Like_ReturnsContainsMatches()
     {
         var service = new ObjectFilterService();

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/SqlDatabaseMetadataProviderTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/SqlDatabaseMetadataProviderTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Test;
 /// </summary>
 public sealed class SqlDatabaseMetadataProviderTests
 {
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public async Task GetObjectAsync_ReturnsCompleteStructureMetadata()
     {
         var executor = new FakeSqlQueryExecutor();
@@ -46,6 +46,10 @@ public sealed class SqlDatabaseMetadataProviderTests
         Assert.Equal("CustomerId|Customers|Id", result.Properties["ForeignKeys"]);
     }
 
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
     [Theory]
     [InlineData("MySql")]
     [InlineData("SqlServer")]
@@ -53,10 +57,6 @@ public sealed class SqlDatabaseMetadataProviderTests
     [InlineData("Oracle")]
     [InlineData("Sqlite")]
     [InlineData("Db2")]
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
-    /// </summary>
     public void QueryFactory_SupportsConfiguredDatabases(string databaseType)
     {
         Assert.False(string.IsNullOrWhiteSpace(SqlMetadataQueryFactory.BuildListObjectsQuery(databaseType)));

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/StructuredClassContentFactoryTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/StructuredClassContentFactoryTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Test;
 /// </summary>
 public sealed class StructuredClassContentFactoryTests
 {
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Build_GeneratesColumnsPkIndexesAndForeignKeysLikeConsole()
     {
         var dbObject = new DatabaseObjectReference(
@@ -33,11 +33,11 @@ public sealed class StructuredClassContentFactoryTests
         Assert.Contains("table.ForeignKeys.Add((\"CustomerId\", \"Customers\", \"Id\"));", content);
     }
 
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Build_WithCompositePrimaryKey_CreatesPrimaryIndexWithAllFields()
     {
         var dbObject = new DatabaseObjectReference(
@@ -60,11 +60,11 @@ public sealed class StructuredClassContentFactoryTests
     }
 
 
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Build_WithSqlServerStrategy_DoesNotTreatTinyIntAsBoolean()
     {
         var dbObject = new DatabaseObjectReference(
@@ -84,11 +84,11 @@ public sealed class StructuredClassContentFactoryTests
         Assert.Contains("table.Columns[\"IsEnabled\"] = new(0, DbType.Byte, false);", content);
         Assert.Contains("table.Columns[\"BitMask\"] = new(1, DbType.Boolean, false);", content);
     }
-    [Fact]
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
+    [Fact]
     public void Build_UsesSameTypeRulesAsConsoleGenerator_ForTinyIntAndBit()
     {
         var dbObject = new DatabaseObjectReference(

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlMetadataQueryFactory.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlMetadataQueryFactory.cs
@@ -17,18 +17,43 @@ public static class SqlMetadataQueryFactory
             ["db2"] = new Db2MetadataQueryStrategy(),
         };
 
+    /// <summary>
+    /// Builds the metadata query that lists schema objects for the specified database type.
+    /// </summary>
+    /// <param name="databaseType">The target database type.</param>
+    /// <returns>The SQL query text.</returns>
     public static string BuildListObjectsQuery(string databaseType)
         => ResolveStrategy(databaseType).BuildListObjectsQuery();
 
+    /// <summary>
+    /// Builds the metadata query that lists columns for a specific object for the specified database type.
+    /// </summary>
+    /// <param name="databaseType">The target database type.</param>
+    /// <returns>The SQL query text.</returns>
     public static string BuildObjectColumnsQuery(string databaseType)
         => ResolveStrategy(databaseType).BuildObjectColumnsQuery();
 
+    /// <summary>
+    /// Builds the metadata query that returns primary-key columns for the specified database type.
+    /// </summary>
+    /// <param name="databaseType">The target database type.</param>
+    /// <returns>The SQL query text.</returns>
     public static string BuildPrimaryKeyQuery(string databaseType)
         => ResolveStrategy(databaseType).BuildPrimaryKeyQuery();
 
+    /// <summary>
+    /// Builds the metadata query that lists indexes for the specified database type.
+    /// </summary>
+    /// <param name="databaseType">The target database type.</param>
+    /// <returns>The SQL query text.</returns>
     public static string BuildIndexesQuery(string databaseType)
         => ResolveStrategy(databaseType).BuildIndexesQuery();
 
+    /// <summary>
+    /// Builds the metadata query that lists foreign keys for the specified database type.
+    /// </summary>
+    /// <param name="databaseType">The target database type.</param>
+    /// <returns>The SQL query text.</returns>
     public static string BuildForeignKeysQuery(string databaseType)
         => ResolveStrategy(databaseType).BuildForeignKeysQuery();
 


### PR DESCRIPTION
### Motivation
- Remove CS1591 and CS1587 compiler warnings caused by missing or misplaced XML documentation on public APIs and test methods.
- Ensure public API methods in the metadata query factory have proper XML summaries so API consumers and analyzers see meaningful documentation.

### Description
- Added XML documentation comments to the public query-builder methods in `SqlMetadataQueryFactory` (`BuildListObjectsQuery`, `BuildObjectColumnsQuery`, `BuildPrimaryKeyQuery`, `BuildIndexesQuery`, `BuildForeignKeysQuery`).
- Reordered/moved misplaced `/// <summary>` blocks in multiple test files so the documentation is attached to the test methods (placed before `[Fact]`/`[Theory]` attributes) instead of appearing in invalid positions.
- Applied the doc-fix transformation across the test suites for SQLite, DB2 and VisualStudioExtension.Core test projects without changing test logic or assertions.
- Files updated include `src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlMetadataQueryFactory.cs` and several test files under `src/*/*.Test/` (e.g. `SqlExpressionParserTests.cs`, `SqliteDialectFeatureParserTests.cs`, `SqliteAdvancedSqlGapTests.cs`, `Db2DialectFeatureParserTests.cs`, `Db2AdvancedSqlGapTests.cs`, `ClassGenerationPlannerTests.cs`, `ClassGeneratorTests.cs`, `GeneratedClassSnapshotReaderTests.cs`, `GenerationRuleSetTests.cs`, `ObjectConsistencyCheckerTests.cs`, `ObjectFilterServiceTests.cs`, `SqlDatabaseMetadataProviderTests.cs`, `StructuredClassContentFactoryTests.cs`).

### Testing
- Ran a transformation script to update docblocks and verified modified files were updated as expected; the script reported the updated files.
- Attempted to run `dotnet build DbSqlLikeMem.sln -v minimal` to validate the build, but the environment lacks the `dotnet` tool (`bash: command not found: dotnet`), so compilation could not be executed here.
- No behavioral changes to tests were made, so test logic remains unchanged and is expected to pass when built in a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d15475f28832c9cbf346a7b77279e)