### PR TITLE
Fix CS1591 and xUnit2004 warnings in dialect test projects

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Db2UnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2UnionLimitAndJsonCompatibilityTests.cs
@@ -88,6 +88,10 @@ SELECT id FROM t WHERE id = 1
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION normalizes equivalent numeric literals into a single row.
+    /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
@@ -100,6 +104,10 @@ SELECT 1 AS v
         Assert.Single(rows);
     }
 
+    /// <summary>
+    /// EN: Ensures UNION rejects incompatible column types across SELECT parts.
+    /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
@@ -113,6 +121,10 @@ SELECT 'x' AS v
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION schema keeps aliases from the first SELECT projection.
+    /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {

--- a/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
@@ -135,7 +135,7 @@ public sealed class Db2DialectFeatureParserTests
         Assert.False(d.AreUnionColumnTypesCompatible(DbType.Int32, DbType.String));
 
         Assert.True(d.IsIntegerCastTypeName("INT"));
-        Assert.Equal(false, d.IsIntegerCastTypeName("NUMBER"));
+        Assert.False(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
     }

--- a/src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs
@@ -88,6 +88,10 @@ SELECT id FROM t WHERE id = 1
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION normalizes equivalent numeric literals into a single row.
+    /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
@@ -100,6 +104,10 @@ SELECT 1 AS v
         Assert.Single(rows);
     }
 
+    /// <summary>
+    /// EN: Ensures UNION rejects incompatible column types across SELECT parts.
+    /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
@@ -113,6 +121,10 @@ SELECT 'x' AS v
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION schema keeps aliases from the first SELECT projection.
+    /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
@@ -73,7 +73,7 @@ public sealed class MySqlDialectFeatureParserTests
         Assert.False(d.AreUnionColumnTypesCompatible(DbType.Int32, DbType.String));
 
         Assert.True(d.IsIntegerCastTypeName("INT"));
-        Assert.Equal(false, d.IsIntegerCastTypeName("NUMBER"));
+        Assert.False(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
     }

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
@@ -115,7 +115,7 @@ RETURNING id";
         Assert.False(d.AreUnionColumnTypesCompatible(DbType.Int32, DbType.String));
 
         Assert.True(d.IsIntegerCastTypeName("INT"));
-        Assert.Equal(false, d.IsIntegerCastTypeName("NUMBER"));
+        Assert.False(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
     }

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs
@@ -76,6 +76,10 @@ SELECT id FROM t WHERE id = 1
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION normalizes equivalent numeric literals into a single row.
+    /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
@@ -88,6 +92,10 @@ SELECT 1 AS v
         Assert.Single(rows);
     }
 
+    /// <summary>
+    /// EN: Ensures UNION rejects incompatible column types across SELECT parts.
+    /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
@@ -101,6 +109,10 @@ SELECT 'x' AS v
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION schema keeps aliases from the first SELECT projection.
+    /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAdvancedSqlGapTests.cs
@@ -104,6 +104,10 @@ ORDER BY id").ToList();
 
 
 
+    /// <summary>
+    /// EN: Ensures NUMBER cast target is treated as integer-compatible in Oracle behavior.
+    /// PT: Garante que o alvo de cast NUMBER seja tratado como compatível com inteiro no comportamento Oracle.
+    /// </summary>
     [Fact]
     public void Cast_StringToInt_NumberType_ShouldWork()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs
@@ -77,6 +77,10 @@ SELECT id FROM t WHERE id = 1
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION normalizes equivalent numeric literals into a single row.
+    /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
@@ -89,6 +93,10 @@ SELECT 1 AS v
         Assert.Single(rows);
     }
 
+    /// <summary>
+    /// EN: Ensures UNION rejects incompatible column types across SELECT parts.
+    /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
@@ -102,6 +110,10 @@ SELECT 'x' AS v
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION schema keeps aliases from the first SELECT projection.
+    /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
@@ -71,7 +71,7 @@ public sealed class OracleDialectFeatureParserTests
         Assert.False(d.AreUnionColumnTypesCompatible(DbType.Int32, DbType.String));
 
         Assert.True(d.IsIntegerCastTypeName("INT"));
-        Assert.Equal(true, d.IsIntegerCastTypeName("NUMBER"));
+        Assert.True(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
     }

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
@@ -92,7 +92,7 @@ public sealed class SqlServerDialectFeatureParserTests
         Assert.False(d.AreUnionColumnTypesCompatible(DbType.Int32, DbType.String));
 
         Assert.True(d.IsIntegerCastTypeName("INT"));
-        Assert.Equal(false, d.IsIntegerCastTypeName("NUMBER"));
+        Assert.False(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
     }

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs
@@ -76,6 +76,10 @@ SELECT id FROM t WHERE id = 1
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION normalizes equivalent numeric literals into a single row.
+    /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
@@ -88,6 +92,10 @@ SELECT 1 AS v
         Assert.Single(rows);
     }
 
+    /// <summary>
+    /// EN: Ensures UNION rejects incompatible column types across SELECT parts.
+    /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
@@ -101,6 +109,10 @@ SELECT 'x' AS v
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION schema keeps aliases from the first SELECT projection.
+    /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
@@ -102,7 +102,7 @@ public sealed class SqliteDialectFeatureParserTests
         Assert.False(d.AreUnionColumnTypesCompatible(DbType.Int32, DbType.String));
 
         Assert.True(d.IsIntegerCastTypeName("INT"));
-        Assert.Equal(false, d.IsIntegerCastTypeName("NUMBER"));
+        Assert.False(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
     }

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs
@@ -88,6 +88,10 @@ SELECT id FROM t WHERE id = 1
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION normalizes equivalent numeric literals into a single row.
+    /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
@@ -100,6 +104,10 @@ SELECT 1 AS v
         Assert.Single(rows);
     }
 
+    /// <summary>
+    /// EN: Ensures UNION rejects incompatible column types across SELECT parts.
+    /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
@@ -113,6 +121,10 @@ SELECT 'x' AS v
 
 
 
+    /// <summary>
+    /// EN: Ensures UNION schema keeps aliases from the first SELECT projection.
+    /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
+    /// </summary>
     [Fact]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {


### PR DESCRIPTION
### Motivation
- Fix missing XML documentation (CS1591) and xUnit boolean assertion warnings (xUnit2004) in dialect test suites to improve API docs and test analyzer compliance.
- Corrigir comentários XML ausentes (CS1591) e avisos de asserção booleana do xUnit (xUnit2004) nas suítes de testes de dialeto para melhorar a documentação da API e a conformidade com os analisadores de teste.

### Description
- Added XML documentation comments (English first, Portuguese second) for public UNION-related test methods across Sqlite, SqlServer, Oracle, Npgsql, Db2 and MySql test projects.
- Added the missing XML documentation comment for `Cast_StringToInt_NumberType_ShouldWork` in the Oracle advanced gap tests.
- Replaced boolean `Assert.Equal(true|false, ...)` usages with `Assert.True(...)`/`Assert.False(...)` in parser runtime dialect rule tests to satisfy xUnit2004.
- Changes span multiple test projects (13 files modified) to address analyzer warnings and improve test API docs.

### Testing
- Attempted to run `dotnet test DbSqlLikeMem.sln --no-restore`, but the `dotnet` command is not available in this execution environment so no test suite was executed.
- All edits were committed locally; no automated test failures were observed because tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d4d650d04832c81c1b13a2069a7a0)