### PR TITLE
Align Npgsql and System.Collections.Immutable package versions by target framework

### DIFF
--- a/src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj
+++ b/src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj
@@ -14,7 +14,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Npgsql" Version="9.0.4" />
+		<PackageReference Include="Npgsql" Version="8.0.8" />
 		<PackageReference Include="System.Text.Json" Version="8.0.6" />
 		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
 	</ItemGroup>

--- a/src/DbSqlLikeMem/DbSqlLikeMem.csproj
+++ b/src/DbSqlLikeMem/DbSqlLikeMem.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="Dapper" Version="2.1.35" />
 		<PackageReference Include="Roslynator.CSharp" Version="4.15.0" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
-		<PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+		<PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
### Motivation
- Reduce framework-support warnings observed during `net6.0` builds by pinning compatible package majors per target framework. 
- Prevent unintended package graph downgrades for legacy TFMs by aligning `System.Collections.Immutable` to a compatible version for `net48`/`netstandard2.1`. 
- Keep newer major packages available for modern TFMs (`net8.0`/`net10.0`) while avoiding unsupported transitive package warnings on older TFMs.

### Description
- In `src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj` changed the `net6.0` `Npgsql` package from `9.0.4` to `8.0.8` to match a supported major for that TFM and avoid pulling `10.x` transitive packages. 
- In `src/DbSqlLikeMem/DbSqlLikeMem.csproj` updated `System.Collections.Immutable` from `8.0.0` to `9.0.0` for the `net48`/`netstandard2.1` item group to prevent legacy-TFM downgrade issues. 
- Left `Npgsql` `10.0.1` and `System.Text.Json` `10.0.3` in place for `net8.0`/`net10.0` so modern TFMs continue to use newer supported packages.

### Testing
- Verified the file changes and diffs using `git diff -- src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj` and `rg "Npgsql\" Version=\"" -n src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj` which reported the updated version. 
- Inspected the modified file contents with `nl -ba src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj` and committed the change with `git commit -m "Align Npgsql net6 package to supported major version"`. 
- Could not run `dotnet restore` or `dotnet build` in this environment because the `dotnet` CLI is not installed, so no runtime/restore builds were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d44a66cf4832ca9d325256d4d08e8)