### PR TITLE
Fix Visual Studio extension build regressions across target frameworks

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Compatibility/CompilerServicesPolyfills.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Compatibility/CompilerServicesPolyfills.cs
@@ -1,0 +1,7 @@
+#if NETSTANDARD2_0
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit
+{
+}
+#endif

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj
@@ -17,4 +17,7 @@
 		<PackageReference Include="Roslynator.CSharp" Version="4.15.0" />
 		<PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
 	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+	</ItemGroup>
 </Project>

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/GenerationRuleSet.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/GenerationRuleSet.cs
@@ -8,8 +8,13 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Generation;
 /// Represents this public API type.
 /// Representa este tipo público da API.
 /// </summary>
-public static partial class GenerationRuleSet
+public static class GenerationRuleSet
 {
+    private static readonly Regex IsNullExpression = new(
+        @"if\s*\(\s*\(\s*`(?<col>\w+)`\s+is\s+null\s*\)\s*,\s*(?<val>[^,]+)\s*,\s*null\s*\)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled,
+        TimeSpan.FromMilliseconds(500));
+
     /// <summary>
     /// Executes this API operation.
     /// Executa esta operação da API.
@@ -106,7 +111,7 @@ public static partial class GenerationRuleSet
     /// </summary>
     public static bool TryConvertIfIsNull(string sqlExpr, out string code)
     {
-        var match = IsNullExpressionRegex().Match(sqlExpr);
+        var match = IsNullExpression.Match(sqlExpr);
         if (!match.Success)
         {
             code = string.Empty;
@@ -158,7 +163,4 @@ public static partial class GenerationRuleSet
 
         return string.Concat(char.ToUpper(cleaned[0], CultureInfo.InvariantCulture), cleaned[1..]);
     }
-
-    [GeneratedRegex(@"if\s*\(\s*\(\s*`(?<col>\w+)`\s+is\s+null\s*\)\s*,\s*(?<val>[^,]+)\s*,\s*null\s*\)", RegexOptions.IgnoreCase)]
-    private static partial Regex IsNullExpressionRegex();
 }

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Services/TreeNode.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Services/TreeNode.cs
@@ -8,11 +8,16 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Services;
 /// </summary>
 public sealed class TreeNode
 {
+    public TreeNode(string label)
+    {
+        Label = label;
+    }
+
     /// <summary>
     /// Gets this API value.
     /// Obtém este valor da API.
     /// </summary>
-    public required string Label { get; init; }
+    public string Label { get; }
 
     /// <summary>
     /// Gets this API value.

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Services/TreeViewBuilder.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Services/TreeViewBuilder.cs
@@ -14,19 +14,18 @@ public sealed class TreeViewBuilder
     /// </summary>
     public TreeNode Build(ConnectionDefinition connection, IReadOnlyCollection<DatabaseObjectReference> objects)
     {
-        var root = new TreeNode { Label = connection.DatabaseType, ContextKey = "database-type" };
-        var dbNode = new TreeNode { Label = connection.DatabaseName, ContextKey = "database-name" };
+        var root = new TreeNode(connection.DatabaseType) { ContextKey = "database-type" };
+        var dbNode = new TreeNode(connection.DatabaseName) { ContextKey = "database-name" };
         root.Children.Add(dbNode);
 
         foreach (var objectType in Enum.GetValues<DatabaseObjectType>())
         {
-            var typeNode = new TreeNode { Label = GetGroupLabel(objectType), ContextKey = "object-type", ObjectType = objectType };
+            var typeNode = new TreeNode(GetGroupLabel(objectType)) { ContextKey = "object-type", ObjectType = objectType };
 
             foreach (var item in objects.Where(o => o.Type == objectType).OrderBy(o => o.Name, StringComparer.OrdinalIgnoreCase))
             {
-                typeNode.Children.Add(new TreeNode
+                typeNode.Children.Add(new TreeNode(item.Name)
                 {
-                    Label = item.Name,
                     ContextKey = "object",
                     ObjectType = objectType
                 });

--- a/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
+++ b/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net472-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
### Motivation
- Resolve multiple compilation errors observed when building the Visual Studio extension and its core library across older target frameworks, including missing `System.Text.Json` on `netstandard2.0`, unsupported `GeneratedRegex` usage, missing `IsExternalInit` for `init` accessors, `required` member issues, and the NETSDK1136 Windows TFM requirement for WPF projects.

### Description
- Add a conditional `System.Text.Json` package reference for `netstandard2.0` in `DbSqlLikeMem.VisualStudioExtension.Core` so `JsonSerializerOptions` and related APIs are available on that TFM.
- Replace `[GeneratedRegex]` / partial `Regex` pattern with a private static compiled `Regex` (with timeout) and remove the partial/GeneratedRegex usage in `GenerationRuleSet` to maintain compatibility with older compilers/runtimes.
- Add a small `IsExternalInit` polyfill under `#if NETSTANDARD2_0` so `init` accessors compile on `netstandard2.0`.
- Remove the `required` accessor usage from `TreeNode`, introduce a constructor that requires `Label`, and update `TreeViewBuilder` call sites to use the new constructor.
- Update the VS extension project TFM to `net472-windows` to satisfy the Windows desktop SDK requirement when `UseWPF=true`.

### Testing
- Attempted to run `dotnet build` for the core project, but the execution environment does not have the .NET SDK installed so the build could not be validated here (`dotnet` not found) and no automated build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6e3be9ec832c91776083459391a0)