### PR TITLE
Enhance NuGet package metadata, update readiness report, and mark internal projects non-packable

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -28,6 +28,7 @@ jobs:
         run: dotnet pack src/DbSqlLikeMem.slnx -c Release -o ./artifacts
 
       - name: Publish to NuGet.org
+        shell: bash
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |

--- a/docs/nuget-readiness-validation-report.md
+++ b/docs/nuget-readiness-validation-report.md
@@ -1,0 +1,40 @@
+# NuGet readiness validation report
+
+Date: 2026-02-12
+
+## Executed validations
+
+1. Checked runtime availability for .NET CLI:
+   - `dotnet --info`
+   - Result: `dotnet: command not found` in this container.
+
+2. Tried installing .NET SDK via official install script:
+   - `curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh`
+   - Result: HTTP 403 from network gateway in this environment.
+
+3. Tried installing .NET SDK via apt repositories:
+   - `apt-get update -y`
+   - Result: repository access blocked with HTTP 403, package install unavailable.
+
+4. Static packaging checks (without build):
+   - Verified global multi-target frameworks in `src/Directory.Build.props`.
+   - Verified non-package internal projects are marked `IsPackable=false`:
+     - `DbSqlLikeMem.MySqlConsoleGenerator`
+     - `DbSqlLikeMem.VisualStudioExtension.Core`
+
+5. Metadata checks (NuGet quality gates):
+   - Present: `Version`, `Authors`, `PackageTags`, `PackageReadmeFile`, `RepositoryType`, `RepositoryUrl`, `PackageProjectUrl`.
+   - Missing/recommended: `PackageLicenseExpression` (or `PackageLicenseFile`).
+
+## Conclusion
+
+- The repository is structurally close to NuGet publication readiness for multiple frameworks.
+- Full runtime validation (`restore`, `build`, `test`, `pack`) could not be executed in this environment due blocked .NET installation/network access.
+- Before final release tag, run in CI or a machine with .NET SDK:
+
+```bash
+dotnet restore src/DbSqlLikeMem.slnx
+dotnet build src/DbSqlLikeMem.slnx -c Release
+dotnet test src/DbSqlLikeMem.slnx -c Release --no-build
+dotnet pack src/DbSqlLikeMem.slnx -c Release -o ./artifacts
+```

--- a/src/DbSqlLikeMem.MySqlConsoleGenerator/DbSqlLikeMem.MySqlConsoleGenerator.csproj
+++ b/src/DbSqlLikeMem.MySqlConsoleGenerator/DbSqlLikeMem.MySqlConsoleGenerator.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 	  <TargetFrameworks>net8.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net8.0</TargetFrameworks>
+		<IsPackable>false</IsPackable>
 		<Description>Core domain and services for the DbSqlLikeMem Visual Studio extension prototype.</Description>
 	</PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,9 +6,12 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>true</IsPackable>
 		<Authors>DbSqlLikeMem Contributors</Authors>
-		<PackageTags>in-memory;database;sql;unit-testing;mock;dapper</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/christianulson/DbSqlLikeMem</RepositoryUrl>
+		<PackageProjectUrl>https://github.com/christianulson/DbSqlLikeMem</PackageProjectUrl>
+		<PackageTags>in-memory;database;sql;unit-testing;mock;dapper;ado.net;npgsql;sqlite;oracle;sqlserver;mysql;db2</PackageTags>
+		<PackageReleaseNotes>See release notes and changelog in the GitHub repository.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Version>0.1.0</Version>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
### Motivation

- Make NuGet package pages more useful by exposing the repository/project URLs and richer metadata so users can quickly find the source and release notes. 
- Improve package discovery with expanded `PackageTags` and a `PackageReleaseNotes` pointer to the repository changelog. 
- Prevent accidental packaging of internal tooling projects by marking them non-packable and ensure the publish step runs under `bash` in the workflow.

### Description

- Updated shared NuGet properties in `src/Directory.Build.props` to add `RepositoryUrl`, `PackageProjectUrl`, expanded `PackageTags`, and `PackageReleaseNotes`, while retaining `PackageReadmeFile` and other package defaults. 
- Updated `docs/nuget-readiness-validation-report.md` to reflect that repository and project URLs are now present and the remaining recommended metadata (`PackageLicenseExpression` or `PackageLicenseFile`). 
- Marked internal projects as non-packable by adding `<IsPackable>false</IsPackable>` to `src/DbSqlLikeMem.MySqlConsoleGenerator/DbSqlLikeMem.MySqlConsoleGenerator.csproj` and `src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj`. 
- Tightened the publish workflow by ensuring the `Publish to NuGet.org` step runs with `shell: bash` so multi-line push scripts execute as intended in CI.

### Testing

- Ran static validation via small Python scripts to parse and confirm the presence of `RepositoryUrl`, `PackageProjectUrl`, `RepositoryType`, `PackageTags`, `PackageReadmeFile`, and `PackageReleaseNotes` in `src/Directory.Build.props`, which succeeded. 
- Verified the readiness report was updated to include the newly-configured repository URLs using file inspection, which succeeded. 
- Attempted runtime `dotnet` commands (`dotnet --info`, `dotnet restore`, `dotnet build`, `dotnet pack`) and installation steps, but execution was blocked in this environment due to missing .NET SDK and network HTTP 403 responses, so full runtime validation could not be performed. 
- Confirmed workflow change (`shell: bash`) and project `IsPackable` flags are present by inspecting the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d30d33114832cb64e71195b12681a)