### PR TITLE
Fix netstandard2.0 API compatibility regressions in core library

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/GenerationRuleSet.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/GenerationRuleSet.cs
@@ -101,7 +101,8 @@ public static class GenerationRuleSet
         }
 
         return Regex.Matches(match.Groups[2].Value, @"'((?:\\'|[^'])*)'")
-            .Select(static m => m.Groups[1].Value.Replace("\\'", "'", StringComparison.Ordinal))
+            .Cast<Match>()
+            .Select(m => m.Groups[1].Value.Replace("\\'", "'"))
             .ToArray();
     }
 
@@ -129,7 +130,7 @@ public static class GenerationRuleSet
     /// Executa esta operação da API.
     /// </summary>
     public static string Literal(string value)
-        => $"\"{value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)}\"";
+        => "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
 
     private static bool IsNumericDbType(string dbType)
         => dbType is "Byte" or "Int16" or "Int32" or "Int64" or "Decimal" or "Double" or "Single" or "UInt64";
@@ -161,6 +162,6 @@ public static class GenerationRuleSet
             return cleaned.ToUpperInvariant();
         }
 
-        return string.Concat(char.ToUpper(cleaned[0], CultureInfo.InvariantCulture), cleaned[1..]);
+        return string.Concat(char.ToUpper(cleaned[0], CultureInfo.InvariantCulture), cleaned.Substring(1));
     }
 }

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlDatabaseMetadataProvider.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlDatabaseMetadataProvider.cs
@@ -208,5 +208,5 @@ public sealed class SqlDatabaseMetadataProvider : IDatabaseMetadataProvider
     }
 
     private static string Escape(string value)
-        => value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("|", "\\|", StringComparison.Ordinal).Replace(";", "\\;", StringComparison.Ordinal).Replace(",", "\\,", StringComparison.Ordinal);
+        => value.Replace("\\", "\\\\").Replace("|", "\\|").Replace(";", "\\;").Replace(",", "\\,");
 }

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlMetadataQueryFactory.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/SqlMetadataQueryFactory.cs
@@ -410,8 +410,8 @@ ORDER BY k.COLSEQ;
     }
 
     private static string Normalize(string databaseType)
-        => databaseType.Replace("_", string.Empty, StringComparison.OrdinalIgnoreCase)
-            .Replace("-", string.Empty, StringComparison.OrdinalIgnoreCase)
+        => databaseType.Replace("_", string.Empty)
+            .Replace("-", string.Empty)
             .Trim()
             .ToLowerInvariant();
 }

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Persistence/StatePersistenceService.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Persistence/StatePersistenceService.cs
@@ -37,7 +37,8 @@ public sealed class StatePersistenceService
         }
 
         var json = JsonSerializer.Serialize(state, SerializerOptions);
-        return File.WriteAllTextAsync(outputPath, json, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.Run(() => File.WriteAllText(outputPath, json), cancellationToken);
     }
 
     /// <summary>
@@ -51,7 +52,8 @@ public sealed class StatePersistenceService
             return null;
         }
 
-        var json = await File.ReadAllTextAsync(inputPath, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        var json = await Task.Run(() => File.ReadAllText(inputPath), cancellationToken);
         return JsonSerializer.Deserialize<ExtensionState>(json, SerializerOptions);
     }
 

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Services/TreeViewBuilder.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Services/TreeViewBuilder.cs
@@ -18,7 +18,7 @@ public sealed class TreeViewBuilder
         var dbNode = new TreeNode(connection.DatabaseName) { ContextKey = "database-name" };
         root.Children.Add(dbNode);
 
-        foreach (var objectType in Enum.GetValues<DatabaseObjectType>())
+        foreach (DatabaseObjectType objectType in Enum.GetValues(typeof(DatabaseObjectType)))
         {
             var typeNode = new TreeNode(GetGroupLabel(objectType)) { ContextKey = "object-type", ObjectType = objectType };
 

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Validation/GeneratedClassSnapshotReader.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Validation/GeneratedClassSnapshotReader.cs
@@ -17,7 +17,8 @@ public static class GeneratedClassSnapshotReader
         DatabaseObjectReference fallbackReference,
         CancellationToken cancellationToken = default)
     {
-        var lines = await File.ReadAllLinesAsync(filePath, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        var lines = await Task.Run(() => File.ReadAllLines(filePath), cancellationToken);
         var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var line in lines)
@@ -28,7 +29,13 @@ public static class GeneratedClassSnapshotReader
                 continue;
             }
 
-            var kv = line[prefix.Length..].Split('=', 2, StringSplitOptions.TrimEntries);
+            var payload = line.Substring(prefix.Length);
+            var kv = payload.Split(new[] {'='}, 2, StringSplitOptions.None);
+            if (kv.Length == 2)
+            {
+                kv[0] = kv[0].Trim();
+                kv[1] = kv[1].Trim();
+            }
             if (kv.Length == 2)
             {
                 metadata[kv[0]] = kv[1];


### PR DESCRIPTION
### Motivation

- The core library targets `netstandard2.0` and compilation failed due to usage of newer BCL APIs that are not available on that target (async file helpers, newer `string.Replace` overloads, `Enum.GetValues<T>`, `StringSplitOptions.TrimEntries`, range/index slicing, etc.).
- The change aims to restore compatibility so the project can compile against the older target without changing the public behavior.

### Description

- Replaced unavailable async file APIs (`File.WriteAllTextAsync`, `File.ReadAllTextAsync`, `File.ReadAllLinesAsync`) with `Task.Run` wrappers that honor a `CancellationToken` in persistence, generation and snapshot reader code (`StatePersistenceService`, `ClassGenerator`, `GeneratedClassSnapshotReader`).
- Replaced `string.Replace(..., StringComparison)` uses with case-insensitive implementations and added a `ReplaceIgnoreCase` helper to perform repeated case-insensitive replacements in `ClassGenerator` filename resolution.
- Replaced `Enum.GetValues<T>()` usage with `Enum.GetValues(typeof(...))` and adjusted enumeration to cast to the enum type in `TreeViewBuilder`.
- Replaced `StringSplitOptions.TrimEntries`, index/range slicing and new `MatchCollection` LINQ overloads with compatible alternatives, including manual trim logic and `.Cast<Match>()` before LINQ projection, and swapped `cleaned[1..]` to `cleaned.Substring(1)` in `GenerationRuleSet`.

### Testing

- Attempted `dotnet build src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj` but the environment does not have `dotnet` installed so a local build could not be executed (failed: `dotnet` not found).
- Verified removal of the known incompatible APIs by running ripgrep patterns for the problematic symbols and confirmed no remaining occurrences of those APIs in the core project.
- No automated unit tests were run in this environment due to missing SDK, but source edits are limited to API compatibility work to preserve existing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6f8007bc832cba7d8dc785bbf9f1)