### PR TITLE
Treat NVL as alias for IFNULL in function evaluator

### DIFF
--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -1776,7 +1776,8 @@ internal abstract class AstQueryExecutorBase(
             return cond ? EvalArg(1) : EvalArg(2);
         }
 
-        if (fn.Name.Equals("IFNULL", StringComparison.OrdinalIgnoreCase))
+        if (fn.Name.Equals("IFNULL", StringComparison.OrdinalIgnoreCase)
+            || fn.Name.Equals("NVL", StringComparison.OrdinalIgnoreCase))
         {
             var v = EvalArg(0);
             return IsNullish(v) ? EvalArg(1) : v;


### PR DESCRIPTION
### Motivation
- The Oracle compatibility test used `NVL(email, 'none')` but the evaluator only recognized `IFNULL`, causing `NVL` calls to return nulls instead of the fallback value.

### Description
- Updated the scalar function handling in `AstQueryExecutorBase.EvalFunction` to also match `NVL` (case-insensitive) in the same branch as `IFNULL`, so `NVL(x, y)` returns `y` when `x` is nullish.
- The change is in `src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs` and only adjusts the function-name checks.

### Testing
- Attempted to run the targeted test `dotnet test src/DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj --filter "Functions_IFNULL_ShouldWork"`, but `dotnet` is not available in this environment so the automated test could not be executed.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d186ae38c832c81142f62a51db1d7)