### PR TITLE
Fix Visual Studio extension warnings and C# compatibility issues

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Models/TemplateConfiguration.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Models/TemplateConfiguration.cs
@@ -4,28 +4,44 @@ namespace DbSqlLikeMem.VisualStudioExtension.Core.Models;
 /// Represents template and output path settings used by the extension code generator.
 /// Representa as configurações de templates e diretórios de saída usadas pelo gerador da extensão.
 /// </summary>
-public sealed record TemplateConfiguration(
+public sealed record TemplateConfiguration
+{
     /// <summary>
     /// Gets the model template file path.
     /// Obtém o caminho do arquivo de template de modelo.
     /// </summary>
-    string ModelTemplatePath,
+    public string ModelTemplatePath { get; init; }
+
     /// <summary>
     /// Gets the repository template file path.
     /// Obtém o caminho do arquivo de template de repositório.
     /// </summary>
-    string RepositoryTemplatePath,
+    public string RepositoryTemplatePath { get; init; }
+
     /// <summary>
     /// Gets the model output directory.
     /// Obtém o diretório de saída dos modelos.
     /// </summary>
-    string ModelOutputDirectory,
+    public string ModelOutputDirectory { get; init; }
+
     /// <summary>
     /// Gets the repository output directory.
     /// Obtém o diretório de saída dos repositórios.
     /// </summary>
-    string RepositoryOutputDirectory)
-{
+    public string RepositoryOutputDirectory { get; init; }
+
+    public TemplateConfiguration(
+        string modelTemplatePath,
+        string repositoryTemplatePath,
+        string modelOutputDirectory,
+        string repositoryOutputDirectory)
+    {
+        ModelTemplatePath = modelTemplatePath;
+        RepositoryTemplatePath = repositoryTemplatePath;
+        ModelOutputDirectory = modelOutputDirectory;
+        RepositoryOutputDirectory = repositoryOutputDirectory;
+    }
+
     /// <summary>
     /// Gets the default template configuration.
     /// Obtém a configuração padrão de templates.

--- a/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
+++ b/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.11.33214" ExcludeAssets="runtime" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.11.32" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.11.35" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />

--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowViewModel.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowViewModel.cs
@@ -524,13 +524,11 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
 
         foreach (var typeGroup in byType)
         {
-            var typeNode = new ExplorerNode { Label = typeGroup.Key, Kind = ExplorerNodeKind.DatabaseType };
+            var typeNode = new ExplorerNode(typeGroup.Key, ExplorerNodeKind.DatabaseType);
             foreach (var connection in typeGroup.OrderBy(c => c.DatabaseName, StringComparer.OrdinalIgnoreCase))
             {
-                var connectionNode = new ExplorerNode
+                var connectionNode = new ExplorerNode(connection.DatabaseName, ExplorerNodeKind.Connection)
                 {
-                    Label = connection.DatabaseName,
-                    Kind = ExplorerNodeKind.Connection,
                     ConnectionId = connection.Id
                 };
 
@@ -540,16 +538,16 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
 
                 foreach (var objectType in Enum.GetValues<DatabaseObjectType>())
                 {
-                    var objectTypeNode = new ExplorerNode
-                    {
-                        Label = objectType switch
+                    var objectTypeNode = new ExplorerNode(
+                        objectType switch
                         {
                             DatabaseObjectType.Table => "Tables",
                             DatabaseObjectType.View => "Views",
                             DatabaseObjectType.Procedure => "Procedures",
                             _ => objectType.ToString()
                         },
-                        Kind = ExplorerNodeKind.ObjectType,
+                        ExplorerNodeKind.ObjectType)
+                    {
                         ConnectionId = connection.Id,
                         ObjectType = objectType
                     };
@@ -565,10 +563,10 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
                     {
                         var key = BuildObjectKey(connection.Id, dbObject);
                         var status = healthByObject.TryGetValue(key, out var health) ? health.Status : null;
-                        objectTypeNode.Children.Add(new ExplorerNode
+                        objectTypeNode.Children.Add(new ExplorerNode(
+                            string.IsNullOrWhiteSpace(dbObject.Schema) ? dbObject.Name : $"{dbObject.Schema}.{dbObject.Name}",
+                            ExplorerNodeKind.Object)
                         {
-                            Label = string.IsNullOrWhiteSpace(dbObject.Schema) ? dbObject.Name : $"{dbObject.Schema}.{dbObject.Name}",
-                            Kind = ExplorerNodeKind.Object,
                             ConnectionId = connection.Id,
                             ObjectType = dbObject.Type,
                             DatabaseObject = dbObject,

--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/ExplorerNode.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/ExplorerNode.cs
@@ -13,15 +13,21 @@ public enum ExplorerNodeKind
 
 public sealed class ExplorerNode
 {
-    public required string Label { get; init; }
+    public ExplorerNode(string label, ExplorerNodeKind kind)
+    {
+        Label = label;
+        Kind = kind;
+    }
 
-    public required ExplorerNodeKind Kind { get; init; }
+    public string Label { get; }
 
-    public string? ConnectionId { get; init; }
+    public ExplorerNodeKind Kind { get; }
 
-    public DatabaseObjectType? ObjectType { get; init; }
+    public string? ConnectionId { get; set; }
 
-    public DatabaseObjectReference? DatabaseObject { get; init; }
+    public DatabaseObjectType? ObjectType { get; set; }
+
+    public DatabaseObjectReference? DatabaseObject { get; set; }
 
     public ObjectHealthStatus? HealthStatus { get; set; }
 


### PR DESCRIPTION
### Motivation
- Fix XML doc warnings (CS1587) from a positional record and C# language compatibility errors (CS0518/CS0656) in the Visual Studio extension targeting `net472`, and reduce package resolution warnings (NU1603).

### Description
- Reworked `TemplateConfiguration` from a positional record to a record with explicit public properties and a constructor so XML documentation comments attach to valid language elements (`src/DbSqlLikeMem.VisualStudioExtension.Core/Models/TemplateConfiguration.cs`).
- Replaced `required`/`init` usage in `ExplorerNode` with a constructor for mandatory fields (`Label`, `Kind`) and mutable optional properties to avoid unsupported language features on `net472` (`src/DbSqlLikeMem.VisualStudioExtension/UI/ExplorerNode.cs`).
- Updated all `ExplorerNode` instantiations in `DbSqlLikeMemToolWindowViewModel` to use the new constructor-based initialization and object initializers for optional fields (`src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowViewModel.cs`).
- Bumped Visual Studio SDK package versions in the VS extension project file to the resolved versions to avoid NU1603 warnings (`src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj`).

### Testing
- Attempted to run `dotnet build src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj`, but the environment does not have the `dotnet` CLI installed so the build could not be executed (failed with `bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d759a5228832c9d6fdec387a2050a)