### PR TITLE
Harden composite index key handling and verify indexed query behavior

### DIFF
--- a/src/DbSqlLikeMem.Sqlite.Test/ExtendedSqliteMockTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/ExtendedSqliteMockTests.cs
@@ -261,4 +261,25 @@ public sealed class ExtendedSqliteMockTests(
         Assert.Equal("A", table[0][1]);
         Assert.Equal("B", table[1][1]);
     }
+
+
+    /// <summary>
+    /// EN: Tests UniqueCompositeIndexShouldNotCollideWhenValuesContainSeparator behavior.
+    /// PT: Testa o comportamento de UniqueCompositeIndexShouldNotCollideWhenValuesContainSeparator.
+    /// </summary>
+    [Fact]
+    public void UniqueCompositeIndexShouldNotCollideWhenValuesContainSeparator()
+    {
+        var db = new SqliteDbMock();
+        var table = db.AddTable("t");
+        table.Columns["first"] = new(0, DbType.String, false);
+        table.Columns["second"] = new(1, DbType.String, false);
+        table.CreateIndex(new IndexDef("ux_first_second", ["first", "second"], unique: true));
+
+        table.Add(new Dictionary<int, object?> { { 0, "A|B" }, { 1, "C" } });
+        table.Add(new Dictionary<int, object?> { { 0, "A" }, { 1, "B|C" } });
+
+        Assert.Equal(2, table.Count);
+    }
+
 }

--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -344,12 +344,14 @@ internal abstract class AstQueryExecutorBase(
         if (best is null)
             return null;
 
-        var key = string.Join("|", best.KeyCols.Select(col =>
-        {
-            var norm = col.NormalizeName();
-            var value = equalsByColumn[norm];
-            return value?.ToString() ?? "<null>";
-        }));
+        var key = src.Physical is TableMock physicalTable
+            ? physicalTable.BuildIndexKeyFromValues(best, equalsByColumn)
+            : string.Join("|", best.KeyCols.Select(col =>
+            {
+                var norm = col.NormalizeName();
+                var value = equalsByColumn[norm];
+                return value?.ToString() ?? "<null>";
+            }));
 
         var positions = LookupIndexWithMetrics(src.Physical, best, key);
         if (positions is null)


### PR DESCRIPTION
### Motivation
- Prevent ambiguous composite index keys when component values contain the separator character and ensure index lookups and uniqueness checks remain correct. 
- Ensure null-like values are treated consistently in index keys so `null` and `DBNull` behave identically for indexing and lookup.

### Description
- Replaced concatenation-based key building in `TableMock.BuildIndexKey` with per-part encoding using `SerializeIndexKeyPart` and added `BuildIndexKeyFromValues(IndexDef, IReadOnlyDictionary<string, object?>)` to build keys for index lookups from column→value maps. 
- Made `SerializeIndexKeyPart` map `null` and `DBNull` to a stable `n;` token and encode strings as `s<length>:<value>;` to make composite keys unambiguous. 
- In `AstQueryExecutorBase.TryRowsFromIndex`, use `TableMock.BuildIndexKeyFromValues` when the table is a `TableMock`, and keep a separator-based fallback (`string.Join("|", ...)` with `"<null>"`) for non-`TableMock` implementations to reduce regression risk. 
- Added tests covering both uniqueness and lookup behavior: `UniqueCompositeIndexShouldNotCollideWhenValuesContainSeparator` in `ExtendedSqliteMockTests` and `Where_IndexedEqualityWithCompositeValuesContainingSeparator_ShouldReturnCorrectRow` in `SqliteWhereParserAndExecutorTests`, and added sample rows containing `|` to validate runtime index resolution.

### Testing
- Added targeted regression/unit tests to the test project to be executed by CI including the composite-key-contains-separator insertion and lookup cases. 
- Attempted to run the new tests locally with `dotnet test src/DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj --filter "Where_IndexedEqualityWithCompositeValuesContainingSeparator_ShouldReturnCorrectRow|Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric"`, but the command failed because `dotnet` is not available in this environment. 
- No automated tests were executed here; the added tests are intended to run in CI or any environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d48399884832caa977120132a6c08)