### PR TITLE
Fix cancellation behavior and default DB type mapping in class generation

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/ClassGenerator.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/ClassGenerator.cs
@@ -33,6 +33,8 @@ public sealed class ClassGenerator
             var fullPath = Path.Combine(mapping.OutputDirectory, fileName);
             var content = classContentFactory(dbObject);
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             await File.WriteAllTextAsync(fullPath, content, cancellationToken);
             writtenFiles.Add(fullPath);
         }

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/StructuredClassContentFactory.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/StructuredClassContentFactory.cs
@@ -16,6 +16,7 @@ public static class StructuredClassContentFactory
     /// </summary>
     public static string Build(DatabaseObjectReference dbObject, string? @namespace = null, string? databaseType = null)
     {
+        var effectiveDatabaseType = string.IsNullOrWhiteSpace(databaseType) ? "MySql" : databaseType;
         var className = $"{GenerationRuleSet.ToPascalCase(dbObject.Name)}{dbObject.Type}Factory";
         var methodName = $"Create{dbObject.Type}{GenerationRuleSet.ToPascalCase(dbObject.Name)}";
 
@@ -47,7 +48,7 @@ public static class StructuredClassContentFactory
 
         foreach (var c in columns.OrderBy(c => c.Ordinal))
         {
-            var mappedDbType = GenerationRuleSet.MapDbType(c.DataType, c.CharMaxLen, c.NumPrecision, c.Name, databaseType);
+            var mappedDbType = GenerationRuleSet.MapDbType(c.DataType, c.CharMaxLen, c.NumPrecision, c.Name, effectiveDatabaseType);
             var ctor = $"new({c.Ordinal}, DbType.{mappedDbType}, {Bool(c.IsNullable)}";
             if (c.IsIdentity) ctor += ", true";
             ctor += ")";


### PR DESCRIPTION
### Motivation

- Ensure generation honors cancellation immediately after content is produced so the operation throws from our cancellation check rather than bubbling up as a `TaskCanceledException` from the file write. 
- Align the Structured class generator's default type-mapping behavior with the console generator by applying MySQL mapping rules when no `databaseType` is provided, fixing tinyint/bit mapping regressions.

### Description

- Added a second cancellation checkpoint in `ClassGenerator.GenerateAsync` immediately after calling the `classContentFactory` and before starting the async file write (`cancellationToken.ThrowIfCancellationRequested()`).
- Defaulted `StructuredClassContentFactory.Build` to an effective database type of `"MySql"` when the `databaseType` parameter is null or whitespace, and used that effective value when calling `GenerationRuleSet.MapDbType`.
- These changes ensure cancellation is detected by `ThrowIfCancellationRequested()` before `File.WriteAllTextAsync` is awaited and that column type mapping without an explicit `databaseType` uses MySQL rules.

### Testing

- Attempted to run unit tests with `dotnet test src/DbSqlLikeMem.VisualStudioExtension.Core.Test/DbSqlLikeMem.VisualStudioExtension.Core.Test.csproj`, but the environment does not have the `dotnet` SDK installed so tests could not be executed (`bash: command not found: dotnet`).
- No automated test results are available from this environment; changes are limited and focused to make behavioral fixes visible to the test suite when run in a CI or developer environment with `dotnet` installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d395167b8832ca1adf99a7145e452)