### PR TITLE
test: ampliar cobertura das regras de geração na extensão VS

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GenerationRuleSetTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GenerationRuleSetTests.cs
@@ -10,11 +10,88 @@ public sealed class GenerationRuleSetTests
     /// Executes this API operation.
     /// Executa esta operação da API.
     /// </summary>
-    [Fact]
-    public void MapDbType_UsesMySqlStrategyWhenDatabaseTypeIsMySql()
+    [Theory]
+    [InlineData("customer_order", "CustomerOrder")]
+    [InlineData("customer-order", "CustomerOrder")]
+    [InlineData("customer.order", "CustomerOrder")]
+    [InlineData("customer order", "CustomerOrder")]
+    [InlineData("123-name", "123Name")]
+    [InlineData("", "Object")]
+    [InlineData("___", "Object")]
+    public void ToPascalCase_TransformsCommonInputs(string input, string expected)
     {
-        var type = GenerationRuleSet.MapDbType("bit", null, 8, "Mask", "MySql");
-        Assert.Equal("UInt64", type);
+        var value = GenerationRuleSet.ToPascalCase(input);
+        Assert.Equal(expected, value);
+    }
+
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
+    [Theory]
+    [InlineData("tinyint", null, 8, "Flags", "MySql", "Byte")]
+    [InlineData("tinyint", 1, null, "IsEnabled", "MySql", "Boolean")]
+    [InlineData("tinyint", null, 1, "IsEnabled", "MySql", "Boolean")]
+    [InlineData("bit", null, 1, "IsDeleted", "MySql", "Boolean")]
+    [InlineData("bit", null, 8, "Mask", "MySql", "UInt64")]
+    [InlineData("tinyint", null, 1, "IsEnabled", "SqlServer", "Byte")]
+    [InlineData("uniqueidentifier", null, null, "Id", "SqlServer", "Guid")]
+    public void MapDbType_ResolvesStrategiesAndRules(
+        string dataType,
+        long? charMaxLen,
+        int? numPrecision,
+        string column,
+        string databaseType,
+        string expected)
+    {
+        var type = GenerationRuleSet.MapDbType(dataType, charMaxLen, numPrecision, column, databaseType);
+        Assert.Equal(expected, type);
+    }
+
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
+    [Theory]
+    [InlineData("binary", 16, null, "Token", "Guid")]
+    [InlineData("varbinary", 16, null, "Token", "Guid")]
+    [InlineData("char", 36, null, "OrderGuid", "Guid")]
+    [InlineData("char", 36, null, "OrderUuid", "Guid")]
+    [InlineData("char", 36, null, "OrderCode", "String")]
+    public void MapDbType_AppliesGuidHeuristics(string dataType, long? charMaxLen, int? precision, string column, string expected)
+    {
+        var type = GenerationRuleSet.MapDbType(dataType, charMaxLen, precision, column, "SqlServer");
+        Assert.Equal(expected, type);
+    }
+
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
+    [Theory]
+    [InlineData("(now())", false)]
+    [InlineData("current_timestamp", false)]
+    [InlineData("null", false)]
+    [InlineData("'abc'", true)]
+    [InlineData("42", true)]
+    public void IsSimpleLiteralDefault_ReturnsExpectedValue(string value, bool expected)
+    {
+        Assert.Equal(expected, GenerationRuleSet.IsSimpleLiteralDefault(value));
+    }
+
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
+    [Theory]
+    [InlineData("('0')", "Boolean", "false")]
+    [InlineData("('1')", "Boolean", "true")]
+    [InlineData("('abc')", "String", "\"abc\"")]
+    [InlineData("(123)", "Int32", "123")]
+    public void FormatDefaultLiteral_FormatsByTargetType(string input, string dbType, string expected)
+    {
+        var value = GenerationRuleSet.FormatDefaultLiteral(input, dbType);
+        Assert.Equal(expected, value);
     }
 
     /// <summary>
@@ -22,9 +99,61 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
-    public void MapDbType_UsesDefaultStrategyWhenDatabaseTypeIsSqlServer()
+    public void TryParseEnumValues_ReturnsEntriesForEnumAndSet()
     {
-        var type = GenerationRuleSet.MapDbType("tinyint", null, 1, "IsEnabled", "SqlServer");
-        Assert.Equal("Byte", type);
+        var enumValues = GenerationRuleSet.TryParseEnumValues("enum('A','B','C')");
+        var setValues = GenerationRuleSet.TryParseEnumValues("set('x','y')");
+
+        Assert.Equal(["A", "B", "C"], enumValues);
+        Assert.Equal(["x", "y"], setValues);
+    }
+
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
+    [Fact]
+    public void TryParseEnumValues_ReturnsEmptyForNonEnumType()
+    {
+        var values = GenerationRuleSet.TryParseEnumValues("varchar(100)");
+        Assert.Empty(values);
+    }
+
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
+    [Fact]
+    public void TryConvertIfIsNull_ReturnsLambdaWhenPatternMatches()
+    {
+        var success = GenerationRuleSet.TryConvertIfIsNull("if((`deleted` is null), 1, null)", out var code);
+
+        Assert.True(success);
+        Assert.Contains("tb.Columns[\"deleted\"].Index", code, StringComparison.Ordinal);
+        Assert.Contains("(byte?)1", code, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
+    [Fact]
+    public void TryConvertIfIsNull_ReturnsFalseWhenPatternDoesNotMatch()
+    {
+        var success = GenerationRuleSet.TryConvertIfIsNull("coalesce(`deleted`, 1)", out var code);
+
+        Assert.False(success);
+        Assert.Equal(string.Empty, code);
+    }
+
+    /// <summary>
+    /// Executes this API operation.
+    /// Executa esta operação da API.
+    /// </summary>
+    [Fact]
+    public void Literal_EscapesSlashAndQuotes()
+    {
+        var value = GenerationRuleSet.Literal("c:\\temp\\\"file\"");
+        Assert.Equal("\"c:\\\\temp\\\\\\\"file\\\"\"", value);
     }
 }


### PR DESCRIPTION
### Motivation
- Garantir que as regras de geração de código da extensão Visual Studio estejam cobertas por testes unitários para evitar regressões nas transformações de nomes e no mapeamento de tipos.
- Exercitar heurísticas e utilitários auxiliares usados pelo gerador (por exemplo, detecção de GUID, parsing de enums e conversões de default) para aumentar confiança nas mudanças futuras.

### Description
- Expande o conjunto de testes em `src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GenerationRuleSetTests.cs` adicionando cenários para `ToPascalCase` com vários separadores e entradas inválidas.
- Adiciona testes para `MapDbType` cobrindo estratégia MySQL e fallback padrão, incluindo casos de `tinyint`, `bit`, `uniqueidentifier` e heurísticas de GUID (`binary/varbinary(16)` e `char(36)` com sufixos `guid/uuid`).
- Inclui testes para utilitários auxiliares: `IsSimpleLiteralDefault`, `FormatDefaultLiteral`, `TryParseEnumValues` (enum/set e não-enum), `TryConvertIfIsNull` (match e não-match) e `Literal` (escaping de barras e aspas).
- O arquivo de teste modificado foi adicionado e commitado no repositório de teste da extensão (mensagem de commit: `test: ampliar cobertura das regras de geração`).

### Testing
- Executado comando de teste automatizado: `dotnet test src/DbSqlLikeMem.VisualStudioExtension.Core.Test/DbSqlLikeMem.VisualStudioExtension.Core.Test.csproj`.
- Resultado: falha de execução no ambiente atual porque o comando `dotnet` não está disponível (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e17a73fdc832c9e2403dd28b8134f)