### PR TITLE
Ensure ClassGenerator completes current file write when cancelled

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/ClassGenerator.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/ClassGenerator.cs
@@ -33,9 +33,7 @@ public sealed class ClassGenerator
             var fullPath = Path.Combine(mapping.OutputDirectory, fileName);
             var content = classContentFactory(dbObject);
 
-            cancellationToken.ThrowIfCancellationRequested();
-
-            await File.WriteAllTextAsync(fullPath, content, cancellationToken);
+            await File.WriteAllTextAsync(fullPath, content, CancellationToken.None);
             writtenFiles.Add(fullPath);
         }
 


### PR DESCRIPTION
### Motivation
- Fix a regression where cancellation during content generation could prevent the currently processed file from being written, causing tests that expect at least one generated file to fail.

### Description
- Updated `ClassGenerator.GenerateAsync` to avoid throwing mid-iteration by using `File.WriteAllTextAsync(fullPath, content, CancellationToken.None)` so the current file write always completes while still honoring cancellation at the start of each iteration; change located in `src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/ClassGenerator.cs`.

### Testing
- Attempted to run the targeted regression test `dotnet test src/DbSqlLikeMem.VisualStudioExtension.Core.Test/DbSqlLikeMem.VisualStudioExtension.Core.Test.csproj --filter "ClassGenerator_WhenCanceled_StopsWritingFurtherFiles"`, but the environment does not have the `dotnet` CLI installed so the test could not be executed here (failure: `bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d42393d38832c95f928866c0a281e)