### PR TITLE
docs: align provider baseline and simulated versions across README and compatibility docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,20 @@
 | MySQL | `DbSqlLikeMem.MySql` |
 | SQL Server | `DbSqlLikeMem.SqlServer` |
 | Oracle | `DbSqlLikeMem.Oracle` |
-| PostgreSQL | `DbSqlLikeMem.Npgsql` |
-| SQLite | `DbSqlLikeMem.Sqlite` |
+| PostgreSQL (Npgsql) | `DbSqlLikeMem.Npgsql` |
+| SQLite (Sqlite) | `DbSqlLikeMem.Sqlite` |
 | DB2 | `DbSqlLikeMem.Db2` |
+
+## Simulated versions by provider | Versões simuladas por provedor
+
+| Provider / Provedor | Simulated versions / Versões simuladas |
+| --- | --- |
+| MySQL | 3, 4, 5, 8 |
+| SQL Server | 7, 2000, 2005, 2008, 2012, 2014, 2016, 2017, 2019, 2022 |
+| Oracle | 7, 8, 9, 10, 11, 12, 18, 19, 21, 23 |
+| PostgreSQL (Npgsql) | 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 |
+| SQLite (Sqlite) | 3 |
+| DB2 | 8, 9, 10, 11 |
 
 ## Runtime provider factory example | Exemplo de factory de provider em runtime
 

--- a/docs/providers-and-features.md
+++ b/docs/providers-and-features.md
@@ -10,10 +10,10 @@
 | SQL Server | `DbSqlLikeMem.SqlServer` | 7, 2000, 2005, 2008, 2012, 2014, 2016, 2017, 2019, 2022 |
 | Oracle | `DbSqlLikeMem.Oracle` | 7, 8, 9, 10, 11, 12, 18, 19, 21, 23 |
 | PostgreSQL (Npgsql) | `DbSqlLikeMem.Npgsql` | 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 |
-| SQLite | `DbSqlLikeMem.Sqlite` | 3 |
+| SQLite (Sqlite) | `DbSqlLikeMem.Sqlite` | 3 |
 | DB2 | `DbSqlLikeMem.Db2` | 8, 9, 10, 11 |
 
-## Capacidades comuns (MySQL / SQL Server / Oracle / PostgreSQL)
+## Capacidades comuns (todos os providers)
 
 - Mock de conexão/ADO.NET específico do provedor.
 - Parser e execução de SQL para DDL/DML comuns.


### PR DESCRIPTION
### Motivation

- Ensure documentation reflects the actual list of providers and the simulated versions implemented in code and remove naming inconsistencies across docs.
- Provide a clear, centralized table in the repository root `README.md` so consumers can quickly see which provider versions are simulated by the project.

### Description

- Normalized provider naming in `README.md` to `PostgreSQL (Npgsql)` and `SQLite (Sqlite)` to match project/package names.
- Added a new `Simulated versions by provider` table to `README.md` listing the simulated versions for MySQL, SQL Server, Oracle, PostgreSQL (Npgsql), SQLite (Sqlite), and DB2.
- Updated `docs/providers-and-features.md` to use the `SQLite (Sqlite)` name and changed the common-capabilities heading to `Capacidades comuns (todos os providers)` for clarity.
- No runtime/source code behavior was modified; changes are documentation-only and align with values in the provider `*DbVersions.cs` files.

### Testing

- Verified version lists against the implementation by running `rg "yield return" src/*/*DbVersions.cs` and confirmed the README table matches the `*DbVersions.cs` outputs (all checks succeeded).
- Confirmed diffs contain only documentation changes using `git diff -- README.md docs/providers-and-features.md` (succeeded).
- Confirmed working tree status with `git status --short` showing only the two modified docs (succeeded).
- No unit tests were executed as this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d53cda97c832cae3e3fc53de8b672)