### PR TITLE
Enable Oracle dialect parsing of `DELETE <alias> FROM ... JOIN`

### DIFF
--- a/src/DbSqlLikeMem.Oracle/OracleDialect.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDialect.cs
@@ -76,7 +76,8 @@ internal sealed class OracleDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsDeleteTargetAlias => false;
+    // Permite o parse de DELETE alvo FROM ... JOIN (...) usado pelos testes smart.
+    public override bool SupportsDeleteTargetAlias => true;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>


### PR DESCRIPTION
### Motivation
- Fix parser failure for Oracle where `DELETE u FROM users u JOIN (SELECT ...)` was rejected with `DELETE sem FROM não suportado no dialeto 'oracle'`, enabling the smart delete-from-select strategy used by tests.

### Description
- Set `SupportsDeleteTargetAlias` to `true` in `src/DbSqlLikeMem.Oracle/OracleDialect.cs` and added an inline comment explaining this is to allow parsing of `DELETE <alias> FROM <table> <alias> JOIN (...)` statements.

### Testing
- Attempted to run the targeted test `SelectIntoInsertSelectUpdateDeleteFromSelectTests.DeleteJoinDerivedSelect_ShouldDeleteRows` via `dotnet test`, but the `dotnet` CLI is not available in this environment so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d1878c090832c91abe96405b40854)