### PR TITLE
Fix SQLite WHERE test expectations for expanded seed data

### DIFF
--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteWhereParserAndExecutorTests.cs
@@ -144,7 +144,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     public void Where_IsNotNull_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE email IS NOT NULL").ToList();
-        Assert.Equal(2, rows.Count);
+        Assert.Equal(4, rows.Count);
     }
 
     /// <summary>
@@ -158,7 +158,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal([2, 3], [.. rows.Select(r => (int)r.id).OrderBy(_=>_)]);
 
         var rows2 = _cnn.Query<dynamic>("SELECT id FROM users WHERE id != 2").ToList();
-        Assert.Equal([1, 3], [.. rows2.Select(r => (int)r.id).OrderBy(_=>_)]);
+        Assert.Equal([1, 3, 4, 5], [.. rows2.Select(r => (int)r.id).OrderBy(_=>_)]);
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- The shared SQLite test fixture was expanded to seed five `users` rows (ids 1..5), so two test assertions were still expecting the old, smaller fixture and started failing; the intent is to update the test expectations to match the new seed data.

### Description
- Updated two assertions in `src/DbSqlLikeMem.Sqlite.Test/SqliteWhereParserAndExecutorTests.cs`: `Where_IsNotNull_ShouldFilter` expected count changed from `2` to `4`, and `Where_Operators_ShouldWork` expected result for `id != 2` changed from `[1, 3]` to `[1, 3, 4, 5]`.

### Testing
- Attempted to run targeted tests with `dotnet test ... --filter "FullyQualifiedName~SqliteWhereParserAndExecutorTests.Where_IsNotNull_ShouldFilter|FullyQualifiedName~SqliteWhereParserAndExecutorTests.Where_Operators_ShouldWork"`, but the run failed because `dotnet` is not available in this environment (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d50148ec0832ca36baf62a2b3b7bb)