### PR TITLE
Fix Visual Studio extension compile errors for .NET Framework (net472)

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
+++ b/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
@@ -32,6 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Design" />
+  </ItemGroup>
+
+  <ItemGroup>
     <VSCTCompile Include="DbSqlLikeMemExtension.vsct" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>

--- a/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMemExtensionPackage.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMemExtensionPackage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using DbSqlLikeMem.VisualStudioExtension.Commands;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/DbSqlLikeMem.VisualStudioExtension/Services/ConnectionStringProtector.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/Services/ConnectionStringProtector.cs
@@ -26,7 +26,7 @@ internal static class ConnectionStringProtector
             return value;
         }
 
-        var payload = value[Prefix.Length..];
+        var payload = value.Substring(Prefix.Length);
         var protectedBytes = Convert.FromBase64String(payload);
         var plainBytes = ProtectedData.Unprotect(protectedBytes, null, DataProtectionScope.CurrentUser);
         return Encoding.UTF8.GetString(plainBytes);

--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowControl.xaml.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowControl.xaml.cs
@@ -7,6 +7,9 @@ using System.Windows;
 using System.Windows.Controls;
 using DbSqlLikeMem.VisualStudioExtension.Services;
 using EnvDTE;
+using DteProject = EnvDTE.Project;
+using DteProjectItem = EnvDTE.ProjectItem;
+using DteProjectItems = EnvDTE.ProjectItems;
 using Microsoft.VisualStudio.Shell;
 
 namespace DbSqlLikeMem.VisualStudioExtension.UI;
