### PR TITLE
Pass cancellation token to ClassGenerator file writes

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/ClassGenerator.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/Generation/ClassGenerator.cs
@@ -33,7 +33,7 @@ public sealed class ClassGenerator
             var fullPath = Path.Combine(mapping.OutputDirectory, fileName);
             var content = classContentFactory(dbObject);
 
-            await Task.Run(() => File.WriteAllText(fullPath, content), cancellationToken);
+            await File.WriteAllTextAsync(fullPath, content, cancellationToken);
             writtenFiles.Add(fullPath);
         }
 


### PR DESCRIPTION
### Motivation
- Ensure cancellation is observed by the async file write itself so generation stops promptly and does not continue writing files after cancellation.

### Description
- Pass the `cancellationToken` into `File.WriteAllTextAsync(fullPath, content, cancellationToken)` and remove the extra immediate pre-write `ThrowIfCancellationRequested()`, while keeping the per-iteration cancellation check at the start of the `foreach`.

### Testing
- Attempted to run the targeted regression test with `dotnet test --filter "FullyQualifiedName~QualityRegressionTests.ClassGenerator_WhenCanceled_StopsWritingFurtherFiles"`, but `dotnet` is not available in this environment so the test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e0d8654ac832c804e2c1594165c89)