### PR TITLE
Add persisted computed columns (PersistComputedValue) and keep them indexed

### DIFF
--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs
@@ -315,6 +315,43 @@ public sealed class MySqlUpdateStrategyTests(
         Assert.Contains("Duplicate", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+
+    [Fact]
+    public void Update_ShouldRecomputePersistedGeneratedColumn_AndAllowUniqueIndex()
+    {
+        var db = new MySqlDbMock();
+        var table = db.AddTable("gen_persisted");
+
+        table.Columns["id"] = new(0, DbType.Int32, false);
+        table.Columns["base"] = new(1, DbType.Int32, false);
+        table.Columns["gen"] = new(2, DbType.Int32, false)
+        {
+            GetGenValue = (row, _) => ((int?)row[1] ?? 0) * 2,
+            PersistComputedValue = true
+        };
+
+        table.CreateIndex(new IndexDef("ux_gen", ["gen"], unique: true));
+        table.Add(new Dictionary<int, object?> { { 0, 1 }, { 1, 10 } });
+
+        Assert.Equal(20, table[0][2]);
+
+        using var connection = NewConn(threadSafe: false, db);
+        using var command = new MySqlCommandMock(connection)
+        {
+            CommandText = "UPDATE gen_persisted SET base = 15 WHERE id = 1"
+        };
+
+        var rowsAffected = command.ExecuteNonQuery();
+
+        Assert.Equal(1, rowsAffected);
+        Assert.Equal(15, table[0][1]);
+        Assert.Equal(30, table[0][2]);
+
+        var duplicate = Assert.ThrowsAny<MySqlMockException>(() =>
+            table.Add(new Dictionary<int, object?> { { 0, 2 }, { 1, 15 } }));
+        Assert.Contains("Duplicate", duplicate.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     // ---------------- helpers ----------------
 
     private static MySqlConnectionMock NewConn(bool threadSafe, MySqlDbMock db)

--- a/src/DbSqlLikeMem/Models/ColumnDef.cs
+++ b/src/DbSqlLikeMem/Models/ColumnDef.cs
@@ -137,4 +137,10 @@ public sealed class ColumnDef
     /// PT: Função geradora de valor calculado para colunas derivadas.
     /// </summary>
     public Func<IReadOnlyDictionary<int, object?>, ITableMock, object?>? GetGenValue { get; set; }
+
+    /// <summary>
+    /// EN: When true, stores the generated value in the row and keeps it updated on writes.
+    /// PT: Quando true, armazena o valor calculado na linha e o mantém atualizado em escritas.
+    /// </summary>
+    public bool PersistComputedValue { get; set; }
 }


### PR DESCRIPTION
### Motivation
- Provide support for persisted (materialized) computed columns that can be indexed and that stay consistent after writes for databases that offer this feature.
- Ensure unique/indexed constraints work correctly when a computed value is stored in the row and recomputed after source updates.

### Description
- Added a new column flag `PersistComputedValue` on `ColumnDef` to mark computed columns that should be stored and maintained in rows (`src/DbSqlLikeMem/Models/ColumnDef.cs`).
- Materialize and refresh persisted computed values on insert by calling `RefreshPersistedComputedValues` from `Add(...)` and `ApplyDefaultValues(...)` to write generated values into the row prior to uniqueness checks (`src/DbSqlLikeMem/Models/TableMock.cs`).
- Recompute and store persisted computed values after updates by invoking `RefreshPersistedComputedValues` in `UpdateRowColumn(...)` so indexes remain consistent after writes (`src/DbSqlLikeMem/Models/TableMock.cs`).
- Added regression tests for SQL Server and MySQL to validate the behavior: a persisted generated column is materialized on insert, recomputed on update, and can participate in a unique index that prevents duplicates (`src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs`, `src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs`).

### Testing
- Added unit tests that exercise insert + update + unique-index scenarios for persisted computed columns, but these tests were not executed in this environment because `dotnet` is not available here and `dotnet test` failed with `bash: command not found: dotnet`.
- Static inspection and local execution in the repository (file modifications and commits) were performed and the new tests and code compile paths were added, but automated test run could not be completed due to the missing .NET SDK in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e571036f8832ca70151a36bc49000)