### PR TITLE
Evolve UNION AST to carry final ORDER BY/LIMIT and apply in executor across providers

### DIFF
--- a/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
@@ -240,7 +240,7 @@ public class Db2CommandMock(
                     break;
 
                 case SqlUnionQuery unionQ:
-                    tables.Add(executor.ExecuteUnion(unionQ.Parts, unionQ.AllFlags, unionQ.RawSql));
+                    tables.Add(executor.ExecuteUnion(unionQ.Parts, unionQ.AllFlags, unionQ.OrderBy, unionQ.RowLimit, unionQ.RawSql));
                     break;
 
                 default:

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
@@ -142,14 +142,6 @@ public class NpgsqlCommandMock(
 
         var executor = new NpgsqlAstQueryExecutor(connection!, Parameters);
 
-        if (sql.Contains("UNION", StringComparison.OrdinalIgnoreCase) && !sql.Contains(';'))
-        {
-            var chain = SqlQueryParser.ParseUnionChain(sql, connection!.Db.Dialect);
-            var unionTable = executor.ExecuteUnion(chain.Parts.Cast<SqlSelectQuery>().ToList(), chain.AllFlags, sql);
-            connection.Metrics.Selects += unionTable.Count;
-            return new NpgsqlDataReaderMock([unionTable]);
-        }
-
         var queries = SqlQueryParser.ParseMulti(sql, connection!.Db.Dialect).ToList();
         var tables = new List<TableResultMock>();
 
@@ -159,6 +151,10 @@ public class NpgsqlCommandMock(
             {
                 case SqlSelectQuery selectQ:
                     tables.Add(executor.ExecuteSelect(selectQ));
+                    break;
+
+                case SqlUnionQuery unionQ:
+                    tables.Add(executor.ExecuteUnion(unionQ.Parts, unionQ.AllFlags, unionQ.OrderBy, unionQ.RowLimit, unionQ.RawSql));
                     break;
                 case SqlInsertQuery insertQ:
                     connection.ExecuteInsert(insertQ, Parameters, connection.Db.Dialect);

--- a/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
@@ -142,14 +142,6 @@ public class SqlServerCommandMock(
 
         var executor = new SqlServerAstQueryExecutor(connection!, Parameters);
 
-        if (sql.Contains("UNION", StringComparison.OrdinalIgnoreCase) && !sql.Contains(';'))
-        {
-            var chain = SqlQueryParser.ParseUnionChain(sql, connection!.Db.Dialect);
-            var unionTable = executor.ExecuteUnion([.. chain.Parts.Cast<SqlSelectQuery>()], chain.AllFlags, sql);
-            connection.Metrics.Selects += unionTable.Count;
-            return new SqlServerDataReaderMock([unionTable]);
-        }
-
         var queries = SqlQueryParser.ParseMulti(sql, connection!.Db.Dialect).ToList();
         var tables = new List<TableResultMock>();
 
@@ -159,6 +151,10 @@ public class SqlServerCommandMock(
             {
                 case SqlSelectQuery selectQ:
                     tables.Add(executor.ExecuteSelect(selectQ));
+                    break;
+
+                case SqlUnionQuery unionQ:
+                    tables.Add(executor.ExecuteUnion(unionQ.Parts, unionQ.AllFlags, unionQ.OrderBy, unionQ.RowLimit, unionQ.RawSql));
                     break;
                 case SqlInsertQuery insertQ:
                     connection.ExecuteInsert(insertQ, Parameters, connection.Db.Dialect);

--- a/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
@@ -206,7 +206,7 @@ public class SqliteCommandMock(
                     break;
 
                 case SqlUnionQuery unionQ:
-                    tables.Add(executor.ExecuteUnion(unionQ.Parts, unionQ.AllFlags, unionQ.RawSql));
+                    tables.Add(executor.ExecuteUnion(unionQ.Parts, unionQ.AllFlags, unionQ.OrderBy, unionQ.RowLimit, unionQ.RawSql));
                     break;
 
                 default:

--- a/src/DbSqlLikeMem/Executor/AstQueryExecutorFactory.cs
+++ b/src/DbSqlLikeMem/Executor/AstQueryExecutorFactory.cs
@@ -57,6 +57,8 @@ internal static class AstQueryExecutorFactory
         public TableResultMock ExecuteUnion(
             IReadOnlyList<SqlSelectQuery> parts,
             IReadOnlyList<bool> allFlags,
+            IReadOnlyList<SqlOrderByItem>? orderBy = null,
+            SqlRowLimit? rowLimit = null,
             string? sqlContextForErrors = null)
             => throw new NotSupportedException(
                 $"AST executor não implementado para dialeto '{_dialectName}'. " +

--- a/src/DbSqlLikeMem/Executor/IAstQueryExecutor.cs
+++ b/src/DbSqlLikeMem/Executor/IAstQueryExecutor.cs
@@ -13,5 +13,7 @@ internal interface IAstQueryExecutor
     TableResultMock ExecuteUnion(
         IReadOnlyList<SqlSelectQuery> parts,
         IReadOnlyList<bool> allFlags,
+        IReadOnlyList<SqlOrderByItem>? orderBy = null,
+        SqlRowLimit? rowLimit = null,
         string? sqlContextForErrors = null);
 }

--- a/src/DbSqlLikeMem/Parser/SqlQueryAst.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryAst.cs
@@ -28,7 +28,9 @@ internal sealed record SqlSelectQuery(
 
 internal sealed record SqlUnionQuery(
     IReadOnlyList<SqlSelectQuery> Parts,
-    IReadOnlyList<bool> AllFlags
+    IReadOnlyList<bool> AllFlags,
+    IReadOnlyList<SqlOrderByItem> OrderBy,
+    SqlRowLimit? RowLimit
 ) : SqlQueryBase;
 
 internal sealed record SqlInsertQuery : SqlQueryBase


### PR DESCRIPTION
### Motivation
- Tornar a composição de `UNION` determinística e compatível com cenários de API/relatório ao não depender do último `SELECT` para `ORDER BY`/`LIMIT` e ao permitir `UNION` em subselects e CTEs de forma consistente.
- Evitar parsing ad‑hoc por detecção de string (`sql.Contains("UNION")`) e mover a responsabilidade para a AST/executor, mantendo a evolução centrada na AST.

### Description
- Estendi o nó de AST `SqlUnionQuery` e a helper `UnionChain` para transportar `OrderBy` (`IReadOnlyList<SqlOrderByItem>`) e `RowLimit` (`SqlRowLimit?`).
- Refatorei `SqlQueryParser` para parsear partes de `UNION` sem consumir `ORDER BY`/`LIMIT` localmente, e em seguida parsear/applicar o `ORDER BY`/`LIMIT` final no nível do `UNION` (nova assinatura `ParseSelectQuery(bool allowCtes = true, bool allowOrderByAndLimit = true)`).
- Atualizei o contrato do executor para `ExecuteUnion(..., IReadOnlyList<SqlOrderByItem>? orderBy = null, SqlRowLimit? rowLimit = null, string? sqlContextForErrors = null)` e implementei a aplicação do `ORDER BY`/`LIMIT` final no `AstQueryExecutorBase` após o merge das partes.
- Propaguei os metadados de ordenação/limite para `DerivedUnion` (derived tables), e removi os fast-paths ad‑hoc por string nas `CommandMock` de provedores, roteando `SqlUnionQuery` pelo switch AST comum em todos os providers.

### Testing
- Executei `git diff --check` para validar alterações de patch e conflitos, que passou com sucesso.
- Tentei rodar o conjunto de testes com `dotnet test --filter SqlCompatibilityGapTests` porém o ambiente não tem `dotnet` instalado, portanto os testes automatizados não puderam ser executados aqui.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d54be6c0c832c9748612f254cecbc)