### PR TITLE
Fix CS0103 and CS8604 in DbSqlLikeMemToolWindowViewModel

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowViewModel.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowViewModel.cs
@@ -234,7 +234,7 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
             {
                 if (!string.IsNullOrWhiteSpace(result.error))
                 {
-                    failures.Add(result.error);
+                    failures.Add(result.error!);
                     continue;
                 }
 
@@ -332,6 +332,7 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
 
         try
         {
+            var token = currentOperationCts?.Token ?? CancellationToken.None;
             var connection = ResolveConnection(node);
             if (connection is null || !objectsByConnection.TryGetValue(connection.Id, out var objects))
             {


### PR DESCRIPTION
### Motivation
- Resolve compiler errors reported during build: undefined `token` usage in template generation and a possible null reference when adding error messages to a list.
- Ensure async flows correctly propagate cancellation tokens and avoid nullable warnings in refresh logic.

### Description
- Added a local cancellation `token` in `GenerateFromTemplateForNodeAsync` before any `Task.Run(..., token)` calls to fix `CS0103` errors and enable cancellation propagation.
- Used the null-forgiving operator on `result.error` when adding to `failures` in `RefreshObjectsAsync` after guarding with `string.IsNullOrWhiteSpace`, addressing `CS8604` nullable warning.
- Changes are confined to `src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowViewModel.cs` and do not alter external behavior beyond fixing the compile-time issues.

### Testing
- Attempted to run `dotnet build DbSqlLikeMem.sln -c Debug`, but `dotnet` is not available in the environment and the build could not be executed (`command not found`).
- Verified the source edits with a local diff and committed the changes; no automated tests were run due to environment constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d788ad5dc832c95cb24533c8df15e)