### PR TITLE
Allow DELETE target alias parsing across dialects

### DIFF
--- a/src/DbSqlLikeMem/Parser/Dialects.cs
+++ b/src/DbSqlLikeMem/Parser/Dialects.cs
@@ -304,7 +304,7 @@ internal abstract class SqlDialectBase : ISqlDialect
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public virtual bool SupportsDeleteTargetAlias => false;
+    public virtual bool SupportsDeleteTargetAlias => true;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>


### PR DESCRIPTION
### Motivation
- Fix the SQL parser rejecting statements of the form `DELETE u FROM users u JOIN ...` (which caused the `DeleteJoinDerivedSelect_ShouldDeleteRows` test to fail) by recognizing target-alias delete syntax used across dialect test suites.

### Description
- Change default capability `SupportsDeleteTargetAlias` to `true` in `src/DbSqlLikeMem/Parser/Dialects.cs` so `SqlQueryParser.ParseDelete` accepts `DELETE <alias> FROM <table> <alias> JOIN ...` forms instead of throwing for "DELETE without FROM".

### Testing
- Attempted to run `dotnet test` for the specific failing test `SelectIntoInsertSelectUpdateDeleteFromSelectTests.DeleteJoinDerivedSelect_ShouldDeleteRows`, but test execution could not be performed because the `dotnet` CLI is not available in this environment (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d189daaa0832c92fef1c6e772792d)