### PR TITLE
Enforce dialect-specific parser rules and improve IN-subquery resolution

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -221,7 +221,7 @@ ORDER BY u.Id, o.Amount", "JOIN with derived subquery + ORDER BY multiple keys" 
         yield return new object[] { "select json_extract(data, '$.name') from users", "JSON_EXTRACT function call" };
 
         // Regex / null-safe equality
-        yield return new object[] { "select * from users where a <=> b", "null-safe equality <=>" };
+        yield return new object[] { "select * from users where a <=> b", "invalid: null-safe equality <=>" };
         yield return new object[] { "select * from users where name regexp '^[A-Z]+'", "REGEXP operator" };
         yield return new object[] { "select * from users where name not regexp '[0-9]'", "NOT REGEXP operator" };
 

--- a/src/DbSqlLikeMem.Db2.Test/TemporaryTable/Db2TemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/TemporaryTable/Db2TemporaryTableParserTests.cs
@@ -49,14 +49,6 @@ SELECT * FROM tmp_users;
             "CREATE TEMPORARY TABLE tmp_users (id INT, name VARCHAR(50)) AS SELECT id, name FROM users",
         };
 
-        yield return new object[]
-        {
-            // backticks + multiline select
-            @"CREATE TEMPORARY TABLE `tmp_users` AS
-SELECT `id`, `name`
-FROM `users`
-WHERE `tenantid` = 10",
-        };
     }
 
     /// <summary>
@@ -72,6 +64,23 @@ WHERE `tenantid` = 10",
         Assert.NotNull(q);
         Assert.Contains("CREATE", q.RawSql, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("TEMPORARY", q.RawSql, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Parse_ShouldReject_Backticks_ByDb2Spec behavior.
+    /// PT: Testa o comportamento de Parse_ShouldReject_Backticks_ByDb2Spec.
+    /// </summary>
+    [Theory]
+    [MemberDataDb2Version]
+    public void Parse_ShouldReject_Backticks_ByDb2Spec(int version)
+    {
+        const string sql = @"CREATE TEMPORARY TABLE `tmp_users` AS
+SELECT `id`, `name`
+FROM `users`
+WHERE `tenantid` = 10";
+
+        Assert.ThrowsAny<Exception>(() => SqlQueryParser.Parse(sql, new Db2Dialect(version)));
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Db2.Test/Views/Db2CreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Views/Db2CreateViewParserTests.cs
@@ -69,12 +69,10 @@ SELECT * FROM v_users;
     /// </summary>
     [Theory]
     [MemberDataDb2Version]
-    public void Parse_CreateView_WithBackticks_ShouldWork(int version)
+    public void Parse_CreateView_WithBackticks_ShouldFail_ByDb2Spec(int version)
     {
         const string sql = "CREATE VIEW `v` AS SELECT `id` FROM `users`;";
-        var q = SqlQueryParser.ParseMulti(sql, new Db2Dialect(version)).Single();
-        var cv = Assert.IsType<SqlCreateViewQuery>(q);
-        Assert.Equal("v", cv.Table?.Name);
+        Assert.ThrowsAny<Exception>(() => SqlQueryParser.ParseMulti(sql, new Db2Dialect(version)).ToList());
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Sqlite.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -125,7 +125,7 @@ WHERE u.tenantid = 10";
         users.Add(new Dictionary<int, object?> { { 0, 3 }, { 1, 20 } });
 
         using var c = new SqliteConnectionMock(db);
-        const string sql = "DELETE u FROM users u JOIN (SELECT id FROM users WHERE tenantid = 10) s ON s.id = u.id";
+        const string sql = "DELETE FROM users WHERE id IN (SELECT id FROM users WHERE tenantid = 10)";
 
         using var cmd = new SqliteCommandMock(c) { CommandText = sql };
         var deleted = cmd.ExecuteNonQuery();

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteAdditionalBehaviorCoverageTests.cs
@@ -178,7 +178,7 @@ ORDER BY userid
     [Fact]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
-        var deleted = _cnn.Execute("DELETE users WHERE id IN @ids", new { ids = param });
+        var deleted = _cnn.Execute("DELETE FROM users WHERE id IN @ids", new { ids = param });
         Assert.Equal(2, deleted);
 
         var remaining = _cnn.Query<int>("SELECT id FROM users ORDER BY id").ToList();

--- a/src/DbSqlLikeMem/Parser/SqlTokenizer.cs
+++ b/src/DbSqlLikeMem/Parser/SqlTokenizer.cs
@@ -275,6 +275,17 @@ internal sealed class SqlTokenizer
     {
         token = default!;
 
+        // Greedy safeguard for tokens like "<=>" even when the dialect does not
+        // explicitly list the full operator (prevents tokenizing as "<=" + ">").
+        if (_pos + 3 <= _sql.Length
+            && string.CompareOrdinal(_sql, _pos, "<=>", 0, 3) == 0)
+        {
+            var p = _pos;
+            _pos += 3;
+            token = new SqlToken(SqlTokenKind.Operator, "<=>", p);
+            return true;
+        }
+
         // Compat parser: operadores JSON podem ser aceitos conforme regra do dialeto.
         if (_dialect.SupportsJsonArrowOperators || _dialect.AllowsParserCrossDialectJsonOperators)
         {


### PR DESCRIPTION
### Motivation
- Align parser behavior with strict per-dialect SQL rules so each dialect only accepts syntax valid for its engine. 
- Remove permissive cross-dialect allowances that let non-DB2/SQLite syntax slip into DB2/SQLite tests. 
- Improve in-memory engine support for `IN (SELECT ...)` so test and engine semantics better match realistic subquery evaluation.

### Description
- DB2: removed the `<=>` null-safe operator mapping from the DB2 dialect and removed `<=>` from the DB2 operator list, and disabled cross-dialect quoted-identifier acceptance by setting `AllowsParserCrossDialectQuotedIdentifiers` to `false` to enforce DB2 identifier rules. 
- SQLite: disabled the parser compatibility flag `AllowsParserDeleteWithoutFromCompatibility` to stop accepting `DELETE <table> WHERE ...` forms and updated tests to use `DELETE FROM ...`. 
- Tokenizer: added a greedy safeguard to recognize the `<=>` operator token during tokenization to avoid mis-tokenization even when a particular dialect does not accept it at the AST level. 
- Table engine: enhanced `TableMock` `IN` handling to detect subquery forms and added `ResolveInSubqueryCandidates` to parse simple `SELECT ... FROM ... [WHERE ...]` shapes and collect candidate values with best-effort coercion into the target column type. 
- Tests: updated DB2 corpus and parser tests to mark `<=>` as invalid for DB2 and added tests that assert backtick-quoted identifiers are rejected by DB2, and updated SQLite tests to use dialect-valid `DELETE FROM` syntax and parameterized `IN` calls.

### Testing
- No automated `dotnet test` runs were executed in this environment because `dotnet` is unavailable. 
- Changes were validated by modifying tests to reflect the stricter dialect rules, and a local repository check/commit completed without running the test suite. 
- Integration/compilation was not verified here, so consumers should run `dotnet test` across projects to confirm behavior on CI or a development machine.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d38ef6c88832c984dc3f89540fe87)