@@ -32,7 +35,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
     private async void OnAddConnectionClick(object sender, RoutedEventArgs e)
         => await RunSafeAsync(async () =>
         {
-            var dialog = new ConnectionDialog { Owner = Window.GetWindow(this) };
+            var dialog = new ConnectionDialog { Owner = System.Windows.Window.GetWindow(this) };
 
             if (dialog.ShowDialog() != true)
             {
@@ -42,7 +45,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
             var test = await viewModel.TestConnectionAsync(dialog.DatabaseType, dialog.ConnectionString);
             if (!test.Success)
             {
-                MessageBox.Show(this, test.Message, "Falha de conexão", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBox.Show(System.Windows.Window.GetWindow(this), test.Message, "Falha de conexão", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 
@@ -55,14 +58,14 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
         {
             if (ExplorerTree.SelectedItem is not ExplorerNode selected || selected.Kind != ExplorerNodeKind.Connection)
             {
-                MessageBox.Show(this, "Selecione um nó de conexão para editar.", "Editar conexão", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(System.Windows.Window.GetWindow(this), "Selecione um nó de conexão para editar.", "Editar conexão", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
             }
 
             var existing = selected.ConnectionId is null ? null : viewModel.GetConnection(selected.ConnectionId);
             var dialog = new ConnectionDialog
             {
-                Owner = Window.GetWindow(this),
+                Owner = System.Windows.Window.GetWindow(this),
                 ConnectionName = existing?.DatabaseName ?? selected.Label,
                 DatabaseType = existing?.DatabaseType ?? "SqlServer",
                 ConnectionString = existing?.ConnectionString ?? string.Empty
@@ -76,7 +79,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
             var test = await viewModel.TestConnectionAsync(dialog.DatabaseType, dialog.ConnectionString);
             if (!test.Success)
             {
-                MessageBox.Show(this, test.Message, "Falha de conexão", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBox.Show(System.Windows.Window.GetWindow(this), test.Message, "Falha de conexão", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 
@@ -88,11 +91,11 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
     {
         if (ExplorerTree.SelectedItem is not ExplorerNode selected || selected.Kind != ExplorerNodeKind.Connection)
         {
-            MessageBox.Show(this, "Selecione um nó de conexão para remover.", "Remover conexão", MessageBoxButton.OK, MessageBoxImage.Information);
+            MessageBox.Show(System.Windows.Window.GetWindow(this), "Selecione um nó de conexão para remover.", "Remover conexão", MessageBoxButton.OK, MessageBoxImage.Information);
             return;
         }
 
-        var confirm = MessageBox.Show(this, $"Remover conexão '{selected.Label}'?", "Confirmação", MessageBoxButton.YesNo, MessageBoxImage.Question);
+        var confirm = MessageBox.Show(System.Windows.Window.GetWindow(this), $"Remover conexão '{selected.Label}'?", "Confirmação", MessageBoxButton.YesNo, MessageBoxImage.Question);
         if (confirm == MessageBoxResult.Yes)
         {
             viewModel.RemoveConnection(selected);
@@ -102,7 +105,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
     private void OnConfigureMappingsClick(object sender, RoutedEventArgs e)
     {
         var defaults = viewModel.GetMappingDefaults();
-        var dialog = new MappingDialog(defaults.FileNamePattern, defaults.OutputDirectory) { Owner = Window.GetWindow(this) };
+        var dialog = new MappingDialog(defaults.FileNamePattern, defaults.OutputDirectory) { Owner = System.Windows.Window.GetWindow(this) };
 
         if (dialog.ShowDialog() == true)
         {
@@ -113,7 +116,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
 
     private void OnConfigureTemplatesClick(object sender, RoutedEventArgs e)
     {
-        var dialog = new TemplateConfigurationDialog(viewModel.GetTemplateConfiguration()) { Owner = Window.GetWindow(this) };
+        var dialog = new TemplateConfigurationDialog(viewModel.GetTemplateConfiguration()) { Owner = System.Windows.Window.GetWindow(this) };
         if (dialog.ShowDialog() == true)
         {
             viewModel.ConfigureTemplates(dialog.ModelTemplatePath, dialog.RepositoryTemplatePath, dialog.ModelOutputDirectory, dialog.RepositoryOutputDirectory);
@@ -131,7 +134,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
         {
             if (ExplorerTree.SelectedItem is not ExplorerNode selected || !GenerationSupportedKinds.Contains(selected.Kind))
             {
-                MessageBox.Show(this, "Selecione conexão, tipo de objeto ou objeto para gerar classes de teste.", "Gerar classes de teste", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(System.Windows.Window.GetWindow(this), "Selecione conexão, tipo de objeto ou objeto para gerar classes de teste.", "Gerar classes de teste", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
             }
 
@@ -140,7 +143,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
             {
                 var preview = string.Join(Environment.NewLine, conflicts.Take(10));
                 var message = $"{conflicts.Count} arquivo(s) já existem e serão sobrescritos:\n\n{preview}";
-                var confirm = MessageBox.Show(this, message, "Pré-visualização de sobrescrita", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                var confirm = MessageBox.Show(System.Windows.Window.GetWindow(this), message, "Pré-visualização de sobrescrita", MessageBoxButton.YesNo, MessageBoxImage.Warning);
                 if (confirm != MessageBoxResult.Yes)
                 {
                     return;
@@ -157,7 +160,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
         {
             if (ExplorerTree.SelectedItem is not ExplorerNode selected || !GenerationSupportedKinds.Contains(selected.Kind))
             {
-                MessageBox.Show(this, "Selecione conexão, tipo de objeto ou objeto para gerar classes de modelos.", "Gerar modelos", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(System.Windows.Window.GetWindow(this), "Selecione conexão, tipo de objeto ou objeto para gerar classes de modelos.", "Gerar modelos", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
             }
 
@@ -170,7 +173,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
         {
             if (ExplorerTree.SelectedItem is not ExplorerNode selected || !GenerationSupportedKinds.Contains(selected.Kind))
             {
-                MessageBox.Show(this, "Selecione conexão, tipo de objeto ou objeto para gerar classes de repositório.", "Gerar repositórios", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(System.Windows.Window.GetWindow(this), "Selecione conexão, tipo de objeto ou objeto para gerar classes de repositório.", "Gerar repositórios", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
             }
 
@@ -183,7 +186,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
         {
             if (ExplorerTree.SelectedItem is not ExplorerNode selected || !GenerationSupportedKinds.Contains(selected.Kind))
             {
-                MessageBox.Show(this, "Selecione conexão, tipo de objeto ou objeto para checar consistência.", "Checar consistência", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(System.Windows.Window.GetWindow(this), "Selecione conexão, tipo de objeto ou objeto para checar consistência.", "Checar consistência", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
             }
 
@@ -199,7 +202,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
         catch (Exception ex)
         {
             ExtensionLogger.Log($"UI operation error: {ex}");
-            MessageBox.Show(this, ex.Message, "Erro inesperado", MessageBoxButton.OK, MessageBoxImage.Error);
+            MessageBox.Show(System.Windows.Window.GetWindow(this), ex.Message, "Erro inesperado", MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
 
@@ -213,13 +216,13 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
             return;
         }
 
-        var dte = Package.GetGlobalService(typeof(SDTE)) as DTE;
+        var dte = Package.GetGlobalService(typeof(DTE)) as DTE;
         if (dte?.ActiveSolutionProjects is not Array activeProjects || activeProjects.Length == 0)
         {
             return;
         }
 
-        if (activeProjects.GetValue(0) is not Project project)
+        if (activeProjects.GetValue(0) is not DteProject project)
         {
             return;
         }
@@ -233,7 +236,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
         }
     }
 
-    private static bool ProjectContainsFile(ProjectItems? items, string fullPath)
+    private static bool ProjectContainsFile(DteProjectItems? items, string fullPath)
     {
         ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -242,7 +245,7 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
             return false;
         }
 
-        foreach (ProjectItem item in items)
+        foreach (DteProjectItem item in items)
         {
             var itemPath = item.FileCount > 0 ? item.FileNames[1] : string.Empty;
             if (string.Equals(Path.GetFullPath(itemPath), Path.GetFullPath(fullPath), StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
### Motivation
- Corrigir falhas de compilação e incompatibilidades observadas ao compilar a extensão do Visual Studio contra `net472`, removendo usos de APIs e sintaxes que requerem runtimes mais novos e ajustando integração com DTE/MenuCommand.

### Description
- Substituí o uso de slicing `value[Prefix.Length..]` por `value.Substring(Prefix.Length)` para compatibilidade com versões mais antigas do runtime; (file: `ConnectionStringProtector.cs`).
- Adicionei `<Reference Include="System.Design" />` ao projeto e importei o namespace de comandos no package para resolver erros relacionados a `MenuCommandService`/`AddCommand` e à inicialização do comando (file: `.csproj`, `DbSqlLikeMemExtensionPackage.cs`).
- Removi ambiguidade entre `EnvDTE.Window` e `System.Windows.Window` e corrigi chamadas de `MessageBox.Show` para usar a janela dona correta (`System.Windows.Window.GetWindow(this)`), além de trocar o lookup do serviço `SDTE` para `DTE` e tipar explicitamente `Project/ProjectItems` como tipos DTE apropriados (file: `DbSqlLikeMemToolWindowControl.xaml.cs`).
- Substituí `File.ReadAllTextAsync`/`File.WriteAllTextAsync` por `Task.Run(() => File.ReadAllText(...))`/`Task.Run(() => File.WriteAllText(...))`, removi `Enum.GetValues<T>()` em favor de `Enum.GetValues(typeof(...))` com cast, e reimplementei um `ReplaceIgnoreCase` para evitar sobrecargas de `string.Replace` que não existem no .NET Framework, além de ajustar conversões nullable de status (file: `DbSqlLikeMemToolWindowViewModel.cs`).

### Testing
- Executei buscas automatizadas com `rg` para garantir que as ocorrências problemáticas (`ReadAllTextAsync`, `WriteAllTextAsync`, `Enum.GetValues<`, `MessageBox.Show(this)`, `Prefix.Length..`, etc.) foram removidas ou substituídas; a verificação encontrou as alterações aplicadas com sucesso.
- Tentei rodar `dotnet build src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj` mas a ferramenta `dotnet`/`msbuild` não está disponível neste ambiente, então a compilação local não pôde ser verificada automaticamente.
- Confira o diff e os arquivos modificados para validação manual em ambiente de desenvolvimento com SDK/Visual Studio instalados antes de publicar o VSIX.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d76b6f470832ca6645bc0295c5032)