### PR TITLE
Fix Oracle parser corpus expectation for WITH RECURSIVE

### DIFF
--- a/src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -46,10 +46,13 @@ public sealed class SqlQueryParserCorpusTests(
             var sql = (string)row[0];
             var why = row.Length > 1 ? (string)row[1] : "valid statement";
             var minVersion = 0;
+            var expectation = SqlCaseExpectation.ParseOk;
 
             var trimmed = sql.TrimStart();
             if (trimmed.StartsWith("MERGE", StringComparison.OrdinalIgnoreCase))
                 minVersion = OracleDialect.MergeMinVersion;
+            else if (trimmed.StartsWith("WITH RECURSIVE", StringComparison.OrdinalIgnoreCase))
+                expectation = SqlCaseExpectation.ThrowNotSupported;
             else if (trimmed.Contains("WITH", StringComparison.OrdinalIgnoreCase))
                 minVersion = OracleDialect.WithCteMinVersion;
             else if (trimmed.Contains("OFFSET", StringComparison.OrdinalIgnoreCase))
@@ -57,7 +60,7 @@ public sealed class SqlQueryParserCorpusTests(
             else if (trimmed.Contains("FETCH", StringComparison.OrdinalIgnoreCase))
                 minVersion = OracleDialect.FetchFirstMinVersion;
 
-            yield return Case(sql, why, SqlCaseExpectation.ParseOk, minVersion);
+            yield return Case(sql, why, expectation, minVersion);
         }
 
         // Inválidas (ThrowInvalid)


### PR DESCRIPTION
### Motivation
- Align the Oracle test corpus with the Oracle dialect behavior by marking `WITH RECURSIVE` cases as not supported instead of expecting a successful parse.

### Description
- Update `SqlQueryParserCorpusTests.Statements()` (`src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs`) to introduce a per-case `expectation` variable and set it to `SqlCaseExpectation.ThrowNotSupported` when a statement starts with `WITH RECURSIVE`, then yield the computed expectation while keeping existing min-version logic for `MERGE`, `WITH`, `OFFSET`, and `FETCH` unchanged.

### Testing
- Attempted to run `dotnet test` for the affected test (`--filter "FullyQualifiedName~SqlQueryParserCorpusTests.Parse_Corpus"`) but `dotnet` is not available in this environment, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d188e1f28832cb02bf81893156724)