### PR TITLE
feat(vsix): adicionar filtro de objetos na árvore da extensão do Visual Studio

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ObjectFilterServiceTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ObjectFilterServiceTests.cs
@@ -45,4 +45,24 @@ public class ObjectFilterServiceTests
 
         Assert.Equal(2, result.Count);
     }
+
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
+    [Fact]
+    public void Filter_EmptyValue_ReturnsAllObjects()
+    {
+        var service = new ObjectFilterService();
+        var source = new[]
+        {
+            new DatabaseObjectReference("dbo", "Order", DatabaseObjectType.Table),
+            new DatabaseObjectReference("dbo", "OrderItem", DatabaseObjectType.Table),
+            new DatabaseObjectReference("dbo", "User", DatabaseObjectType.Table)
+        };
+
+        var result = service.Filter(source, "   ", FilterMode.Like);
+
+        Assert.Equal(source.Length, result.Count);
+    }
 }

--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowControl.xaml
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowControl.xaml
@@ -20,6 +20,8 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="8" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="8" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -33,8 +35,23 @@
             <Button Content="Cancelar operação" Padding="10,4" Margin="0,0,8,8" Click="OnCancelOperationClick" />
         </WrapPanel>
 
+        <StackPanel Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Center">
+            <TextBlock Margin="0,0,8,0" VerticalAlignment="Center" Text="Filtro:" />
+            <TextBox Width="220"
+                     Margin="0,0,8,0"
+                     VerticalAlignment="Center"
+                     Text="{Binding ObjectFilterText, UpdateSourceTrigger=PropertyChanged}" />
+            <ComboBox Width="120"
+                      VerticalAlignment="Center"
+                      SelectedValuePath="Tag"
+                      SelectedValue="{Binding ObjectFilterMode}">
+                <ComboBoxItem Content="Contém" Tag="Like" />
+                <ComboBoxItem Content="Exato" Tag="Equals" />
+            </ComboBox>
+        </StackPanel>
+
         <TreeView x:Name="ExplorerTree"
-                  Grid.Row="2"
+                  Grid.Row="4"
                   ItemsSource="{Binding Nodes}">
             <TreeView.ContextMenu>
                 <ContextMenu>
@@ -44,7 +61,7 @@
             </TreeView.ContextMenu>
         </TreeView>
 
-        <Border Grid.Row="3" Margin="0,8,0,0" Padding="6" Background="#11000000" CornerRadius="4">
+        <Border Grid.Row="5" Margin="0,8,0,0" Padding="6" Background="#11000000" CornerRadius="4">
             <TextBlock Text="{Binding StatusMessage}" TextWrapping="Wrap" />
         </Border>
     </Grid>

--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowViewModel.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowViewModel.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using DbSqlLikeMem.VisualStudioExtension.Core.Generation;
 using DbSqlLikeMem.VisualStudioExtension.Core.Models;
 using DbSqlLikeMem.VisualStudioExtension.Core.Persistence;
+using DbSqlLikeMem.VisualStudioExtension.Core.Services;
 using DbSqlLikeMem.VisualStudioExtension.Core.Validation;
 using DbSqlLikeMem.VisualStudioExtension.Services;
 
@@ -27,6 +28,10 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
     private readonly ObservableCollection<ConnectionMappingConfiguration> mappings = new();
     private readonly Dictionary<string, IReadOnlyCollection<DatabaseObjectReference>> objectsByConnection = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, ObjectHealthResult> healthByObject = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ObjectFilterService objectFilterService = new();
+
+    private string objectFilterText = string.Empty;
+    private FilterMode objectFilterMode = FilterMode.Like;
 
     public DbSqlLikeMemToolWindowViewModel()
     {
@@ -40,6 +45,38 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
     public string StatusMessage { get; private set; } = "Pronto.";
 
     public bool IsBusy { get; private set; }
+
+    public string ObjectFilterText
+    {
+        get => objectFilterText;
+        set
+        {
+            if (string.Equals(objectFilterText, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            objectFilterText = value;
+            OnPropertyChanged(nameof(ObjectFilterText));
+            RefreshTree();
+        }
+    }
+
+    public FilterMode ObjectFilterMode
+    {
+        get => objectFilterMode;
+        set
+        {
+            if (objectFilterMode == value)
+            {
+                return;
+            }
+
+            objectFilterMode = value;
+            OnPropertyChanged(nameof(ObjectFilterMode));
+            RefreshTree();
+        }
+    }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -414,11 +451,13 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
                     };
 
                     var typedObjects = objects
-                        .Where(o => o.Type == objectType)
+                        .Where(o => o.Type == objectType);
+
+                    var filteredObjects = objectFilterService.Filter(typedObjects, ObjectFilterText, ObjectFilterMode)
                         .OrderBy(o => o.Schema, StringComparer.OrdinalIgnoreCase)
                         .ThenBy(o => o.Name, StringComparer.OrdinalIgnoreCase);
 
-                    foreach (var dbObject in typedObjects)
+                    foreach (var dbObject in filteredObjects)
                     {
                         var key = BuildObjectKey(connection.Id, dbObject);
                         var status = healthByObject.TryGetValue(key, out var health) ? health.Status : null;


### PR DESCRIPTION
### Motivation
- Melhorar a usabilidade da tool window permitindo filtrar os objetos listados na árvore sem recarregar metadados.
- Oferecer modos de busca `Contém` e `Exato` para facilitar localização rápida de tabelas, views e procedures.

### Description
- Adiciona controles de UI: campo de texto `ObjectFilterText` e seletor `ObjectFilterMode` na `DbSqlLikeMemToolWindowControl.xaml` posicionados acima da árvore de objetos. 
- Estende `DbSqlLikeMemToolWindowViewModel` com propriedades `ObjectFilterText` e `ObjectFilterMode`, a instância `ObjectFilterService` e aplicação do filtro em `RefreshTree` para filtrar objetos por tipo antes da ordenação e montagem dos nós.
- Ajusta a árvore para reexecutar `RefreshTree()` automaticamente quando `ObjectFilterText` ou `ObjectFilterMode` mudam, acionando `INotifyPropertyChanged`.
- Adiciona um teste unitário `Filter_EmptyValue_ReturnsAllObjects` em `ObjectFilterServiceTests` cobrindo o comportamento com valor vazio/branco.

### Testing
- Testes unitários adicionados: atualização de `ObjectFilterServiceTests` com `Filter_EmptyValue_ReturnsAllObjects` que valida retorno de todos os objetos para valor de filtro vazio; teste de unidade local compilável no projeto.
- Tentativa de executar `dotnet test src/DbSqlLikeMem.slnx --filter ObjectFilterServiceTests` falhou por limitação do ambiente (`dotnet` não disponível no container), logo testes automáticos não puderam ser executados aqui.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5577c850832cb2ff2e747e2223ff)