### PR TITLE
Add ConsoleGenerator projects for Npgsql, SQL Server, Oracle, SQLite and DB2

### DIFF
--- a/src/DbSqlLikeMem.Db2ConsoleGenerator/DbSqlLikeMem.Db2ConsoleGenerator.csproj
+++ b/src/DbSqlLikeMem.Db2ConsoleGenerator/DbSqlLikeMem.Db2ConsoleGenerator.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DbSqlLikeMem.VisualStudioExtension.Core\DbSqlLikeMem.VisualStudioExtension.Core.csproj" />
+    <ProjectReference Include="..\DbSqlLikeMem.Db2\DbSqlLikeMem.Db2.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DbSqlLikeMem.Db2ConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.Db2ConsoleGenerator/Program.cs
@@ -1,0 +1,373 @@
+using System.Data;
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+using Dapper;
+using DbSqlLikeMem.VisualStudioExtension.Core.Generation;
+using Microsoft.Extensions.Configuration;
+
+namespace TableStructureGenerator;
+
+static partial class Program
+{
+#pragma warning disable CA1303
+
+#pragma warning disable  CA1812
+    private sealed record DestinyInfo(
+        string OutputPath,
+        string Schema,
+        string Namespace,
+        List<string>? Tables = null);
+
+    private sealed record ConnectionInfo(
+        string Name,
+        string ProviderName,
+        string Connection,
+        bool? Enable,
+        List<DestinyInfo> Destinies);
+
+#pragma warning restore CA1812
+
+    private const string DatabaseType = "db2";
+    private const string DefaultProvider = "IBM.Data.Db2";
+
+    static void Main(string[] args)
+    {
+        var baseDirectory = Directory.GetCurrentDirectory()
+            .Split("\\Tools")
+            [0];
+        Console.WriteLine($"BaseDirectory: {baseDirectory}");
+
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var connections = configuration
+            .GetSection("ConnectionsString")
+            .Get<List<ConnectionInfo>>()
+            ?.Where(_ => !_.Enable.HasValue || _.Enable.Value)
+            .ToList();
+
+        if (connections == null || connections.Count == 0)
+        {
+            Console.WriteLine("No connection strings found in appsettings.json.");
+            return;
+        }
+
+        bool runAll = args.Any(a => string.Equals(a, "--all", StringComparison.OrdinalIgnoreCase));
+
+        int selectedConnectionIndex = 1;
+        if (!runAll)
+        {
+            Console.WriteLine("Select a connection:");
+            Console.WriteLine("0. Todas");
+            for (int i = 0; i < connections.Count; i++)
+                Console.WriteLine($"{i + 1}. {connections[i].Name}");
+
+            Console.Write("Enter the number of the connection to use: ");
+            if (!int.TryParse(Console.ReadLine(), out selectedConnectionIndex)
+                || selectedConnectionIndex < 0 || selectedConnectionIndex > connections.Count)
+            {
+                Console.WriteLine("Invalid connection selection.");
+                return;
+            }
+
+            if (selectedConnectionIndex == 0)
+                runAll = true;
+        }
+
+        foreach (var connInfo in runAll
+            ? connections
+            : [connections[selectedConnectionIndex - 1]])
+        {
+            using var connection = CreateConnection(connInfo);
+            connection.Open();
+
+            foreach (var destiny in connInfo.Destinies)
+            {
+                var tables = (destiny.Tables != null && destiny.Tables.Count != 0)
+                    ? destiny.Tables
+                    : GetTablesInSchema(connection, destiny.Schema);
+
+                Console.WriteLine($"Schema: {destiny.Schema}");
+
+                var outputPath = Path.Combine(baseDirectory, destiny.OutputPath);
+                if (tables.Count > 0 && !Directory.Exists(outputPath))
+                    Directory.CreateDirectory(outputPath);
+
+                foreach (var tableName in tables.Distinct(StringComparer.OrdinalIgnoreCase))
+                {
+                    var clean = tableName.Trim();
+                    if (string.IsNullOrEmpty(clean)) continue;
+
+                    var meta = LoadTableMetadata(connection, destiny.Schema, clean);
+
+                    GenerateTableFile(
+                        destiny.Namespace,
+                        tableName: clean,
+                        columns: meta.Columns,
+                        primaryKey: meta.PrimaryKey,
+                        indexes: meta.Indexes,
+                        foreignKeys: meta.ForeignKeys,
+                        outputPath: outputPath);
+
+                    Console.WriteLine($" - Tabela: {tableName} gerada.");
+                }
+            }
+        }
+
+        Console.WriteLine("Table structure files have been generated.");
+    }
+
+    private static IDbConnection CreateConnection(ConnectionInfo connInfo)
+    {
+        var providerName = string.IsNullOrWhiteSpace(connInfo.ProviderName) ? DefaultProvider : connInfo.ProviderName;
+        var factory = DbProviderFactories.GetFactory(providerName);
+        var connection = factory.CreateConnection() ?? throw new InvalidOperationException($"Failed to create provider connection for '{providerName}'.");
+        connection.ConnectionString = connInfo.Connection;
+        return connection;
+    }
+
+    private static List<string> GetTablesInSchema(IDbConnection cn, string schema)
+    {
+        var qObjects = SqlMetadataQueryFactory.BuildListObjectsQuery(DatabaseType);
+        var rows = cn.Query(qObjects, new { databaseName = schema })
+            .Select(ToDictionary)
+            .Where(r => ReadString(r, "ObjectType").Equals("Table", StringComparison.OrdinalIgnoreCase))
+            .Where(r => string.IsNullOrWhiteSpace(schema) || ReadString(r, "SchemaName").Equals(schema, StringComparison.OrdinalIgnoreCase))
+            .Select(r => ReadString(r, "ObjectName"))
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static name => name)
+            .ToList();
+
+        return rows;
+    }
+
+    private sealed record ColumnMeta(
+        string ColumnName,
+        string DataType,
+        string ColumnType,
+        bool IsNullable,
+        bool IsIdentity,
+        string? DefaultValue,
+        int Ordinal,
+        long? CharMaxLen,
+        int? NumPrecision,
+        int? NumScale,
+        string? Generated);
+
+    private sealed record TableMeta(
+        List<ColumnMeta> Columns,
+        List<string> PrimaryKey,
+        Dictionary<string, (bool Unique, List<string> Cols)> Indexes,
+        List<(string Col, string RefTable, string RefCol)> ForeignKeys);
+
+    private static TableMeta LoadTableMetadata(IDbConnection cn, string schema, string table)
+    {
+        var args = new { schemaName = schema, objectName = table };
+
+        var cols = cn.Query(SqlMetadataQueryFactory.BuildObjectColumnsQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => new ColumnMeta(
+                ColumnName: ReadString(row, "ColumnName"),
+                DataType: ReadString(row, "DataType"),
+                ColumnType: ReadString(row, "ColumnType"),
+                IsNullable: ReadBoolFlexible(row, "IsNullable"),
+                IsIdentity: ReadBoolFlexible(row, "IsIdentity") || ReadString(row, "Extra").Contains("identity", StringComparison.OrdinalIgnoreCase) || ReadString(row, "Extra").Contains("auto_increment", StringComparison.OrdinalIgnoreCase),
+                DefaultValue: string.IsNullOrWhiteSpace(ReadString(row, "DefaultValue")) ? null : ReadString(row, "DefaultValue"),
+                Ordinal: ReadInt(row, "Ordinal") - 1,
+                CharMaxLen: ReadNullableLong(row, "CharMaxLen"),
+                NumPrecision: ReadNullableInt(row, "NumPrecision"),
+                NumScale: ReadNullableInt(row, "NumScale"),
+                Generated: string.IsNullOrWhiteSpace(ReadString(row, "Generated")) ? null : ReadString(row, "Generated")))
+            .Where(static c => !string.IsNullOrWhiteSpace(c.ColumnName))
+            .OrderBy(static c => c.Ordinal)
+            .ToList();
+
+        var pk = cn.Query(SqlMetadataQueryFactory.BuildPrimaryKeyQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => ReadString(row, "ColumnName"))
+            .Where(static c => !string.IsNullOrWhiteSpace(c))
+            .ToList();
+
+        var idx = new Dictionary<string, (bool Unique, List<string> Cols)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in cn.Query(SqlMetadataQueryFactory.BuildIndexesQuery(DatabaseType), args).Select(ToDictionary))
+        {
+            var name = ReadString(row, "IndexName");
+            var col = ReadString(row, "ColumnName");
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(col))
+                continue;
+            if (name.Equals("PRIMARY", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("PK", StringComparison.OrdinalIgnoreCase)
+                || name.StartsWith("PK_", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var unique = ReadBoolFlexible(row, "IsUnique")
+                         || ReadString(row, "Uniqueness").Equals("UNIQUE", StringComparison.OrdinalIgnoreCase)
+                         || ReadString(row, "UniqueRule").Equals("U", StringComparison.OrdinalIgnoreCase)
+                         || ReadInt(row, "NonUnique") == 0;
+
+            if (!idx.TryGetValue(name, out var tuple))
+                tuple = (Unique: unique, Cols: []);
+
+            tuple = (Unique: tuple.Unique || unique, tuple.Cols);
+            tuple.Cols.Add(col);
+            idx[name] = tuple;
+        }
+
+        var fks = cn.Query(SqlMetadataQueryFactory.BuildForeignKeysQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => (
+                Col: ReadString(row, "ColumnName"),
+                RefTable: ReadString(row, "RefTable"),
+                RefCol: ReadString(row, "RefColumn")))
+            .Where(f => !string.IsNullOrWhiteSpace(f.Col) && !string.IsNullOrWhiteSpace(f.RefTable) && !string.IsNullOrWhiteSpace(f.RefCol))
+            .ToList();
+
+        return new TableMeta(cols, pk, idx, fks);
+    }
+
+    private static void GenerateTableFile(
+        string ns,
+        string tableName,
+        List<ColumnMeta> columns,
+        List<string> primaryKey,
+        Dictionary<string, (bool Unique, List<string> Cols)> indexes,
+        List<(string Col, string RefTable, string RefCol)> foreignKeys,
+        string outputPath)
+    {
+        var className = $"{GenerationRuleSet.ToPascalCase(tableName)}TableFactory";
+        var methodName = $"CreateTable{GenerationRuleSet.ToPascalCase(tableName)}";
+        var fileName = Path.Combine(outputPath, $"{className}.cs");
+
+        using var w = new StreamWriter(fileName, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        w.WriteLine($"namespace {ns};");
+        w.WriteLine();
+        w.WriteLine($"public static class {className}");
+        w.WriteLine("{");
+        w.WriteLine($"    public static ITableMock {methodName}(        this DbMock db)");
+        w.WriteLine("    {");
+        w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
+
+        foreach (var c in columns.OrderBy(c => c.Ordinal))
+        {
+            var dbType = GenerationRuleSet.MapDbType(c.DataType, c.CharMaxLen, c.NumPrecision, c.ColumnName, DatabaseType);
+            var nullable = c.IsNullable ? "true" : "false";
+            var ctor = $"new({c.Ordinal}, DbType.{dbType}, {nullable}";
+
+            if (c.IsIdentity) ctor += ", true";
+            ctor += ")";
+
+            w.WriteLine($"        table.Columns[\"{c.ColumnName}\"] = {ctor};");
+
+            if (!string.IsNullOrEmpty(c.DefaultValue)
+                && GenerationRuleSet.IsSimpleLiteralDefault(c.DefaultValue!))
+            {
+                var literal = GenerationRuleSet.FormatDefaultLiteral(c.DefaultValue!, dbType);
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DefaultValue = {literal};");
+            }
+
+            if (c.CharMaxLen is > 0 and <= int.MaxValue)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].Size = {(int)c.CharMaxLen};");
+
+            if (c.NumScale is >= 0)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DecimalPlaces = {c.NumScale.Value};");
+
+            var enums = GenerationRuleSet.TryParseEnumValues(c.ColumnType);
+            if (enums.Length > 0)
+            {
+                var arr = string.Join(", ", enums.Select(GenerationRuleSet.Literal));
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].EnumValues = new[] {{ {arr} }};");
+            }
+            if (!string.IsNullOrWhiteSpace(c.Generated))
+            {
+                if (!GenerationRuleSet.TryConvertIfIsNull(c.Generated, out var genCode))
+                    throw new NotSupportedException($"Expressão não suportada: {c.Generated}");
+
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].GetGenValue = {genCode};");
+            }
+        }
+
+        if (primaryKey.Count > 0)
+        {
+            foreach (var pkCol in primaryKey)
+                w.WriteLine($"        table.PrimaryKeyIndexes.Add(table.Columns[\"{pkCol}\"]?.Index);");
+            var cols = string.Join(", ", primaryKey.Select(GenerationRuleSet.Literal));
+            w.WriteLine($"        table.CreateIndex(new IndexDef(\"PRIMARY\", [{cols}], unique: true));");
+        }
+
+        foreach (var (name, (Unique, Cols)) in indexes.OrderBy(p => p.Key))
+        {
+            var cols = string.Join(", ", Cols.Select(GenerationRuleSet.Literal));
+            var uniq = Unique ? "true" : "false";
+            w.WriteLine($"        table.CreateIndex(new IndexDef({GenerationRuleSet.Literal(name)}, [{cols}], unique: {uniq}));");
+        }
+
+        foreach (var (col, rtab, rcol) in foreignKeys)
+        {
+            w.WriteLine($"        table.ForeignKeys.Add(({GenerationRuleSet.Literal(col)}, {GenerationRuleSet.Literal(rtab)}, {GenerationRuleSet.Literal(rcol)}));");
+        }
+
+        w.WriteLine("        return table;");
+        w.WriteLine("    }");
+        w.WriteLine("}");
+    }
+
+    private static IDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IDictionary<string, object?> dict)
+            return dict;
+
+        return row
+            .GetType()
+            .GetProperties()
+            .ToDictionary(p => p.Name, p => p.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool ReadBoolFlexible(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return false;
+        return s.Equals("1", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("y", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static long? ReadNullableLong(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : null;
+    }
+
+    private static int? ReadNullableInt(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : null;
+    }
+
+    private static int ReadInt(IDictionary<string, object?> row, string key)
+        => ReadNullableInt(row, key) ?? 0;
+
+    private static string ReadString(IDictionary<string, object?> row, string key)
+    {
+        foreach (var item in row)
+        {
+            if (string.Equals(item.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                if (item.Value is null || item.Value is DBNull)
+                    return string.Empty;
+                return Convert.ToString(item.Value, CultureInfo.InvariantCulture)?.Trim() ?? string.Empty;
+            }
+        }
+
+        return string.Empty;
+    }
+
+#pragma warning restore CA1303
+}

--- a/src/DbSqlLikeMem.Db2ConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.Db2ConsoleGenerator/appsettings.json
@@ -1,0 +1,17 @@
+{
+    "ConnectionsString": [
+        {
+            "Name": "CONNECTION",
+            "Enable": true,
+            "ProviderName": "IBM.Data.Db2",
+            "Connection": "Server=localhost:50000;Database=SAMPLE;UID=db2inst1;PWD=Password;",
+            "Destinies": [
+                {
+                    "OutputPath": "Project\\src\\Project.Domain.TestTools\\Db2",
+                    "Schema": "public",
+                    "Namespace": "Project.Domain.TestTools.Db2"
+                }
+            ]
+        }
+    ]
+}

--- a/src/DbSqlLikeMem.NpgsqlConsoleGenerator/DbSqlLikeMem.NpgsqlConsoleGenerator.csproj
+++ b/src/DbSqlLikeMem.NpgsqlConsoleGenerator/DbSqlLikeMem.NpgsqlConsoleGenerator.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DbSqlLikeMem.VisualStudioExtension.Core\DbSqlLikeMem.VisualStudioExtension.Core.csproj" />
+    <ProjectReference Include="..\DbSqlLikeMem.Npgsql\DbSqlLikeMem.Npgsql.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DbSqlLikeMem.NpgsqlConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.NpgsqlConsoleGenerator/Program.cs
@@ -1,0 +1,373 @@
+using System.Data;
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+using Dapper;
+using DbSqlLikeMem.VisualStudioExtension.Core.Generation;
+using Microsoft.Extensions.Configuration;
+
+namespace TableStructureGenerator;
+
+static partial class Program
+{
+#pragma warning disable CA1303
+
+#pragma warning disable  CA1812
+    private sealed record DestinyInfo(
+        string OutputPath,
+        string Schema,
+        string Namespace,
+        List<string>? Tables = null);
+
+    private sealed record ConnectionInfo(
+        string Name,
+        string ProviderName,
+        string Connection,
+        bool? Enable,
+        List<DestinyInfo> Destinies);
+
+#pragma warning restore CA1812
+
+    private const string DatabaseType = "postgresql";
+    private const string DefaultProvider = "Npgsql";
+
+    static void Main(string[] args)
+    {
+        var baseDirectory = Directory.GetCurrentDirectory()
+            .Split("\\Tools")
+            [0];
+        Console.WriteLine($"BaseDirectory: {baseDirectory}");
+
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var connections = configuration
+            .GetSection("ConnectionsString")
+            .Get<List<ConnectionInfo>>()
+            ?.Where(_ => !_.Enable.HasValue || _.Enable.Value)
+            .ToList();
+
+        if (connections == null || connections.Count == 0)
+        {
+            Console.WriteLine("No connection strings found in appsettings.json.");
+            return;
+        }
+
+        bool runAll = args.Any(a => string.Equals(a, "--all", StringComparison.OrdinalIgnoreCase));
+
+        int selectedConnectionIndex = 1;
+        if (!runAll)
+        {
+            Console.WriteLine("Select a connection:");
+            Console.WriteLine("0. Todas");
+            for (int i = 0; i < connections.Count; i++)
+                Console.WriteLine($"{i + 1}. {connections[i].Name}");
+
+            Console.Write("Enter the number of the connection to use: ");
+            if (!int.TryParse(Console.ReadLine(), out selectedConnectionIndex)
+                || selectedConnectionIndex < 0 || selectedConnectionIndex > connections.Count)
+            {
+                Console.WriteLine("Invalid connection selection.");
+                return;
+            }
+
+            if (selectedConnectionIndex == 0)
+                runAll = true;
+        }
+
+        foreach (var connInfo in runAll
+            ? connections
+            : [connections[selectedConnectionIndex - 1]])
+        {
+            using var connection = CreateConnection(connInfo);
+            connection.Open();
+
+            foreach (var destiny in connInfo.Destinies)
+            {
+                var tables = (destiny.Tables != null && destiny.Tables.Count != 0)
+                    ? destiny.Tables
+                    : GetTablesInSchema(connection, destiny.Schema);
+
+                Console.WriteLine($"Schema: {destiny.Schema}");
+
+                var outputPath = Path.Combine(baseDirectory, destiny.OutputPath);
+                if (tables.Count > 0 && !Directory.Exists(outputPath))
+                    Directory.CreateDirectory(outputPath);
+
+                foreach (var tableName in tables.Distinct(StringComparer.OrdinalIgnoreCase))
+                {
+                    var clean = tableName.Trim();
+                    if (string.IsNullOrEmpty(clean)) continue;
+
+                    var meta = LoadTableMetadata(connection, destiny.Schema, clean);
+
+                    GenerateTableFile(
+                        destiny.Namespace,
+                        tableName: clean,
+                        columns: meta.Columns,
+                        primaryKey: meta.PrimaryKey,
+                        indexes: meta.Indexes,
+                        foreignKeys: meta.ForeignKeys,
+                        outputPath: outputPath);
+
+                    Console.WriteLine($" - Tabela: {tableName} gerada.");
+                }
+            }
+        }
+
+        Console.WriteLine("Table structure files have been generated.");
+    }
+
+    private static IDbConnection CreateConnection(ConnectionInfo connInfo)
+    {
+        var providerName = string.IsNullOrWhiteSpace(connInfo.ProviderName) ? DefaultProvider : connInfo.ProviderName;
+        var factory = DbProviderFactories.GetFactory(providerName);
+        var connection = factory.CreateConnection() ?? throw new InvalidOperationException($"Failed to create provider connection for '{providerName}'.");
+        connection.ConnectionString = connInfo.Connection;
+        return connection;
+    }
+
+    private static List<string> GetTablesInSchema(IDbConnection cn, string schema)
+    {
+        var qObjects = SqlMetadataQueryFactory.BuildListObjectsQuery(DatabaseType);
+        var rows = cn.Query(qObjects, new { databaseName = schema })
+            .Select(ToDictionary)
+            .Where(r => ReadString(r, "ObjectType").Equals("Table", StringComparison.OrdinalIgnoreCase))
+            .Where(r => string.IsNullOrWhiteSpace(schema) || ReadString(r, "SchemaName").Equals(schema, StringComparison.OrdinalIgnoreCase))
+            .Select(r => ReadString(r, "ObjectName"))
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static name => name)
+            .ToList();
+
+        return rows;
+    }
+
+    private sealed record ColumnMeta(
+        string ColumnName,
+        string DataType,
+        string ColumnType,
+        bool IsNullable,
+        bool IsIdentity,
+        string? DefaultValue,
+        int Ordinal,
+        long? CharMaxLen,
+        int? NumPrecision,
+        int? NumScale,
+        string? Generated);
+
+    private sealed record TableMeta(
+        List<ColumnMeta> Columns,
+        List<string> PrimaryKey,
+        Dictionary<string, (bool Unique, List<string> Cols)> Indexes,
+        List<(string Col, string RefTable, string RefCol)> ForeignKeys);
+
+    private static TableMeta LoadTableMetadata(IDbConnection cn, string schema, string table)
+    {
+        var args = new { schemaName = schema, objectName = table };
+
+        var cols = cn.Query(SqlMetadataQueryFactory.BuildObjectColumnsQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => new ColumnMeta(
+                ColumnName: ReadString(row, "ColumnName"),
+                DataType: ReadString(row, "DataType"),
+                ColumnType: ReadString(row, "ColumnType"),
+                IsNullable: ReadBoolFlexible(row, "IsNullable"),
+                IsIdentity: ReadBoolFlexible(row, "IsIdentity") || ReadString(row, "Extra").Contains("identity", StringComparison.OrdinalIgnoreCase) || ReadString(row, "Extra").Contains("auto_increment", StringComparison.OrdinalIgnoreCase),
+                DefaultValue: string.IsNullOrWhiteSpace(ReadString(row, "DefaultValue")) ? null : ReadString(row, "DefaultValue"),
+                Ordinal: ReadInt(row, "Ordinal") - 1,
+                CharMaxLen: ReadNullableLong(row, "CharMaxLen"),
+                NumPrecision: ReadNullableInt(row, "NumPrecision"),
+                NumScale: ReadNullableInt(row, "NumScale"),
+                Generated: string.IsNullOrWhiteSpace(ReadString(row, "Generated")) ? null : ReadString(row, "Generated")))
+            .Where(static c => !string.IsNullOrWhiteSpace(c.ColumnName))
+            .OrderBy(static c => c.Ordinal)
+            .ToList();
+
+        var pk = cn.Query(SqlMetadataQueryFactory.BuildPrimaryKeyQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => ReadString(row, "ColumnName"))
+            .Where(static c => !string.IsNullOrWhiteSpace(c))
+            .ToList();
+
+        var idx = new Dictionary<string, (bool Unique, List<string> Cols)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in cn.Query(SqlMetadataQueryFactory.BuildIndexesQuery(DatabaseType), args).Select(ToDictionary))
+        {
+            var name = ReadString(row, "IndexName");
+            var col = ReadString(row, "ColumnName");
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(col))
+                continue;
+            if (name.Equals("PRIMARY", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("PK", StringComparison.OrdinalIgnoreCase)
+                || name.StartsWith("PK_", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var unique = ReadBoolFlexible(row, "IsUnique")
+                         || ReadString(row, "Uniqueness").Equals("UNIQUE", StringComparison.OrdinalIgnoreCase)
+                         || ReadString(row, "UniqueRule").Equals("U", StringComparison.OrdinalIgnoreCase)
+                         || ReadInt(row, "NonUnique") == 0;
+
+            if (!idx.TryGetValue(name, out var tuple))
+                tuple = (Unique: unique, Cols: []);
+
+            tuple = (Unique: tuple.Unique || unique, tuple.Cols);
+            tuple.Cols.Add(col);
+            idx[name] = tuple;
+        }
+
+        var fks = cn.Query(SqlMetadataQueryFactory.BuildForeignKeysQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => (
+                Col: ReadString(row, "ColumnName"),
+                RefTable: ReadString(row, "RefTable"),
+                RefCol: ReadString(row, "RefColumn")))
+            .Where(f => !string.IsNullOrWhiteSpace(f.Col) && !string.IsNullOrWhiteSpace(f.RefTable) && !string.IsNullOrWhiteSpace(f.RefCol))
+            .ToList();
+
+        return new TableMeta(cols, pk, idx, fks);
+    }
+
+    private static void GenerateTableFile(
+        string ns,
+        string tableName,
+        List<ColumnMeta> columns,
+        List<string> primaryKey,
+        Dictionary<string, (bool Unique, List<string> Cols)> indexes,
+        List<(string Col, string RefTable, string RefCol)> foreignKeys,
+        string outputPath)
+    {
+        var className = $"{GenerationRuleSet.ToPascalCase(tableName)}TableFactory";
+        var methodName = $"CreateTable{GenerationRuleSet.ToPascalCase(tableName)}";
+        var fileName = Path.Combine(outputPath, $"{className}.cs");
+
+        using var w = new StreamWriter(fileName, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        w.WriteLine($"namespace {ns};");
+        w.WriteLine();
+        w.WriteLine($"public static class {className}");
+        w.WriteLine("{");
+        w.WriteLine($"    public static ITableMock {methodName}(        this DbMock db)");
+        w.WriteLine("    {");
+        w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
+
+        foreach (var c in columns.OrderBy(c => c.Ordinal))
+        {
+            var dbType = GenerationRuleSet.MapDbType(c.DataType, c.CharMaxLen, c.NumPrecision, c.ColumnName, DatabaseType);
+            var nullable = c.IsNullable ? "true" : "false";
+            var ctor = $"new({c.Ordinal}, DbType.{dbType}, {nullable}";
+
+            if (c.IsIdentity) ctor += ", true";
+            ctor += ")";
+
+            w.WriteLine($"        table.Columns[\"{c.ColumnName}\"] = {ctor};");
+
+            if (!string.IsNullOrEmpty(c.DefaultValue)
+                && GenerationRuleSet.IsSimpleLiteralDefault(c.DefaultValue!))
+            {
+                var literal = GenerationRuleSet.FormatDefaultLiteral(c.DefaultValue!, dbType);
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DefaultValue = {literal};");
+            }
+
+            if (c.CharMaxLen is > 0 and <= int.MaxValue)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].Size = {(int)c.CharMaxLen};");
+
+            if (c.NumScale is >= 0)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DecimalPlaces = {c.NumScale.Value};");
+
+            var enums = GenerationRuleSet.TryParseEnumValues(c.ColumnType);
+            if (enums.Length > 0)
+            {
+                var arr = string.Join(", ", enums.Select(GenerationRuleSet.Literal));
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].EnumValues = new[] {{ {arr} }};");
+            }
+            if (!string.IsNullOrWhiteSpace(c.Generated))
+            {
+                if (!GenerationRuleSet.TryConvertIfIsNull(c.Generated, out var genCode))
+                    throw new NotSupportedException($"Expressão não suportada: {c.Generated}");
+
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].GetGenValue = {genCode};");
+            }
+        }
+
+        if (primaryKey.Count > 0)
+        {
+            foreach (var pkCol in primaryKey)
+                w.WriteLine($"        table.PrimaryKeyIndexes.Add(table.Columns[\"{pkCol}\"]?.Index);");
+            var cols = string.Join(", ", primaryKey.Select(GenerationRuleSet.Literal));
+            w.WriteLine($"        table.CreateIndex(new IndexDef(\"PRIMARY\", [{cols}], unique: true));");
+        }
+
+        foreach (var (name, (Unique, Cols)) in indexes.OrderBy(p => p.Key))
+        {
+            var cols = string.Join(", ", Cols.Select(GenerationRuleSet.Literal));
+            var uniq = Unique ? "true" : "false";
+            w.WriteLine($"        table.CreateIndex(new IndexDef({GenerationRuleSet.Literal(name)}, [{cols}], unique: {uniq}));");
+        }
+
+        foreach (var (col, rtab, rcol) in foreignKeys)
+        {
+            w.WriteLine($"        table.ForeignKeys.Add(({GenerationRuleSet.Literal(col)}, {GenerationRuleSet.Literal(rtab)}, {GenerationRuleSet.Literal(rcol)}));");
+        }
+
+        w.WriteLine("        return table;");
+        w.WriteLine("    }");
+        w.WriteLine("}");
+    }
+
+    private static IDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IDictionary<string, object?> dict)
+            return dict;
+
+        return row
+            .GetType()
+            .GetProperties()
+            .ToDictionary(p => p.Name, p => p.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool ReadBoolFlexible(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return false;
+        return s.Equals("1", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("y", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static long? ReadNullableLong(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : null;
+    }
+
+    private static int? ReadNullableInt(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : null;
+    }
+
+    private static int ReadInt(IDictionary<string, object?> row, string key)
+        => ReadNullableInt(row, key) ?? 0;
+
+    private static string ReadString(IDictionary<string, object?> row, string key)
+    {
+        foreach (var item in row)
+        {
+            if (string.Equals(item.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                if (item.Value is null || item.Value is DBNull)
+                    return string.Empty;
+                return Convert.ToString(item.Value, CultureInfo.InvariantCulture)?.Trim() ?? string.Empty;
+            }
+        }
+
+        return string.Empty;
+    }
+
+#pragma warning restore CA1303
+}

--- a/src/DbSqlLikeMem.NpgsqlConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.NpgsqlConsoleGenerator/appsettings.json
@@ -1,0 +1,17 @@
+{
+    "ConnectionsString": [
+        {
+            "Name": "CONNECTION",
+            "Enable": true,
+            "ProviderName": "Npgsql",
+            "Connection": "Host=localhost;Database=postgres;Username=postgres;Password=Password;",
+            "Destinies": [
+                {
+                    "OutputPath": "Project\\src\\Project.Domain.TestTools\\Npgsql",
+                    "Schema": "public",
+                    "Namespace": "Project.Domain.TestTools.Npgsql"
+                }
+            ]
+        }
+    ]
+}

--- a/src/DbSqlLikeMem.OracleConsoleGenerator/DbSqlLikeMem.OracleConsoleGenerator.csproj
+++ b/src/DbSqlLikeMem.OracleConsoleGenerator/DbSqlLikeMem.OracleConsoleGenerator.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DbSqlLikeMem.VisualStudioExtension.Core\DbSqlLikeMem.VisualStudioExtension.Core.csproj" />
+    <ProjectReference Include="..\DbSqlLikeMem.Oracle\DbSqlLikeMem.Oracle.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DbSqlLikeMem.OracleConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.OracleConsoleGenerator/Program.cs
@@ -1,0 +1,373 @@
+using System.Data;
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+using Dapper;
+using DbSqlLikeMem.VisualStudioExtension.Core.Generation;
+using Microsoft.Extensions.Configuration;
+
+namespace TableStructureGenerator;
+
+static partial class Program
+{
+#pragma warning disable CA1303
+
+#pragma warning disable  CA1812
+    private sealed record DestinyInfo(
+        string OutputPath,
+        string Schema,
+        string Namespace,
+        List<string>? Tables = null);
+
+    private sealed record ConnectionInfo(
+        string Name,
+        string ProviderName,
+        string Connection,
+        bool? Enable,
+        List<DestinyInfo> Destinies);
+
+#pragma warning restore CA1812
+
+    private const string DatabaseType = "oracle";
+    private const string DefaultProvider = "Oracle.ManagedDataAccess.Client";
+
+    static void Main(string[] args)
+    {
+        var baseDirectory = Directory.GetCurrentDirectory()
+            .Split("\\Tools")
+            [0];
+        Console.WriteLine($"BaseDirectory: {baseDirectory}");
+
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var connections = configuration
+            .GetSection("ConnectionsString")
+            .Get<List<ConnectionInfo>>()
+            ?.Where(_ => !_.Enable.HasValue || _.Enable.Value)
+            .ToList();
+
+        if (connections == null || connections.Count == 0)
+        {
+            Console.WriteLine("No connection strings found in appsettings.json.");
+            return;
+        }
+
+        bool runAll = args.Any(a => string.Equals(a, "--all", StringComparison.OrdinalIgnoreCase));
+
+        int selectedConnectionIndex = 1;
+        if (!runAll)
+        {
+            Console.WriteLine("Select a connection:");
+            Console.WriteLine("0. Todas");
+            for (int i = 0; i < connections.Count; i++)
+                Console.WriteLine($"{i + 1}. {connections[i].Name}");
+
+            Console.Write("Enter the number of the connection to use: ");
+            if (!int.TryParse(Console.ReadLine(), out selectedConnectionIndex)
+                || selectedConnectionIndex < 0 || selectedConnectionIndex > connections.Count)
+            {
+                Console.WriteLine("Invalid connection selection.");
+                return;
+            }
+
+            if (selectedConnectionIndex == 0)
+                runAll = true;
+        }
+
+        foreach (var connInfo in runAll
+            ? connections
+            : [connections[selectedConnectionIndex - 1]])
+        {
+            using var connection = CreateConnection(connInfo);
+            connection.Open();
+
+            foreach (var destiny in connInfo.Destinies)
+            {
+                var tables = (destiny.Tables != null && destiny.Tables.Count != 0)
+                    ? destiny.Tables
+                    : GetTablesInSchema(connection, destiny.Schema);
+
+                Console.WriteLine($"Schema: {destiny.Schema}");
+
+                var outputPath = Path.Combine(baseDirectory, destiny.OutputPath);
+                if (tables.Count > 0 && !Directory.Exists(outputPath))
+                    Directory.CreateDirectory(outputPath);
+
+                foreach (var tableName in tables.Distinct(StringComparer.OrdinalIgnoreCase))
+                {
+                    var clean = tableName.Trim();
+                    if (string.IsNullOrEmpty(clean)) continue;
+
+                    var meta = LoadTableMetadata(connection, destiny.Schema, clean);
+
+                    GenerateTableFile(
+                        destiny.Namespace,
+                        tableName: clean,
+                        columns: meta.Columns,
+                        primaryKey: meta.PrimaryKey,
+                        indexes: meta.Indexes,
+                        foreignKeys: meta.ForeignKeys,
+                        outputPath: outputPath);
+
+                    Console.WriteLine($" - Tabela: {tableName} gerada.");
+                }
+            }
+        }
+
+        Console.WriteLine("Table structure files have been generated.");
+    }
+
+    private static IDbConnection CreateConnection(ConnectionInfo connInfo)
+    {
+        var providerName = string.IsNullOrWhiteSpace(connInfo.ProviderName) ? DefaultProvider : connInfo.ProviderName;
+        var factory = DbProviderFactories.GetFactory(providerName);
+        var connection = factory.CreateConnection() ?? throw new InvalidOperationException($"Failed to create provider connection for '{providerName}'.");
+        connection.ConnectionString = connInfo.Connection;
+        return connection;
+    }
+
+    private static List<string> GetTablesInSchema(IDbConnection cn, string schema)
+    {
+        var qObjects = SqlMetadataQueryFactory.BuildListObjectsQuery(DatabaseType);
+        var rows = cn.Query(qObjects, new { databaseName = schema })
+            .Select(ToDictionary)
+            .Where(r => ReadString(r, "ObjectType").Equals("Table", StringComparison.OrdinalIgnoreCase))
+            .Where(r => string.IsNullOrWhiteSpace(schema) || ReadString(r, "SchemaName").Equals(schema, StringComparison.OrdinalIgnoreCase))
+            .Select(r => ReadString(r, "ObjectName"))
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static name => name)
+            .ToList();
+
+        return rows;
+    }
+
+    private sealed record ColumnMeta(
+        string ColumnName,
+        string DataType,
+        string ColumnType,
+        bool IsNullable,
+        bool IsIdentity,
+        string? DefaultValue,
+        int Ordinal,
+        long? CharMaxLen,
+        int? NumPrecision,
+        int? NumScale,
+        string? Generated);
+
+    private sealed record TableMeta(
+        List<ColumnMeta> Columns,
+        List<string> PrimaryKey,
+        Dictionary<string, (bool Unique, List<string> Cols)> Indexes,
+        List<(string Col, string RefTable, string RefCol)> ForeignKeys);
+
+    private static TableMeta LoadTableMetadata(IDbConnection cn, string schema, string table)
+    {
+        var args = new { schemaName = schema, objectName = table };
+
+        var cols = cn.Query(SqlMetadataQueryFactory.BuildObjectColumnsQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => new ColumnMeta(
+                ColumnName: ReadString(row, "ColumnName"),
+                DataType: ReadString(row, "DataType"),
+                ColumnType: ReadString(row, "ColumnType"),
+                IsNullable: ReadBoolFlexible(row, "IsNullable"),
+                IsIdentity: ReadBoolFlexible(row, "IsIdentity") || ReadString(row, "Extra").Contains("identity", StringComparison.OrdinalIgnoreCase) || ReadString(row, "Extra").Contains("auto_increment", StringComparison.OrdinalIgnoreCase),
+                DefaultValue: string.IsNullOrWhiteSpace(ReadString(row, "DefaultValue")) ? null : ReadString(row, "DefaultValue"),
+                Ordinal: ReadInt(row, "Ordinal") - 1,
+                CharMaxLen: ReadNullableLong(row, "CharMaxLen"),
+                NumPrecision: ReadNullableInt(row, "NumPrecision"),
+                NumScale: ReadNullableInt(row, "NumScale"),
+                Generated: string.IsNullOrWhiteSpace(ReadString(row, "Generated")) ? null : ReadString(row, "Generated")))
+            .Where(static c => !string.IsNullOrWhiteSpace(c.ColumnName))
+            .OrderBy(static c => c.Ordinal)
+            .ToList();
+
+        var pk = cn.Query(SqlMetadataQueryFactory.BuildPrimaryKeyQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => ReadString(row, "ColumnName"))
+            .Where(static c => !string.IsNullOrWhiteSpace(c))
+            .ToList();
+
+        var idx = new Dictionary<string, (bool Unique, List<string> Cols)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in cn.Query(SqlMetadataQueryFactory.BuildIndexesQuery(DatabaseType), args).Select(ToDictionary))
+        {
+            var name = ReadString(row, "IndexName");
+            var col = ReadString(row, "ColumnName");
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(col))
+                continue;
+            if (name.Equals("PRIMARY", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("PK", StringComparison.OrdinalIgnoreCase)
+                || name.StartsWith("PK_", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var unique = ReadBoolFlexible(row, "IsUnique")
+                         || ReadString(row, "Uniqueness").Equals("UNIQUE", StringComparison.OrdinalIgnoreCase)
+                         || ReadString(row, "UniqueRule").Equals("U", StringComparison.OrdinalIgnoreCase)
+                         || ReadInt(row, "NonUnique") == 0;
+
+            if (!idx.TryGetValue(name, out var tuple))
+                tuple = (Unique: unique, Cols: []);
+
+            tuple = (Unique: tuple.Unique || unique, tuple.Cols);
+            tuple.Cols.Add(col);
+            idx[name] = tuple;
+        }
+
+        var fks = cn.Query(SqlMetadataQueryFactory.BuildForeignKeysQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => (
+                Col: ReadString(row, "ColumnName"),
+                RefTable: ReadString(row, "RefTable"),
+                RefCol: ReadString(row, "RefColumn")))
+            .Where(f => !string.IsNullOrWhiteSpace(f.Col) && !string.IsNullOrWhiteSpace(f.RefTable) && !string.IsNullOrWhiteSpace(f.RefCol))
+            .ToList();
+
+        return new TableMeta(cols, pk, idx, fks);
+    }
+
+    private static void GenerateTableFile(
+        string ns,
+        string tableName,
+        List<ColumnMeta> columns,
+        List<string> primaryKey,
+        Dictionary<string, (bool Unique, List<string> Cols)> indexes,
+        List<(string Col, string RefTable, string RefCol)> foreignKeys,
+        string outputPath)
+    {
+        var className = $"{GenerationRuleSet.ToPascalCase(tableName)}TableFactory";
+        var methodName = $"CreateTable{GenerationRuleSet.ToPascalCase(tableName)}";
+        var fileName = Path.Combine(outputPath, $"{className}.cs");
+
+        using var w = new StreamWriter(fileName, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        w.WriteLine($"namespace {ns};");
+        w.WriteLine();
+        w.WriteLine($"public static class {className}");
+        w.WriteLine("{");
+        w.WriteLine($"    public static ITableMock {methodName}(        this DbMock db)");
+        w.WriteLine("    {");
+        w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
+
+        foreach (var c in columns.OrderBy(c => c.Ordinal))
+        {
+            var dbType = GenerationRuleSet.MapDbType(c.DataType, c.CharMaxLen, c.NumPrecision, c.ColumnName, DatabaseType);
+            var nullable = c.IsNullable ? "true" : "false";
+            var ctor = $"new({c.Ordinal}, DbType.{dbType}, {nullable}";
+
+            if (c.IsIdentity) ctor += ", true";
+            ctor += ")";
+
+            w.WriteLine($"        table.Columns[\"{c.ColumnName}\"] = {ctor};");
+
+            if (!string.IsNullOrEmpty(c.DefaultValue)
+                && GenerationRuleSet.IsSimpleLiteralDefault(c.DefaultValue!))
+            {
+                var literal = GenerationRuleSet.FormatDefaultLiteral(c.DefaultValue!, dbType);
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DefaultValue = {literal};");
+            }
+
+            if (c.CharMaxLen is > 0 and <= int.MaxValue)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].Size = {(int)c.CharMaxLen};");
+
+            if (c.NumScale is >= 0)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DecimalPlaces = {c.NumScale.Value};");
+
+            var enums = GenerationRuleSet.TryParseEnumValues(c.ColumnType);
+            if (enums.Length > 0)
+            {
+                var arr = string.Join(", ", enums.Select(GenerationRuleSet.Literal));
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].EnumValues = new[] {{ {arr} }};");
+            }
+            if (!string.IsNullOrWhiteSpace(c.Generated))
+            {
+                if (!GenerationRuleSet.TryConvertIfIsNull(c.Generated, out var genCode))
+                    throw new NotSupportedException($"Expressão não suportada: {c.Generated}");
+
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].GetGenValue = {genCode};");
+            }
+        }
+
+        if (primaryKey.Count > 0)
+        {
+            foreach (var pkCol in primaryKey)
+                w.WriteLine($"        table.PrimaryKeyIndexes.Add(table.Columns[\"{pkCol}\"]?.Index);");
+            var cols = string.Join(", ", primaryKey.Select(GenerationRuleSet.Literal));
+            w.WriteLine($"        table.CreateIndex(new IndexDef(\"PRIMARY\", [{cols}], unique: true));");
+        }
+
+        foreach (var (name, (Unique, Cols)) in indexes.OrderBy(p => p.Key))
+        {
+            var cols = string.Join(", ", Cols.Select(GenerationRuleSet.Literal));
+            var uniq = Unique ? "true" : "false";
+            w.WriteLine($"        table.CreateIndex(new IndexDef({GenerationRuleSet.Literal(name)}, [{cols}], unique: {uniq}));");
+        }
+
+        foreach (var (col, rtab, rcol) in foreignKeys)
+        {
+            w.WriteLine($"        table.ForeignKeys.Add(({GenerationRuleSet.Literal(col)}, {GenerationRuleSet.Literal(rtab)}, {GenerationRuleSet.Literal(rcol)}));");
+        }
+
+        w.WriteLine("        return table;");
+        w.WriteLine("    }");
+        w.WriteLine("}");
+    }
+
+    private static IDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IDictionary<string, object?> dict)
+            return dict;
+
+        return row
+            .GetType()
+            .GetProperties()
+            .ToDictionary(p => p.Name, p => p.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool ReadBoolFlexible(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return false;
+        return s.Equals("1", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("y", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static long? ReadNullableLong(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : null;
+    }
+
+    private static int? ReadNullableInt(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : null;
+    }
+
+    private static int ReadInt(IDictionary<string, object?> row, string key)
+        => ReadNullableInt(row, key) ?? 0;
+
+    private static string ReadString(IDictionary<string, object?> row, string key)
+    {
+        foreach (var item in row)
+        {
+            if (string.Equals(item.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                if (item.Value is null || item.Value is DBNull)
+                    return string.Empty;
+                return Convert.ToString(item.Value, CultureInfo.InvariantCulture)?.Trim() ?? string.Empty;
+            }
+        }
+
+        return string.Empty;
+    }
+
+#pragma warning restore CA1303
+}

--- a/src/DbSqlLikeMem.OracleConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.OracleConsoleGenerator/appsettings.json
@@ -1,0 +1,17 @@
+{
+    "ConnectionsString": [
+        {
+            "Name": "CONNECTION",
+            "Enable": true,
+            "ProviderName": "Oracle.ManagedDataAccess.Client",
+            "Connection": "Data Source=localhost/XEPDB1;User Id=system;Password=Password;",
+            "Destinies": [
+                {
+                    "OutputPath": "Project\\src\\Project.Domain.TestTools\\Oracle",
+                    "Schema": "public",
+                    "Namespace": "Project.Domain.TestTools.Oracle"
+                }
+            ]
+        }
+    ]
+}

--- a/src/DbSqlLikeMem.SqlServerConsoleGenerator/DbSqlLikeMem.SqlServerConsoleGenerator.csproj
+++ b/src/DbSqlLikeMem.SqlServerConsoleGenerator/DbSqlLikeMem.SqlServerConsoleGenerator.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DbSqlLikeMem.VisualStudioExtension.Core\DbSqlLikeMem.VisualStudioExtension.Core.csproj" />
+    <ProjectReference Include="..\DbSqlLikeMem.SqlServer\DbSqlLikeMem.SqlServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DbSqlLikeMem.SqlServerConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.SqlServerConsoleGenerator/Program.cs
@@ -1,0 +1,373 @@
+using System.Data;
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+using Dapper;
+using DbSqlLikeMem.VisualStudioExtension.Core.Generation;
+using Microsoft.Extensions.Configuration;
+
+namespace TableStructureGenerator;
+
+static partial class Program
+{
+#pragma warning disable CA1303
+
+#pragma warning disable  CA1812
+    private sealed record DestinyInfo(
+        string OutputPath,
+        string Schema,
+        string Namespace,
+        List<string>? Tables = null);
+
+    private sealed record ConnectionInfo(
+        string Name,
+        string ProviderName,
+        string Connection,
+        bool? Enable,
+        List<DestinyInfo> Destinies);
+
+#pragma warning restore CA1812
+
+    private const string DatabaseType = "sqlserver";
+    private const string DefaultProvider = "Microsoft.Data.SqlClient";
+
+    static void Main(string[] args)
+    {
+        var baseDirectory = Directory.GetCurrentDirectory()
+            .Split("\\Tools")
+            [0];
+        Console.WriteLine($"BaseDirectory: {baseDirectory}");
+
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var connections = configuration
+            .GetSection("ConnectionsString")
+            .Get<List<ConnectionInfo>>()
+            ?.Where(_ => !_.Enable.HasValue || _.Enable.Value)
+            .ToList();
+
+        if (connections == null || connections.Count == 0)
+        {
+            Console.WriteLine("No connection strings found in appsettings.json.");
+            return;
+        }
+
+        bool runAll = args.Any(a => string.Equals(a, "--all", StringComparison.OrdinalIgnoreCase));
+
+        int selectedConnectionIndex = 1;
+        if (!runAll)
+        {
+            Console.WriteLine("Select a connection:");
+            Console.WriteLine("0. Todas");
+            for (int i = 0; i < connections.Count; i++)
+                Console.WriteLine($"{i + 1}. {connections[i].Name}");
+
+            Console.Write("Enter the number of the connection to use: ");
+            if (!int.TryParse(Console.ReadLine(), out selectedConnectionIndex)
+                || selectedConnectionIndex < 0 || selectedConnectionIndex > connections.Count)
+            {
+                Console.WriteLine("Invalid connection selection.");
+                return;
+            }
+
+            if (selectedConnectionIndex == 0)
+                runAll = true;
+        }
+
+        foreach (var connInfo in runAll
+            ? connections
+            : [connections[selectedConnectionIndex - 1]])
+        {
+            using var connection = CreateConnection(connInfo);
+            connection.Open();
+
+            foreach (var destiny in connInfo.Destinies)
+            {
+                var tables = (destiny.Tables != null && destiny.Tables.Count != 0)
+                    ? destiny.Tables
+                    : GetTablesInSchema(connection, destiny.Schema);
+
+                Console.WriteLine($"Schema: {destiny.Schema}");
+
+                var outputPath = Path.Combine(baseDirectory, destiny.OutputPath);
+                if (tables.Count > 0 && !Directory.Exists(outputPath))
+                    Directory.CreateDirectory(outputPath);
+
+                foreach (var tableName in tables.Distinct(StringComparer.OrdinalIgnoreCase))
+                {
+                    var clean = tableName.Trim();
+                    if (string.IsNullOrEmpty(clean)) continue;
+
+                    var meta = LoadTableMetadata(connection, destiny.Schema, clean);
+
+                    GenerateTableFile(
+                        destiny.Namespace,
+                        tableName: clean,
+                        columns: meta.Columns,
+                        primaryKey: meta.PrimaryKey,
+                        indexes: meta.Indexes,
+                        foreignKeys: meta.ForeignKeys,
+                        outputPath: outputPath);
+
+                    Console.WriteLine($" - Tabela: {tableName} gerada.");
+                }
+            }
+        }
+
+        Console.WriteLine("Table structure files have been generated.");
+    }
+
+    private static IDbConnection CreateConnection(ConnectionInfo connInfo)
+    {
+        var providerName = string.IsNullOrWhiteSpace(connInfo.ProviderName) ? DefaultProvider : connInfo.ProviderName;
+        var factory = DbProviderFactories.GetFactory(providerName);
+        var connection = factory.CreateConnection() ?? throw new InvalidOperationException($"Failed to create provider connection for '{providerName}'.");
+        connection.ConnectionString = connInfo.Connection;
+        return connection;
+    }
+
+    private static List<string> GetTablesInSchema(IDbConnection cn, string schema)
+    {
+        var qObjects = SqlMetadataQueryFactory.BuildListObjectsQuery(DatabaseType);
+        var rows = cn.Query(qObjects, new { databaseName = schema })
+            .Select(ToDictionary)
+            .Where(r => ReadString(r, "ObjectType").Equals("Table", StringComparison.OrdinalIgnoreCase))
+            .Where(r => string.IsNullOrWhiteSpace(schema) || ReadString(r, "SchemaName").Equals(schema, StringComparison.OrdinalIgnoreCase))
+            .Select(r => ReadString(r, "ObjectName"))
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static name => name)
+            .ToList();
+
+        return rows;
+    }
+
+    private sealed record ColumnMeta(
+        string ColumnName,
+        string DataType,
+        string ColumnType,
+        bool IsNullable,
+        bool IsIdentity,
+        string? DefaultValue,
+        int Ordinal,
+        long? CharMaxLen,
+        int? NumPrecision,
+        int? NumScale,
+        string? Generated);
+
+    private sealed record TableMeta(
+        List<ColumnMeta> Columns,
+        List<string> PrimaryKey,
+        Dictionary<string, (bool Unique, List<string> Cols)> Indexes,
+        List<(string Col, string RefTable, string RefCol)> ForeignKeys);
+
+    private static TableMeta LoadTableMetadata(IDbConnection cn, string schema, string table)
+    {
+        var args = new { schemaName = schema, objectName = table };
+
+        var cols = cn.Query(SqlMetadataQueryFactory.BuildObjectColumnsQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => new ColumnMeta(
+                ColumnName: ReadString(row, "ColumnName"),
+                DataType: ReadString(row, "DataType"),
+                ColumnType: ReadString(row, "ColumnType"),
+                IsNullable: ReadBoolFlexible(row, "IsNullable"),
+                IsIdentity: ReadBoolFlexible(row, "IsIdentity") || ReadString(row, "Extra").Contains("identity", StringComparison.OrdinalIgnoreCase) || ReadString(row, "Extra").Contains("auto_increment", StringComparison.OrdinalIgnoreCase),
+                DefaultValue: string.IsNullOrWhiteSpace(ReadString(row, "DefaultValue")) ? null : ReadString(row, "DefaultValue"),
+                Ordinal: ReadInt(row, "Ordinal") - 1,
+                CharMaxLen: ReadNullableLong(row, "CharMaxLen"),
+                NumPrecision: ReadNullableInt(row, "NumPrecision"),
+                NumScale: ReadNullableInt(row, "NumScale"),
+                Generated: string.IsNullOrWhiteSpace(ReadString(row, "Generated")) ? null : ReadString(row, "Generated")))
+            .Where(static c => !string.IsNullOrWhiteSpace(c.ColumnName))
+            .OrderBy(static c => c.Ordinal)
+            .ToList();
+
+        var pk = cn.Query(SqlMetadataQueryFactory.BuildPrimaryKeyQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => ReadString(row, "ColumnName"))
+            .Where(static c => !string.IsNullOrWhiteSpace(c))
+            .ToList();
+
+        var idx = new Dictionary<string, (bool Unique, List<string> Cols)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in cn.Query(SqlMetadataQueryFactory.BuildIndexesQuery(DatabaseType), args).Select(ToDictionary))
+        {
+            var name = ReadString(row, "IndexName");
+            var col = ReadString(row, "ColumnName");
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(col))
+                continue;
+            if (name.Equals("PRIMARY", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("PK", StringComparison.OrdinalIgnoreCase)
+                || name.StartsWith("PK_", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var unique = ReadBoolFlexible(row, "IsUnique")
+                         || ReadString(row, "Uniqueness").Equals("UNIQUE", StringComparison.OrdinalIgnoreCase)
+                         || ReadString(row, "UniqueRule").Equals("U", StringComparison.OrdinalIgnoreCase)
+                         || ReadInt(row, "NonUnique") == 0;
+
+            if (!idx.TryGetValue(name, out var tuple))
+                tuple = (Unique: unique, Cols: []);
+
+            tuple = (Unique: tuple.Unique || unique, tuple.Cols);
+            tuple.Cols.Add(col);
+            idx[name] = tuple;
+        }
+
+        var fks = cn.Query(SqlMetadataQueryFactory.BuildForeignKeysQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => (
+                Col: ReadString(row, "ColumnName"),
+                RefTable: ReadString(row, "RefTable"),
+                RefCol: ReadString(row, "RefColumn")))
+            .Where(f => !string.IsNullOrWhiteSpace(f.Col) && !string.IsNullOrWhiteSpace(f.RefTable) && !string.IsNullOrWhiteSpace(f.RefCol))
+            .ToList();
+
+        return new TableMeta(cols, pk, idx, fks);
+    }
+
+    private static void GenerateTableFile(
+        string ns,
+        string tableName,
+        List<ColumnMeta> columns,
+        List<string> primaryKey,
+        Dictionary<string, (bool Unique, List<string> Cols)> indexes,
+        List<(string Col, string RefTable, string RefCol)> foreignKeys,
+        string outputPath)
+    {
+        var className = $"{GenerationRuleSet.ToPascalCase(tableName)}TableFactory";
+        var methodName = $"CreateTable{GenerationRuleSet.ToPascalCase(tableName)}";
+        var fileName = Path.Combine(outputPath, $"{className}.cs");
+
+        using var w = new StreamWriter(fileName, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        w.WriteLine($"namespace {ns};");
+        w.WriteLine();
+        w.WriteLine($"public static class {className}");
+        w.WriteLine("{");
+        w.WriteLine($"    public static ITableMock {methodName}(        this DbMock db)");
+        w.WriteLine("    {");
+        w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
+
+        foreach (var c in columns.OrderBy(c => c.Ordinal))
+        {
+            var dbType = GenerationRuleSet.MapDbType(c.DataType, c.CharMaxLen, c.NumPrecision, c.ColumnName, DatabaseType);
+            var nullable = c.IsNullable ? "true" : "false";
+            var ctor = $"new({c.Ordinal}, DbType.{dbType}, {nullable}";
+
+            if (c.IsIdentity) ctor += ", true";
+            ctor += ")";
+
+            w.WriteLine($"        table.Columns[\"{c.ColumnName}\"] = {ctor};");
+
+            if (!string.IsNullOrEmpty(c.DefaultValue)
+                && GenerationRuleSet.IsSimpleLiteralDefault(c.DefaultValue!))
+            {
+                var literal = GenerationRuleSet.FormatDefaultLiteral(c.DefaultValue!, dbType);
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DefaultValue = {literal};");
+            }
+
+            if (c.CharMaxLen is > 0 and <= int.MaxValue)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].Size = {(int)c.CharMaxLen};");
+
+            if (c.NumScale is >= 0)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DecimalPlaces = {c.NumScale.Value};");
+
+            var enums = GenerationRuleSet.TryParseEnumValues(c.ColumnType);
+            if (enums.Length > 0)
+            {
+                var arr = string.Join(", ", enums.Select(GenerationRuleSet.Literal));
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].EnumValues = new[] {{ {arr} }};");
+            }
+            if (!string.IsNullOrWhiteSpace(c.Generated))
+            {
+                if (!GenerationRuleSet.TryConvertIfIsNull(c.Generated, out var genCode))
+                    throw new NotSupportedException($"Expressão não suportada: {c.Generated}");
+
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].GetGenValue = {genCode};");
+            }
+        }
+
+        if (primaryKey.Count > 0)
+        {
+            foreach (var pkCol in primaryKey)
+                w.WriteLine($"        table.PrimaryKeyIndexes.Add(table.Columns[\"{pkCol}\"]?.Index);");
+            var cols = string.Join(", ", primaryKey.Select(GenerationRuleSet.Literal));
+            w.WriteLine($"        table.CreateIndex(new IndexDef(\"PRIMARY\", [{cols}], unique: true));");
+        }
+
+        foreach (var (name, (Unique, Cols)) in indexes.OrderBy(p => p.Key))
+        {
+            var cols = string.Join(", ", Cols.Select(GenerationRuleSet.Literal));
+            var uniq = Unique ? "true" : "false";
+            w.WriteLine($"        table.CreateIndex(new IndexDef({GenerationRuleSet.Literal(name)}, [{cols}], unique: {uniq}));");
+        }
+
+        foreach (var (col, rtab, rcol) in foreignKeys)
+        {
+            w.WriteLine($"        table.ForeignKeys.Add(({GenerationRuleSet.Literal(col)}, {GenerationRuleSet.Literal(rtab)}, {GenerationRuleSet.Literal(rcol)}));");
+        }
+
+        w.WriteLine("        return table;");
+        w.WriteLine("    }");
+        w.WriteLine("}");
+    }
+
+    private static IDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IDictionary<string, object?> dict)
+            return dict;
+
+        return row
+            .GetType()
+            .GetProperties()
+            .ToDictionary(p => p.Name, p => p.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool ReadBoolFlexible(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return false;
+        return s.Equals("1", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("y", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static long? ReadNullableLong(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : null;
+    }
+
+    private static int? ReadNullableInt(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : null;
+    }
+
+    private static int ReadInt(IDictionary<string, object?> row, string key)
+        => ReadNullableInt(row, key) ?? 0;
+
+    private static string ReadString(IDictionary<string, object?> row, string key)
+    {
+        foreach (var item in row)
+        {
+            if (string.Equals(item.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                if (item.Value is null || item.Value is DBNull)
+                    return string.Empty;
+                return Convert.ToString(item.Value, CultureInfo.InvariantCulture)?.Trim() ?? string.Empty;
+            }
+        }
+
+        return string.Empty;
+    }
+
+#pragma warning restore CA1303
+}

--- a/src/DbSqlLikeMem.SqlServerConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.SqlServerConsoleGenerator/appsettings.json
@@ -1,0 +1,17 @@
+{
+    "ConnectionsString": [
+        {
+            "Name": "CONNECTION",
+            "Enable": true,
+            "ProviderName": "Microsoft.Data.SqlClient",
+            "Connection": "Server=localhost;Database=master;User Id=sa;Password=Password123!;TrustServerCertificate=True;",
+            "Destinies": [
+                {
+                    "OutputPath": "Project\\src\\Project.Domain.TestTools\\SqlServer",
+                    "Schema": "public",
+                    "Namespace": "Project.Domain.TestTools.SqlServer"
+                }
+            ]
+        }
+    ]
+}

--- a/src/DbSqlLikeMem.SqliteConsoleGenerator/DbSqlLikeMem.SqliteConsoleGenerator.csproj
+++ b/src/DbSqlLikeMem.SqliteConsoleGenerator/DbSqlLikeMem.SqliteConsoleGenerator.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DbSqlLikeMem.VisualStudioExtension.Core\DbSqlLikeMem.VisualStudioExtension.Core.csproj" />
+    <ProjectReference Include="..\DbSqlLikeMem.Sqlite\DbSqlLikeMem.Sqlite.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DbSqlLikeMem.SqliteConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.SqliteConsoleGenerator/Program.cs
@@ -1,0 +1,373 @@
+using System.Data;
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+using Dapper;
+using DbSqlLikeMem.VisualStudioExtension.Core.Generation;
+using Microsoft.Extensions.Configuration;
+
+namespace TableStructureGenerator;
+
+static partial class Program
+{
+#pragma warning disable CA1303
+
+#pragma warning disable  CA1812
+    private sealed record DestinyInfo(
+        string OutputPath,
+        string Schema,
+        string Namespace,
+        List<string>? Tables = null);
+
+    private sealed record ConnectionInfo(
+        string Name,
+        string ProviderName,
+        string Connection,
+        bool? Enable,
+        List<DestinyInfo> Destinies);
+
+#pragma warning restore CA1812
+
+    private const string DatabaseType = "sqlite";
+    private const string DefaultProvider = "Microsoft.Data.Sqlite";
+
+    static void Main(string[] args)
+    {
+        var baseDirectory = Directory.GetCurrentDirectory()
+            .Split("\\Tools")
+            [0];
+        Console.WriteLine($"BaseDirectory: {baseDirectory}");
+
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var connections = configuration
+            .GetSection("ConnectionsString")
+            .Get<List<ConnectionInfo>>()
+            ?.Where(_ => !_.Enable.HasValue || _.Enable.Value)
+            .ToList();
+
+        if (connections == null || connections.Count == 0)
+        {
+            Console.WriteLine("No connection strings found in appsettings.json.");
+            return;
+        }
+
+        bool runAll = args.Any(a => string.Equals(a, "--all", StringComparison.OrdinalIgnoreCase));
+
+        int selectedConnectionIndex = 1;
+        if (!runAll)
+        {
+            Console.WriteLine("Select a connection:");
+            Console.WriteLine("0. Todas");
+            for (int i = 0; i < connections.Count; i++)
+                Console.WriteLine($"{i + 1}. {connections[i].Name}");
+
+            Console.Write("Enter the number of the connection to use: ");
+            if (!int.TryParse(Console.ReadLine(), out selectedConnectionIndex)
+                || selectedConnectionIndex < 0 || selectedConnectionIndex > connections.Count)
+            {
+                Console.WriteLine("Invalid connection selection.");
+                return;
+            }
+
+            if (selectedConnectionIndex == 0)
+                runAll = true;
+        }
+
+        foreach (var connInfo in runAll
+            ? connections
+            : [connections[selectedConnectionIndex - 1]])
+        {
+            using var connection = CreateConnection(connInfo);
+            connection.Open();
+
+            foreach (var destiny in connInfo.Destinies)
+            {
+                var tables = (destiny.Tables != null && destiny.Tables.Count != 0)
+                    ? destiny.Tables
+                    : GetTablesInSchema(connection, destiny.Schema);
+
+                Console.WriteLine($"Schema: {destiny.Schema}");
+
+                var outputPath = Path.Combine(baseDirectory, destiny.OutputPath);
+                if (tables.Count > 0 && !Directory.Exists(outputPath))
+                    Directory.CreateDirectory(outputPath);
+
+                foreach (var tableName in tables.Distinct(StringComparer.OrdinalIgnoreCase))
+                {
+                    var clean = tableName.Trim();
+                    if (string.IsNullOrEmpty(clean)) continue;
+
+                    var meta = LoadTableMetadata(connection, destiny.Schema, clean);
+
+                    GenerateTableFile(
+                        destiny.Namespace,
+                        tableName: clean,
+                        columns: meta.Columns,
+                        primaryKey: meta.PrimaryKey,
+                        indexes: meta.Indexes,
+                        foreignKeys: meta.ForeignKeys,
+                        outputPath: outputPath);
+
+                    Console.WriteLine($" - Tabela: {tableName} gerada.");
+                }
+            }
+        }
+
+        Console.WriteLine("Table structure files have been generated.");
+    }
+
+    private static IDbConnection CreateConnection(ConnectionInfo connInfo)
+    {
+        var providerName = string.IsNullOrWhiteSpace(connInfo.ProviderName) ? DefaultProvider : connInfo.ProviderName;
+        var factory = DbProviderFactories.GetFactory(providerName);
+        var connection = factory.CreateConnection() ?? throw new InvalidOperationException($"Failed to create provider connection for '{providerName}'.");
+        connection.ConnectionString = connInfo.Connection;
+        return connection;
+    }
+
+    private static List<string> GetTablesInSchema(IDbConnection cn, string schema)
+    {
+        var qObjects = SqlMetadataQueryFactory.BuildListObjectsQuery(DatabaseType);
+        var rows = cn.Query(qObjects, new { databaseName = schema })
+            .Select(ToDictionary)
+            .Where(r => ReadString(r, "ObjectType").Equals("Table", StringComparison.OrdinalIgnoreCase))
+            .Where(r => string.IsNullOrWhiteSpace(schema) || ReadString(r, "SchemaName").Equals(schema, StringComparison.OrdinalIgnoreCase))
+            .Select(r => ReadString(r, "ObjectName"))
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static name => name)
+            .ToList();
+
+        return rows;
+    }
+
+    private sealed record ColumnMeta(
+        string ColumnName,
+        string DataType,
+        string ColumnType,
+        bool IsNullable,
+        bool IsIdentity,
+        string? DefaultValue,
+        int Ordinal,
+        long? CharMaxLen,
+        int? NumPrecision,
+        int? NumScale,
+        string? Generated);
+
+    private sealed record TableMeta(
+        List<ColumnMeta> Columns,
+        List<string> PrimaryKey,
+        Dictionary<string, (bool Unique, List<string> Cols)> Indexes,
+        List<(string Col, string RefTable, string RefCol)> ForeignKeys);
+
+    private static TableMeta LoadTableMetadata(IDbConnection cn, string schema, string table)
+    {
+        var args = new { schemaName = schema, objectName = table };
+
+        var cols = cn.Query(SqlMetadataQueryFactory.BuildObjectColumnsQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => new ColumnMeta(
+                ColumnName: ReadString(row, "ColumnName"),
+                DataType: ReadString(row, "DataType"),
+                ColumnType: ReadString(row, "ColumnType"),
+                IsNullable: ReadBoolFlexible(row, "IsNullable"),
+                IsIdentity: ReadBoolFlexible(row, "IsIdentity") || ReadString(row, "Extra").Contains("identity", StringComparison.OrdinalIgnoreCase) || ReadString(row, "Extra").Contains("auto_increment", StringComparison.OrdinalIgnoreCase),
+                DefaultValue: string.IsNullOrWhiteSpace(ReadString(row, "DefaultValue")) ? null : ReadString(row, "DefaultValue"),
+                Ordinal: ReadInt(row, "Ordinal") - 1,
+                CharMaxLen: ReadNullableLong(row, "CharMaxLen"),
+                NumPrecision: ReadNullableInt(row, "NumPrecision"),
+                NumScale: ReadNullableInt(row, "NumScale"),
+                Generated: string.IsNullOrWhiteSpace(ReadString(row, "Generated")) ? null : ReadString(row, "Generated")))
+            .Where(static c => !string.IsNullOrWhiteSpace(c.ColumnName))
+            .OrderBy(static c => c.Ordinal)
+            .ToList();
+
+        var pk = cn.Query(SqlMetadataQueryFactory.BuildPrimaryKeyQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => ReadString(row, "ColumnName"))
+            .Where(static c => !string.IsNullOrWhiteSpace(c))
+            .ToList();
+
+        var idx = new Dictionary<string, (bool Unique, List<string> Cols)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in cn.Query(SqlMetadataQueryFactory.BuildIndexesQuery(DatabaseType), args).Select(ToDictionary))
+        {
+            var name = ReadString(row, "IndexName");
+            var col = ReadString(row, "ColumnName");
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(col))
+                continue;
+            if (name.Equals("PRIMARY", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("PK", StringComparison.OrdinalIgnoreCase)
+                || name.StartsWith("PK_", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var unique = ReadBoolFlexible(row, "IsUnique")
+                         || ReadString(row, "Uniqueness").Equals("UNIQUE", StringComparison.OrdinalIgnoreCase)
+                         || ReadString(row, "UniqueRule").Equals("U", StringComparison.OrdinalIgnoreCase)
+                         || ReadInt(row, "NonUnique") == 0;
+
+            if (!idx.TryGetValue(name, out var tuple))
+                tuple = (Unique: unique, Cols: []);
+
+            tuple = (Unique: tuple.Unique || unique, tuple.Cols);
+            tuple.Cols.Add(col);
+            idx[name] = tuple;
+        }
+
+        var fks = cn.Query(SqlMetadataQueryFactory.BuildForeignKeysQuery(DatabaseType), args)
+            .Select(ToDictionary)
+            .Select(row => (
+                Col: ReadString(row, "ColumnName"),
+                RefTable: ReadString(row, "RefTable"),
+                RefCol: ReadString(row, "RefColumn")))
+            .Where(f => !string.IsNullOrWhiteSpace(f.Col) && !string.IsNullOrWhiteSpace(f.RefTable) && !string.IsNullOrWhiteSpace(f.RefCol))
+            .ToList();
+
+        return new TableMeta(cols, pk, idx, fks);
+    }
+
+    private static void GenerateTableFile(
+        string ns,
+        string tableName,
+        List<ColumnMeta> columns,
+        List<string> primaryKey,
+        Dictionary<string, (bool Unique, List<string> Cols)> indexes,
+        List<(string Col, string RefTable, string RefCol)> foreignKeys,
+        string outputPath)
+    {
+        var className = $"{GenerationRuleSet.ToPascalCase(tableName)}TableFactory";
+        var methodName = $"CreateTable{GenerationRuleSet.ToPascalCase(tableName)}";
+        var fileName = Path.Combine(outputPath, $"{className}.cs");
+
+        using var w = new StreamWriter(fileName, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        w.WriteLine($"namespace {ns};");
+        w.WriteLine();
+        w.WriteLine($"public static class {className}");
+        w.WriteLine("{");
+        w.WriteLine($"    public static ITableMock {methodName}(        this DbMock db)");
+        w.WriteLine("    {");
+        w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
+
+        foreach (var c in columns.OrderBy(c => c.Ordinal))
+        {
+            var dbType = GenerationRuleSet.MapDbType(c.DataType, c.CharMaxLen, c.NumPrecision, c.ColumnName, DatabaseType);
+            var nullable = c.IsNullable ? "true" : "false";
+            var ctor = $"new({c.Ordinal}, DbType.{dbType}, {nullable}";
+
+            if (c.IsIdentity) ctor += ", true";
+            ctor += ")";
+
+            w.WriteLine($"        table.Columns[\"{c.ColumnName}\"] = {ctor};");
+
+            if (!string.IsNullOrEmpty(c.DefaultValue)
+                && GenerationRuleSet.IsSimpleLiteralDefault(c.DefaultValue!))
+            {
+                var literal = GenerationRuleSet.FormatDefaultLiteral(c.DefaultValue!, dbType);
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DefaultValue = {literal};");
+            }
+
+            if (c.CharMaxLen is > 0 and <= int.MaxValue)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].Size = {(int)c.CharMaxLen};");
+
+            if (c.NumScale is >= 0)
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].DecimalPlaces = {c.NumScale.Value};");
+
+            var enums = GenerationRuleSet.TryParseEnumValues(c.ColumnType);
+            if (enums.Length > 0)
+            {
+                var arr = string.Join(", ", enums.Select(GenerationRuleSet.Literal));
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].EnumValues = new[] {{ {arr} }};");
+            }
+            if (!string.IsNullOrWhiteSpace(c.Generated))
+            {
+                if (!GenerationRuleSet.TryConvertIfIsNull(c.Generated, out var genCode))
+                    throw new NotSupportedException($"Expressão não suportada: {c.Generated}");
+
+                w.WriteLine($"        table.Columns[\"{c.ColumnName}\"].GetGenValue = {genCode};");
+            }
+        }
+
+        if (primaryKey.Count > 0)
+        {
+            foreach (var pkCol in primaryKey)
+                w.WriteLine($"        table.PrimaryKeyIndexes.Add(table.Columns[\"{pkCol}\"]?.Index);");
+            var cols = string.Join(", ", primaryKey.Select(GenerationRuleSet.Literal));
+            w.WriteLine($"        table.CreateIndex(new IndexDef(\"PRIMARY\", [{cols}], unique: true));");
+        }
+
+        foreach (var (name, (Unique, Cols)) in indexes.OrderBy(p => p.Key))
+        {
+            var cols = string.Join(", ", Cols.Select(GenerationRuleSet.Literal));
+            var uniq = Unique ? "true" : "false";
+            w.WriteLine($"        table.CreateIndex(new IndexDef({GenerationRuleSet.Literal(name)}, [{cols}], unique: {uniq}));");
+        }
+
+        foreach (var (col, rtab, rcol) in foreignKeys)
+        {
+            w.WriteLine($"        table.ForeignKeys.Add(({GenerationRuleSet.Literal(col)}, {GenerationRuleSet.Literal(rtab)}, {GenerationRuleSet.Literal(rcol)}));");
+        }
+
+        w.WriteLine("        return table;");
+        w.WriteLine("    }");
+        w.WriteLine("}");
+    }
+
+    private static IDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IDictionary<string, object?> dict)
+            return dict;
+
+        return row
+            .GetType()
+            .GetProperties()
+            .ToDictionary(p => p.Name, p => p.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool ReadBoolFlexible(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return false;
+        return s.Equals("1", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("y", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static long? ReadNullableLong(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : null;
+    }
+
+    private static int? ReadNullableInt(IDictionary<string, object?> row, string key)
+    {
+        var s = ReadString(row, key);
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : null;
+    }
+
+    private static int ReadInt(IDictionary<string, object?> row, string key)
+        => ReadNullableInt(row, key) ?? 0;
+
+    private static string ReadString(IDictionary<string, object?> row, string key)
+    {
+        foreach (var item in row)
+        {
+            if (string.Equals(item.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                if (item.Value is null || item.Value is DBNull)
+                    return string.Empty;
+                return Convert.ToString(item.Value, CultureInfo.InvariantCulture)?.Trim() ?? string.Empty;
+            }
+        }
+
+        return string.Empty;
+    }
+
+#pragma warning restore CA1303
+}

--- a/src/DbSqlLikeMem.SqliteConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.SqliteConsoleGenerator/appsettings.json
@@ -1,0 +1,17 @@
+{
+    "ConnectionsString": [
+        {
+            "Name": "CONNECTION",
+            "Enable": true,
+            "ProviderName": "Microsoft.Data.Sqlite",
+            "Connection": "Data Source=database.db;",
+            "Destinies": [
+                {
+                    "OutputPath": "Project\\src\\Project.Domain.TestTools\\Sqlite",
+                    "Schema": "public",
+                    "Namespace": "Project.Domain.TestTools.Sqlite"
+                }
+            ]
+        }
+    ]
+}

--- a/src/DbSqlLikeMem.slnx
+++ b/src/DbSqlLikeMem.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/Db2/">
     <Project Path="DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj" />
     <Project Path="DbSqlLikeMem.Db2/DbSqlLikeMem.Db2.csproj" />
+    <Project Path="DbSqlLikeMem.Db2ConsoleGenerator/DbSqlLikeMem.Db2ConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/MySql/">
     <Project Path="DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj" />
@@ -11,10 +12,12 @@
   <Folder Name="/Npgsql/">
     <Project Path="DbSqlLikeMem.Npgsql.Test/DbSqlLikeMem.Npgsql.Test.csproj" />
     <Project Path="DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj" />
+    <Project Path="DbSqlLikeMem.NpgsqlConsoleGenerator/DbSqlLikeMem.NpgsqlConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/Oracle/">
     <Project Path="DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj" />
     <Project Path="DbSqlLikeMem.Oracle/DbSqlLikeMem.Oracle.csproj" />
+    <Project Path="DbSqlLikeMem.OracleConsoleGenerator/DbSqlLikeMem.OracleConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path="../Features.md" />
@@ -24,10 +27,12 @@
   <Folder Name="/Sqlite/">
     <Project Path="DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj" />
     <Project Path="DbSqlLikeMem.Sqlite/DbSqlLikeMem.Sqlite.csproj" />
+    <Project Path="DbSqlLikeMem.SqliteConsoleGenerator/DbSqlLikeMem.SqliteConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/SqlServer/">
     <Project Path="DbSqlLikeMem.SqlServer.Test/DbSqlLikeMem.SqlServer.Test.csproj" />
     <Project Path="DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj" />
+    <Project Path="DbSqlLikeMem.SqlServerConsoleGenerator/DbSqlLikeMem.SqlServerConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/VisualStudioExtension/">
     <Project Path="DbSqlLikeMem.VisualStudioExtension.Core.Test/DbSqlLikeMem.VisualStudioExtension.Core.Test.csproj" />


### PR DESCRIPTION
### Motivation
- Provide ConsoleGenerator tooling equivalent to the existing MySQL generator for all supported database providers so table-factory code can be generated from each DB metadata.
- Keep generation logic unified (metadata extraction via `SqlMetadataQueryFactory` and code generation via `GenerationRuleSet`) across providers.
- Ensure each provider has a small executable project for consumers to run metadata-based code generation out of the box.

### Description
- Added five new ConsoleGenerator projects: `DbSqlLikeMem.NpgsqlConsoleGenerator`, `DbSqlLikeMem.SqlServerConsoleGenerator`, `DbSqlLikeMem.OracleConsoleGenerator`, `DbSqlLikeMem.SqliteConsoleGenerator` and `DbSqlLikeMem.Db2ConsoleGenerator`, each containing `Program.cs`, `appsettings.json` and a `.csproj` file configured as `net8.0` executables with `IsPackable=false` and references to `DbSqlLikeMem.VisualStudioExtension.Core` and the corresponding provider project.
- Each `Program.cs` is a copy of the MySQL generator flow adapted with provider-specific `DatabaseType` and `DefaultProvider` constants and uses `SqlMetadataQueryFactory` + `GenerationRuleSet` to load metadata and emit table factory files.
- Added `appsettings.json` templates for each new project with a sample connection entry and `Destinies` configuration for output path/namespace.
- Updated solution file `src/DbSqlLikeMem.slnx` to include all new ConsoleGenerator projects under the appropriate database folders.

### Testing
- Validated all newly added `appsettings.json` files parse as JSON using a Python JSON load check with `json.load` (`python` JSON validation) which passed for all files.
- Verified repository changes were staged and committed successfully using `git` (working tree clean after commit).
- Attempted to run `dotnet` builds/tests but `dotnet` is not available in the environment (`dotnet: command not found`), so `dotnet restore/build/test` could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6e721bfc832caf7c116fe53c2f10)