### PR TITLE
Fix SQL Server parser handling of INSERT/View column lists and WITH RECURSIVE

### DIFF
--- a/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
@@ -82,7 +82,7 @@ internal sealed class SqlServerDialect : SqlDialectBase
     /// Auto-generated summary.
     /// </summary>
     public override bool SupportsWithCte => Version >= WithCteMinVersion;
-    public override bool SupportsWithRecursive => false;
+    public override bool SupportsWithRecursive => Version >= WithCteMinVersion;
     public override bool SupportsWithMaterializedHint => false;
     public override bool SupportsOnConflictClause => false;
     /// <summary>

--- a/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
@@ -110,7 +110,7 @@ internal sealed class SqlQueryParser
         Consume(); // INSERT
         if (IsWord(Peek(), "INTO")) Consume();
 
-        var table = ParseTableSource(); // Tabela
+        var table = ParseTableSource(consumeHints: false); // Tabela
 
         // Colunas opcionais: (col1, col2)
         var cols = ParseCols();
@@ -792,7 +792,7 @@ internal sealed class SqlQueryParser
             throw new InvalidOperationException($"Esperava nome da view, veio {nameTok.Kind} '{nameTok.Text}'");
 
 
-        var viewName = ParseTableSource();
+        var viewName = ParseTableSource(consumeHints: false);
 
         // Optional column list: (col1, col2, ...)
         var colNames = new List<string>();
@@ -865,7 +865,7 @@ internal sealed class SqlQueryParser
             ifExists = true;
         }
 
-        var viewName = ParseTableSource();
+        var viewName = ParseTableSource(consumeHints: false);
 
         return new SqlDropViewQuery
         {
@@ -1152,7 +1152,7 @@ internal sealed class SqlQueryParser
         return list;
     }
 
-    private SqlTableSource ParseTableSource()
+    private SqlTableSource(bool consumeHints = true)
     {
         if (IsSymbol(Peek(), "("))
         {
@@ -1189,9 +1189,11 @@ internal sealed class SqlQueryParser
             db = table;
             table = ExpectIdentifier();
         }
-        ConsumeTableHintsIfPresent();
+        if (consumeHints)
+            ConsumeTableHintsIfPresent();
         var alias2 = ReadOptionalAlias();
-        ConsumeTableHintsIfPresent();
+        if (consumeHints)
+            ConsumeTableHintsIfPresent();
         return new SqlTableSource(db, table, alias2, null, null, null);
     }
 


### PR DESCRIPTION
### Motivation
- Tests were failing because parenthesized column lists were being consumed as SQL Server table hints, breaking `INSERT` column mapping and view column capture (failing cases include `Insert_WithColumnsOutOfOrder_ShouldMapCorrectly` and `Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames`).
- The parser corpus also expected `WITH RECURSIVE` to be accepted for SQL Server versions that support CTEs (the corpus case `WITH RECURSIVE` for v2005 was reported as `NotSupported`).

### Description
- Added a `consumeHints` parameter to `ParseTableSource` with signature `private SqlTableSource(bool consumeHints = true)` and guarded table-hint consumption behind this flag. 
- Disabled hint consumption in parsing contexts where parentheses represent explicit column lists by calling `ParseTableSource(consumeHints: false)` in `ParseInsert`, `ParseCreateView`, and `ParseDrop` so view/insert column lists are preserved. 
- Updated `SqlServerDialect` so `SupportsWithRecursive` now returns `Version >= WithCteMinVersion` instead of `false`, enabling `WITH RECURSIVE` for CTE-capable SQL Server versions. 
- Changes touch `src/DbSqlLikeMem/Parser/SqlQueryParser.cs` and `src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs` to implement the above.

### Testing
- Attempted to run targeted tests with `dotnet test` for the SQL Server test project, but the `dotnet` CLI is not available in this environment resulting in `bash: command not found: dotnet` so tests could not be executed here. 
- The changes are narrowly scoped to parser behavior and dialect capability and are expected to address the three failing parser/insert/view cases mentioned above when run in a proper `.NET` test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d27163d24832c94cafe142c4cedfe)