### PR TITLE
Multi-target DbSqlLikeMem.VisualStudioExtension.Core for netstandard2.0 and net8.0

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 		<Description>Core domain and services for the DbSqlLikeMem Visual Studio extension prototype.</Description>
 	</PropertyGroup>


### PR DESCRIPTION
### Motivation
- Fix compatibility errors where projects targeting older runtimes (e.g. .NET Framework or .NET Standard consumers) could not reference the core project that previously only targeted `net8.0`.

### Description
- Update `src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj` to use `TargetFrameworks` set to `netstandard2.0;net8.0` instead of only `net8.0` so older consumers can reference the core library.

### Testing
- Attempted to run `dotnet build src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj` but the `dotnet` CLI is not available in this environment (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6d0eafc4832c925b2fee79d7a874)