### PR TITLE
feat(vscode-extension): adicionar edição de conexão no menu de contexto

### DIFF
--- a/src/DbSqlLikeMem.VsCodeExtension/package.json
+++ b/src/DbSqlLikeMem.VsCodeExtension/package.json
@@ -41,6 +41,7 @@
     "onCommand:dbSqlLikeMem.generateRepositoryClasses",
     "onCommand:dbSqlLikeMem.openManager",
     "onView:dbSqlLikeMem.connections",
+    "onCommand:dbSqlLikeMem.editConnection",
     "onCommand:dbSqlLikeMem.removeConnection"
   ],
   "main": "./out/extension.js",
@@ -110,6 +111,10 @@
       {
         "command": "dbSqlLikeMem.setFilter",
         "title": "DbSqlLikeMem: Set Filter"
+      },
+      {
+        "command": "dbSqlLikeMem.editConnection",
+        "title": "DbSqlLikeMem: Edit Connection"
       },
       {
         "command": "dbSqlLikeMem.removeConnection",
@@ -192,6 +197,16 @@
           "icon": {
             "id": "trash"
           }
+        },
+        {
+          "command": "dbSqlLikeMem.editConnection",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-database",
+          "group": "1_connection"
+        },
+        {
+          "command": "dbSqlLikeMem.removeConnection",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-database",
+          "group": "1_connection@1"
         },
         {
           "command": "dbSqlLikeMem.generateClasses",


### PR DESCRIPTION
### Motivation
- Tornar possível editar e excluir uma conexão diretamente no menu de contexto quando uma conexão (item `db-database`) estiver selecionada, melhorando a usabilidade do gerenciador de conexões.

### Description
- Registra e expõe o comando `dbSqlLikeMem.editConnection` em `package.json` e adiciona o item de menu de contexto para `viewItem == db-database` ao lado de `removeConnection`.
- Implementa o handler do comando `dbSqlLikeMem.editConnection` que resolve a conexão selecionada, abre prompts pré-preenchidos e atualiza o estado com o novo conteúdo da conexão.
- Introduz a função reutilizável `promptConnectionInput` para centralizar os prompts de entrada usados por `addConnection` e `editConnection`, e atualiza `addConnection` para reutilizá-la.
- Mantém a persistência de estado e o refresh da árvore após adicionar, editar ou remover conexões, e preserva a criação de mapeamentos padrão quando necessário.

### Testing
- Executado `npm run lint` em `src/DbSqlLikeMem.VsCodeExtension` (que roda `tsc -p ./ --noEmit`); a verificação de tipos/lint passou com sucesso.
- Nenhum teste automatizado adicional foi modificado ou necessário para esta alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1c300270832c9617db217e040986)