### PR TITLE
feat(p11): transactional reliability and concurrency baseline for all providers

### DIFF
--- a/docs/providers-and-features.md
+++ b/docs/providers-and-features.md
@@ -173,6 +173,23 @@ Se a diferença altera **validade sintática** ou **interpretação semântica**
 - Validação explícita de direção de parâmetros obrigatórios (`IN` exige Input/InputOutput).
 - Fluxo compatível com uso via Dapper (`Execute` com `commandType: StoredProcedure`).
 
+
+### P11 — confiabilidade transacional e concorrência
+
+| Provider | Savepoint | Release savepoint | Isolation (mock simplificado) |
+| --- | --- | --- | --- |
+| MySQL | ✅ `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` | ✅ | ✅ `ReadCommitted`, `RepeatableRead`, `Serializable` |
+| SQL Server | ✅ `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` | ❌ não suportado (mensagem explícita) | ✅ `ReadCommitted`, `RepeatableRead`, `Serializable` |
+| Oracle | ✅ `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` | ✅ | ✅ `ReadCommitted`, `RepeatableRead`, `Serializable` |
+| PostgreSQL (Npgsql) | ✅ `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` | ✅ | ✅ `ReadCommitted`, `RepeatableRead`, `Serializable` |
+| SQLite (Sqlite) | ✅ `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` | ✅ | ✅ `ReadCommitted`, `RepeatableRead`, `Serializable` |
+| DB2 | ✅ `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` | ✅ | ✅ `ReadCommitted`, `RepeatableRead`, `Serializable` |
+
+Notas do modelo simplificado (determinístico):
+- O mock mantém snapshots por savepoint para garantir rollback intermediário consistente em múltiplos comandos DML.
+- `Commit` descarta snapshots ativos; `Rollback` restaura o snapshot inicial da transação.
+- Operações concorrentes continuam protegidas por `Db.SyncRoot` quando `ThreadSafe = true`.
+
 ### Limitações conhecidas (P7–P10)
 
 - `RETURNING`/`OUTPUT` ainda não materializa conjunto retornado completo no executor para todos os dialetos.

--- a/src/DbSqlLikeMem.Db2.Test/Db2TransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2TransactionReliabilityTests.cs
@@ -1,0 +1,98 @@
+namespace DbSqlLikeMem.Db2.Test;
+
+/// <summary>
+/// EN: Validates transactional reliability additions for P11 scenarios.
+/// PT: Valida as adições de confiabilidade transacional para cenários do P11.
+/// </summary>
+public sealed class Db2TransactionReliabilityTests
+{
+    /// <summary>
+    /// EN: Ensures rolling back to a savepoint restores the intermediate state.
+    /// PT: Garante que rollback para savepoint restaure o estado intermediário.
+    /// </summary>
+    [Fact]
+    public void SavepointRollbackShouldRestoreIntermediateState()
+    {
+        var db = new Db2DbMock();
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        using var connection = new Db2ConnectionMock(db);
+        connection.Open();
+        using var transaction = (Db2TransactionMock)connection.BeginTransaction();
+
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (1, 'John')", transaction: transaction);
+        transaction.Save("sp_users");
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (2, 'Mary')", transaction: transaction);
+
+        transaction.Rollback("sp_users");
+        transaction.Commit();
+
+        Assert.Single(table);
+        Assert.Equal(1, table[0][0]);
+    }
+
+    /// <summary>
+    /// EN: Ensures the simplified isolation model is deterministic and visible.
+    /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
+    /// </summary>
+    [Fact]
+    public void IsolationLevelShouldBeExposedDeterministically()
+    {
+        var db = new Db2DbMock();
+        using var connection = new Db2ConnectionMock(db);
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction(IsolationLevel.Serializable);
+
+        Assert.Equal(IsolationLevel.Serializable, transaction.IsolationLevel);
+        Assert.Equal(IsolationLevel.Serializable, connection.CurrentIsolationLevel);
+    }
+
+    /// <summary>
+    /// EN: Ensures savepoint release support follows provider compatibility rules.
+    /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
+    /// </summary>
+    [Fact]
+    public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
+    {
+        var db = new Db2DbMock();
+        using var connection = new Db2ConnectionMock(db);
+        connection.Open();
+
+        using var transaction = (Db2TransactionMock)connection.BeginTransaction();
+        transaction.Save("sp_release");
+
+        if (true)
+        {
+            transaction.Release("sp_release");
+            return;
+        }
+
+        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+    }
+
+    /// <summary>
+    /// EN: Ensures concurrent writes keep data consistent when thread safety is enabled.
+    /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
+    /// </summary>
+    [Fact]
+    public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
+    {
+        var db = new Db2DbMock { ThreadSafe = true };
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        Parallel.For(1, 41, id =>
+        {
+            using var connection = new Db2ConnectionMock(db);
+            connection.Open();
+            connection.Execute("INSERT INTO Users (Id, Name) VALUES (@Id, @Name)", new { Id = id, Name = $"Name{id}" });
+        });
+
+        Assert.Equal(40, table.Count);
+        Assert.Equal(40, table.Select(row => (int)row[0]!).Distinct().Count());
+    }
+}

--- a/src/DbSqlLikeMem.Db2/Db2ConnectionMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2ConnectionMock.cs
@@ -33,8 +33,8 @@ public sealed class Db2ConnectionMock
     /// PT: Cria um mock de transação DB2.
     /// </summary>
     /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
-    protected override DbTransaction CreateTransaction()
-        => new Db2TransactionMock(this);
+    protected override DbTransaction CreateTransaction(IsolationLevel isolationLevel)
+        => new Db2TransactionMock(this, isolationLevel);
 
     /// <summary>
     /// EN: Creates a DB2 command mock for the transaction.

--- a/src/DbSqlLikeMem.Db2/Db2TransactionMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2TransactionMock.cs
@@ -50,6 +50,39 @@ public class Db2TransactionMock(
     }
 
     /// <summary>
+    /// EN: Creates a savepoint in the active transaction.
+    /// PT: Cria um savepoint na transação ativa.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Save(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.CreateSavepoint(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Rolls back to a named savepoint.
+    /// PT: Executa rollback para um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Rollback(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.RollbackTransaction(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Releases a named savepoint.
+    /// PT: Libera um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Release(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.ReleaseSavepoint(savepointName);
+    }
+
+    /// <summary>
     /// EN: Disposes the transaction resources.
     /// PT: Descarta os recursos da transação.
     /// </summary>

--- a/src/DbSqlLikeMem.MySql.Test/MySqlTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlTransactionReliabilityTests.cs
@@ -1,0 +1,98 @@
+namespace DbSqlLikeMem.MySql.Test;
+
+/// <summary>
+/// EN: Validates transactional reliability additions for P11 scenarios.
+/// PT: Valida as adições de confiabilidade transacional para cenários do P11.
+/// </summary>
+public sealed class MySqlTransactionReliabilityTests
+{
+    /// <summary>
+    /// EN: Ensures rolling back to a savepoint restores the intermediate state.
+    /// PT: Garante que rollback para savepoint restaure o estado intermediário.
+    /// </summary>
+    [Fact]
+    public void SavepointRollbackShouldRestoreIntermediateState()
+    {
+        var db = new MySqlDbMock();
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        using var connection = new MySqlConnectionMock(db);
+        connection.Open();
+        using var transaction = (MySqlTransactionMock)connection.BeginTransaction();
+
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (1, 'John')", transaction: transaction);
+        transaction.Save("sp_users");
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (2, 'Mary')", transaction: transaction);
+
+        transaction.Rollback("sp_users");
+        transaction.Commit();
+
+        Assert.Single(table);
+        Assert.Equal(1, table[0][0]);
+    }
+
+    /// <summary>
+    /// EN: Ensures the simplified isolation model is deterministic and visible.
+    /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
+    /// </summary>
+    [Fact]
+    public void IsolationLevelShouldBeExposedDeterministically()
+    {
+        var db = new MySqlDbMock();
+        using var connection = new MySqlConnectionMock(db);
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction(IsolationLevel.Serializable);
+
+        Assert.Equal(IsolationLevel.Serializable, transaction.IsolationLevel);
+        Assert.Equal(IsolationLevel.Serializable, connection.CurrentIsolationLevel);
+    }
+
+    /// <summary>
+    /// EN: Ensures savepoint release support follows provider compatibility rules.
+    /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
+    /// </summary>
+    [Fact]
+    public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
+    {
+        var db = new MySqlDbMock();
+        using var connection = new MySqlConnectionMock(db);
+        connection.Open();
+
+        using var transaction = (MySqlTransactionMock)connection.BeginTransaction();
+        transaction.Save("sp_release");
+
+        if (true)
+        {
+            transaction.Release("sp_release");
+            return;
+        }
+
+        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+    }
+
+    /// <summary>
+    /// EN: Ensures concurrent writes keep data consistent when thread safety is enabled.
+    /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
+    /// </summary>
+    [Fact]
+    public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
+    {
+        var db = new MySqlDbMock { ThreadSafe = true };
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        Parallel.For(1, 41, id =>
+        {
+            using var connection = new MySqlConnectionMock(db);
+            connection.Open();
+            connection.Execute("INSERT INTO Users (Id, Name) VALUES (@Id, @Name)", new { Id = id, Name = $"Name{id}" });
+        });
+
+        Assert.Equal(40, table.Count);
+        Assert.Equal(40, table.Select(row => (int)row[0]!).Distinct().Count());
+    }
+}

--- a/src/DbSqlLikeMem.MySql/MySqlConnectionMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlConnectionMock.cs
@@ -27,8 +27,8 @@ public sealed class MySqlConnectionMock
     /// PT: Cria um mock de transação MySQL.
     /// </summary>
     /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
-    protected override DbTransaction CreateTransaction()
-        => new MySqlTransactionMock(this);
+    protected override DbTransaction CreateTransaction(IsolationLevel isolationLevel)
+        => new MySqlTransactionMock(this, isolationLevel);
 
     /// <summary>
     /// EN: Creates a MySQL command mock for the transaction.

--- a/src/DbSqlLikeMem.MySql/MySqlTransactionMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlTransactionMock.cs
@@ -49,6 +49,39 @@ public class MySqlTransactionMock(
     }
 
     /// <summary>
+    /// EN: Creates a savepoint in the active transaction.
+    /// PT: Cria um savepoint na transação ativa.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Save(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.CreateSavepoint(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Rolls back to a named savepoint.
+    /// PT: Executa rollback para um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Rollback(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.RollbackTransaction(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Releases a named savepoint.
+    /// PT: Libera um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Release(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.ReleaseSavepoint(savepointName);
+    }
+
+    /// <summary>
     /// EN: Disposes the transaction resources.
     /// PT: Descarta os recursos da transação.
     /// </summary>

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlTransactionReliabilityTests.cs
@@ -1,0 +1,98 @@
+namespace DbSqlLikeMem.Npgsql.Test;
+
+/// <summary>
+/// EN: Validates transactional reliability additions for P11 scenarios.
+/// PT: Valida as adições de confiabilidade transacional para cenários do P11.
+/// </summary>
+public sealed class PostgreSqlTransactionReliabilityTests
+{
+    /// <summary>
+    /// EN: Ensures rolling back to a savepoint restores the intermediate state.
+    /// PT: Garante que rollback para savepoint restaure o estado intermediário.
+    /// </summary>
+    [Fact]
+    public void SavepointRollbackShouldRestoreIntermediateState()
+    {
+        var db = new NpgsqlDbMock();
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        using var connection = new NpgsqlConnectionMock(db);
+        connection.Open();
+        using var transaction = (NpgsqlTransactionMock)connection.BeginTransaction();
+
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (1, 'John')", transaction: transaction);
+        transaction.Save("sp_users");
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (2, 'Mary')", transaction: transaction);
+
+        transaction.Rollback("sp_users");
+        transaction.Commit();
+
+        Assert.Single(table);
+        Assert.Equal(1, table[0][0]);
+    }
+
+    /// <summary>
+    /// EN: Ensures the simplified isolation model is deterministic and visible.
+    /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
+    /// </summary>
+    [Fact]
+    public void IsolationLevelShouldBeExposedDeterministically()
+    {
+        var db = new NpgsqlDbMock();
+        using var connection = new NpgsqlConnectionMock(db);
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction(IsolationLevel.Serializable);
+
+        Assert.Equal(IsolationLevel.Serializable, transaction.IsolationLevel);
+        Assert.Equal(IsolationLevel.Serializable, connection.CurrentIsolationLevel);
+    }
+
+    /// <summary>
+    /// EN: Ensures savepoint release support follows provider compatibility rules.
+    /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
+    /// </summary>
+    [Fact]
+    public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
+    {
+        var db = new NpgsqlDbMock();
+        using var connection = new NpgsqlConnectionMock(db);
+        connection.Open();
+
+        using var transaction = (NpgsqlTransactionMock)connection.BeginTransaction();
+        transaction.Save("sp_release");
+
+        if (true)
+        {
+            transaction.Release("sp_release");
+            return;
+        }
+
+        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+    }
+
+    /// <summary>
+    /// EN: Ensures concurrent writes keep data consistent when thread safety is enabled.
+    /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
+    /// </summary>
+    [Fact]
+    public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
+    {
+        var db = new NpgsqlDbMock { ThreadSafe = true };
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        Parallel.For(1, 41, id =>
+        {
+            using var connection = new NpgsqlConnectionMock(db);
+            connection.Open();
+            connection.Execute("INSERT INTO Users (Id, Name) VALUES (@Id, @Name)", new { Id = id, Name = $"Name{id}" });
+        });
+
+        Assert.Equal(40, table.Count);
+        Assert.Equal(40, table.Select(row => (int)row[0]!).Distinct().Count());
+    }
+}

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlConnectionMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlConnectionMock.cs
@@ -31,8 +31,8 @@ public sealed class NpgsqlConnectionMock
     /// PT: Cria um mock de transação PostgreSQL.
     /// </summary>
     /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
-    protected override DbTransaction CreateTransaction()
-        => new NpgsqlTransactionMock(this);
+    protected override DbTransaction CreateTransaction(IsolationLevel isolationLevel)
+        => new NpgsqlTransactionMock(this, isolationLevel);
 
     /// <summary>
     /// EN: Creates a PostgreSQL command mock for the transaction.

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlTransactionMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlTransactionMock.cs
@@ -50,6 +50,39 @@ public sealed class NpgsqlTransactionMock(
     }
 
     /// <summary>
+    /// EN: Creates a savepoint in the active transaction.
+    /// PT: Cria um savepoint na transação ativa.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Save(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.CreateSavepoint(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Rolls back to a named savepoint.
+    /// PT: Executa rollback para um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Rollback(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.RollbackTransaction(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Releases a named savepoint.
+    /// PT: Libera um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Release(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.ReleaseSavepoint(savepointName);
+    }
+
+    /// <summary>
     /// EN: Disposes the transaction resources.
     /// PT: Descarta os recursos da transação.
     /// </summary>

--- a/src/DbSqlLikeMem.Oracle.Test/OracleTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleTransactionReliabilityTests.cs
@@ -1,0 +1,98 @@
+namespace DbSqlLikeMem.Oracle.Test;
+
+/// <summary>
+/// EN: Validates transactional reliability additions for P11 scenarios.
+/// PT: Valida as adições de confiabilidade transacional para cenários do P11.
+/// </summary>
+public sealed class OracleTransactionReliabilityTests
+{
+    /// <summary>
+    /// EN: Ensures rolling back to a savepoint restores the intermediate state.
+    /// PT: Garante que rollback para savepoint restaure o estado intermediário.
+    /// </summary>
+    [Fact]
+    public void SavepointRollbackShouldRestoreIntermediateState()
+    {
+        var db = new OracleDbMock();
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        using var connection = new OracleConnectionMock(db);
+        connection.Open();
+        using var transaction = (OracleTransactionMock)connection.BeginTransaction();
+
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (1, 'John')", transaction: transaction);
+        transaction.Save("sp_users");
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (2, 'Mary')", transaction: transaction);
+
+        transaction.Rollback("sp_users");
+        transaction.Commit();
+
+        Assert.Single(table);
+        Assert.Equal(1, table[0][0]);
+    }
+
+    /// <summary>
+    /// EN: Ensures the simplified isolation model is deterministic and visible.
+    /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
+    /// </summary>
+    [Fact]
+    public void IsolationLevelShouldBeExposedDeterministically()
+    {
+        var db = new OracleDbMock();
+        using var connection = new OracleConnectionMock(db);
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction(IsolationLevel.Serializable);
+
+        Assert.Equal(IsolationLevel.Serializable, transaction.IsolationLevel);
+        Assert.Equal(IsolationLevel.Serializable, connection.CurrentIsolationLevel);
+    }
+
+    /// <summary>
+    /// EN: Ensures savepoint release support follows provider compatibility rules.
+    /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
+    /// </summary>
+    [Fact]
+    public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
+    {
+        var db = new OracleDbMock();
+        using var connection = new OracleConnectionMock(db);
+        connection.Open();
+
+        using var transaction = (OracleTransactionMock)connection.BeginTransaction();
+        transaction.Save("sp_release");
+
+        if (true)
+        {
+            transaction.Release("sp_release");
+            return;
+        }
+
+        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+    }
+
+    /// <summary>
+    /// EN: Ensures concurrent writes keep data consistent when thread safety is enabled.
+    /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
+    /// </summary>
+    [Fact]
+    public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
+    {
+        var db = new OracleDbMock { ThreadSafe = true };
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        Parallel.For(1, 41, id =>
+        {
+            using var connection = new OracleConnectionMock(db);
+            connection.Open();
+            connection.Execute("INSERT INTO Users (Id, Name) VALUES (@Id, @Name)", new { Id = id, Name = $"Name{id}" });
+        });
+
+        Assert.Equal(40, table.Count);
+        Assert.Equal(40, table.Select(row => (int)row[0]!).Distinct().Count());
+    }
+}

--- a/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
@@ -91,6 +91,9 @@ public class OracleCommandMock(
 
         var sqlRaw = CommandText.Trim();
 
+        if (TryExecuteTransactionControlCommand(sqlRaw, out var transactionControlResult))
+            return transactionControlResult;
+
         // Mantém atalhos existentes (CALL / CREATE TABLE AS SELECT) por compatibilidade do engine atual
         if (sqlRaw.StartsWith("call ", StringComparison.OrdinalIgnoreCase))
             return connection!.ExecuteCall(sqlRaw, Parameters);
@@ -183,6 +186,59 @@ public class OracleCommandMock(
         connection.Metrics.Selects += tables.Sum(t => t.Count);
 
         return new OracleDataReaderMock(tables);
+    }
+
+
+    private bool TryExecuteTransactionControlCommand(string sqlRaw, out int affectedRows)
+    {
+        affectedRows = 0;
+
+        ArgumentNullExceptionCompatible.ThrowIfNull(connection, nameof(connection));
+
+        if (sqlRaw.Equals("begin", StringComparison.OrdinalIgnoreCase) ||
+            sqlRaw.Equals("begin transaction", StringComparison.OrdinalIgnoreCase) ||
+            sqlRaw.Equals("start transaction", StringComparison.OrdinalIgnoreCase))
+        {
+            if (connection!.State != ConnectionState.Open)
+                connection.Open();
+
+            if (!connection.HasActiveTransaction)
+                connection.BeginTransaction();
+
+            return true;
+        }
+
+        if (sqlRaw.StartsWith("savepoint ", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.CreateSavepoint(sqlRaw[10..].Trim());
+            return true;
+        }
+
+        if (sqlRaw.StartsWith("rollback to savepoint ", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.RollbackTransaction(sqlRaw[22..].Trim());
+            return true;
+        }
+
+        if (sqlRaw.StartsWith("release savepoint ", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.ReleaseSavepoint(sqlRaw[18..].Trim());
+            return true;
+        }
+
+        if (sqlRaw.Equals("commit", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.CommitTransaction();
+            return true;
+        }
+
+        if (sqlRaw.Equals("rollback", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.RollbackTransaction();
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Oracle/OracleConnectionMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleConnectionMock.cs
@@ -35,8 +35,8 @@ public class OracleConnectionMock
     /// PT: Cria um mock de transação Oracle.
     /// </summary>
     /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
-    protected override DbTransaction CreateTransaction()
-        => new OracleTransactionMock(this);
+    protected override DbTransaction CreateTransaction(IsolationLevel isolationLevel)
+        => new OracleTransactionMock(this, isolationLevel);
 
     /// <summary>
     /// EN: Creates an Oracle command mock for the transaction.

--- a/src/DbSqlLikeMem.Oracle/OracleTransactionMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleTransactionMock.cs
@@ -50,6 +50,39 @@ public sealed class OracleTransactionMock(
     }
 
     /// <summary>
+    /// EN: Creates a savepoint in the active transaction.
+    /// PT: Cria um savepoint na transação ativa.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Save(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.CreateSavepoint(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Rolls back to a named savepoint.
+    /// PT: Executa rollback para um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Rollback(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.RollbackTransaction(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Releases a named savepoint.
+    /// PT: Libera um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Release(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.ReleaseSavepoint(savepointName);
+    }
+
+    /// <summary>
     /// EN: Disposes the transaction resources.
     /// PT: Descarta os recursos da transação.
     /// </summary>

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerTransactionReliabilityTests.cs
@@ -1,0 +1,98 @@
+namespace DbSqlLikeMem.SqlServer.Test;
+
+/// <summary>
+/// EN: Validates transactional reliability additions for P11 scenarios.
+/// PT: Valida as adições de confiabilidade transacional para cenários do P11.
+/// </summary>
+public sealed class SqlServerTransactionReliabilityTests
+{
+    /// <summary>
+    /// EN: Ensures rolling back to a savepoint restores the intermediate state.
+    /// PT: Garante que rollback para savepoint restaure o estado intermediário.
+    /// </summary>
+    [Fact]
+    public void SavepointRollbackShouldRestoreIntermediateState()
+    {
+        var db = new SqlServerDbMock();
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        using var connection = new SqlServerConnectionMock(db);
+        connection.Open();
+        using var transaction = (SqlServerTransactionMock)connection.BeginTransaction();
+
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (1, 'John')", transaction: transaction);
+        transaction.Save("sp_users");
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (2, 'Mary')", transaction: transaction);
+
+        transaction.Rollback("sp_users");
+        transaction.Commit();
+
+        Assert.Single(table);
+        Assert.Equal(1, table[0][0]);
+    }
+
+    /// <summary>
+    /// EN: Ensures the simplified isolation model is deterministic and visible.
+    /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
+    /// </summary>
+    [Fact]
+    public void IsolationLevelShouldBeExposedDeterministically()
+    {
+        var db = new SqlServerDbMock();
+        using var connection = new SqlServerConnectionMock(db);
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction(IsolationLevel.Serializable);
+
+        Assert.Equal(IsolationLevel.Serializable, transaction.IsolationLevel);
+        Assert.Equal(IsolationLevel.Serializable, connection.CurrentIsolationLevel);
+    }
+
+    /// <summary>
+    /// EN: Ensures savepoint release support follows provider compatibility rules.
+    /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
+    /// </summary>
+    [Fact]
+    public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
+    {
+        var db = new SqlServerDbMock();
+        using var connection = new SqlServerConnectionMock(db);
+        connection.Open();
+
+        using var transaction = (SqlServerTransactionMock)connection.BeginTransaction();
+        transaction.Save("sp_release");
+
+        if (false)
+        {
+            transaction.Release("sp_release");
+            return;
+        }
+
+        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+    }
+
+    /// <summary>
+    /// EN: Ensures concurrent writes keep data consistent when thread safety is enabled.
+    /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
+    /// </summary>
+    [Fact]
+    public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
+    {
+        var db = new SqlServerDbMock { ThreadSafe = true };
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        Parallel.For(1, 41, id =>
+        {
+            using var connection = new SqlServerConnectionMock(db);
+            connection.Open();
+            connection.Execute("INSERT INTO Users (Id, Name) VALUES (@Id, @Name)", new { Id = id, Name = $"Name{id}" });
+        });
+
+        Assert.Equal(40, table.Count);
+        Assert.Equal(40, table.Select(row => (int)row[0]!).Distinct().Count());
+    }
+}

--- a/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
@@ -92,6 +92,9 @@ public class SqlServerCommandMock(
 
         var sqlRaw = CommandText.Trim();
 
+        if (TryExecuteTransactionControlCommand(sqlRaw, out var transactionControlResult))
+            return transactionControlResult;
+
         // Mantém atalhos existentes (CALL / CREATE TABLE AS SELECT) por compatibilidade do engine atual
         if (sqlRaw.StartsWith("call ", StringComparison.OrdinalIgnoreCase))
             return connection!.ExecuteCall(sqlRaw, Parameters);
@@ -187,6 +190,59 @@ public class SqlServerCommandMock(
         connection.Metrics.Selects += tables.Sum(t => t.Count);
 
         return new SqlServerDataReaderMock(tables);
+    }
+
+
+    private bool TryExecuteTransactionControlCommand(string sqlRaw, out int affectedRows)
+    {
+        affectedRows = 0;
+
+        ArgumentNullExceptionCompatible.ThrowIfNull(connection, nameof(connection));
+
+        if (sqlRaw.Equals("begin", StringComparison.OrdinalIgnoreCase) ||
+            sqlRaw.Equals("begin transaction", StringComparison.OrdinalIgnoreCase) ||
+            sqlRaw.Equals("start transaction", StringComparison.OrdinalIgnoreCase))
+        {
+            if (connection!.State != ConnectionState.Open)
+                connection.Open();
+
+            if (!connection.HasActiveTransaction)
+                connection.BeginTransaction();
+
+            return true;
+        }
+
+        if (sqlRaw.StartsWith("savepoint ", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.CreateSavepoint(sqlRaw[10..].Trim());
+            return true;
+        }
+
+        if (sqlRaw.StartsWith("rollback to savepoint ", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.RollbackTransaction(sqlRaw[22..].Trim());
+            return true;
+        }
+
+        if (sqlRaw.StartsWith("release savepoint ", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.ReleaseSavepoint(sqlRaw[18..].Trim());
+            return true;
+        }
+
+        if (sqlRaw.Equals("commit", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.CommitTransaction();
+            return true;
+        }
+
+        if (sqlRaw.Equals("rollback", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.RollbackTransaction();
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.SqlServer/SqlServerConnectionMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerConnectionMock.cs
@@ -31,8 +31,8 @@ public sealed class SqlServerConnectionMock
     /// PT: Cria um mock de transação SQL Server.
     /// </summary>
     /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
-    protected override DbTransaction CreateTransaction()
-        => new SqlServerTransactionMock(this);
+    protected override DbTransaction CreateTransaction(IsolationLevel isolationLevel)
+        => new SqlServerTransactionMock(this, isolationLevel);
 
     /// <summary>
     /// EN: Creates a SQL Server command mock for the transaction.
@@ -42,6 +42,12 @@ public sealed class SqlServerConnectionMock
     /// <returns>EN: Command instance. PT: Instância do comando.</returns>
     protected override DbCommand CreateDbCommandCore(DbTransaction? transaction)
         => new SqlServerCommandMock(this, transaction as SqlServerTransactionMock);
+
+    /// <summary>
+    /// EN: SQL Server mock does not support RELEASE SAVEPOINT syntax.
+    /// PT: O mock SQL Server não suporta sintaxe RELEASE SAVEPOINT.
+    /// </summary>
+    protected override bool SupportsReleaseSavepoint => false;
 
     internal override Exception NewException(string message, int code)
         => new SqlServerMockException(message, code);

--- a/src/DbSqlLikeMem.SqlServer/SqlServerTransactionMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerTransactionMock.cs
@@ -50,6 +50,39 @@ public sealed class SqlServerTransactionMock(
     }
 
     /// <summary>
+    /// EN: Creates a savepoint in the active transaction.
+    /// PT: Cria um savepoint na transação ativa.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Save(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.CreateSavepoint(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Rolls back to a named savepoint.
+    /// PT: Executa rollback para um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Rollback(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.RollbackTransaction(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Releases a named savepoint.
+    /// PT: Libera um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Release(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.ReleaseSavepoint(savepointName);
+    }
+
+    /// <summary>
     /// EN: Disposes the transaction resources.
     /// PT: Descarta os recursos da transação.
     /// </summary>

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteTransactionReliabilityTests.cs
@@ -1,0 +1,98 @@
+namespace DbSqlLikeMem.Sqlite.Test;
+
+/// <summary>
+/// EN: Validates transactional reliability additions for P11 scenarios.
+/// PT: Valida as adições de confiabilidade transacional para cenários do P11.
+/// </summary>
+public sealed class SqliteTransactionReliabilityTests
+{
+    /// <summary>
+    /// EN: Ensures rolling back to a savepoint restores the intermediate state.
+    /// PT: Garante que rollback para savepoint restaure o estado intermediário.
+    /// </summary>
+    [Fact]
+    public void SavepointRollbackShouldRestoreIntermediateState()
+    {
+        var db = new SqliteDbMock();
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        using var connection = new SqliteConnectionMock(db);
+        connection.Open();
+        using var transaction = (SqliteTransactionMock)connection.BeginTransaction();
+
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (1, 'John')", transaction: transaction);
+        transaction.Save("sp_users");
+        connection.Execute("INSERT INTO Users (Id, Name) VALUES (2, 'Mary')", transaction: transaction);
+
+        transaction.Rollback("sp_users");
+        transaction.Commit();
+
+        Assert.Single(table);
+        Assert.Equal(1, table[0][0]);
+    }
+
+    /// <summary>
+    /// EN: Ensures the simplified isolation model is deterministic and visible.
+    /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
+    /// </summary>
+    [Fact]
+    public void IsolationLevelShouldBeExposedDeterministically()
+    {
+        var db = new SqliteDbMock();
+        using var connection = new SqliteConnectionMock(db);
+        connection.Open();
+
+        using var transaction = connection.BeginTransaction(IsolationLevel.Serializable);
+
+        Assert.Equal(IsolationLevel.Serializable, transaction.IsolationLevel);
+        Assert.Equal(IsolationLevel.Serializable, connection.CurrentIsolationLevel);
+    }
+
+    /// <summary>
+    /// EN: Ensures savepoint release support follows provider compatibility rules.
+    /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
+    /// </summary>
+    [Fact]
+    public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
+    {
+        var db = new SqliteDbMock();
+        using var connection = new SqliteConnectionMock(db);
+        connection.Open();
+
+        using var transaction = (SqliteTransactionMock)connection.BeginTransaction();
+        transaction.Save("sp_release");
+
+        if (true)
+        {
+            transaction.Release("sp_release");
+            return;
+        }
+
+        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+    }
+
+    /// <summary>
+    /// EN: Ensures concurrent writes keep data consistent when thread safety is enabled.
+    /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
+    /// </summary>
+    [Fact]
+    public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
+    {
+        var db = new SqliteDbMock { ThreadSafe = true };
+        var table = db.AddTable("Users");
+        table.Columns["Id"] = new(0, DbType.Int32, false);
+        table.Columns["Name"] = new(1, DbType.String, false);
+
+        Parallel.For(1, 41, id =>
+        {
+            using var connection = new SqliteConnectionMock(db);
+            connection.Open();
+            connection.Execute("INSERT INTO Users (Id, Name) VALUES (@Id, @Name)", new { Id = id, Name = $"Name{id}" });
+        });
+
+        Assert.Equal(40, table.Count);
+        Assert.Equal(40, table.Select(row => (int)row[0]!).Distinct().Count());
+    }
+}

--- a/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
@@ -96,6 +96,9 @@ public class SqliteCommandMock(
 
         var sqlRaw = CommandText.Trim();
 
+        if (TryExecuteTransactionControlCommand(sqlRaw, out var transactionControlResult))
+            return transactionControlResult;
+
         // 2. Comandos especiais que talvez o Parser ainda não suporte nativamente (DDL, CALL)
         if (sqlRaw.StartsWith("call ", StringComparison.OrdinalIgnoreCase))
         {
@@ -220,6 +223,59 @@ public class SqliteCommandMock(
         connection.Metrics.Selects += tables.Sum(t => t.Count);
 
         return new SqliteDataReaderMock(tables);
+    }
+
+
+    private bool TryExecuteTransactionControlCommand(string sqlRaw, out int affectedRows)
+    {
+        affectedRows = 0;
+
+        ArgumentNullExceptionCompatible.ThrowIfNull(connection, nameof(connection));
+
+        if (sqlRaw.Equals("begin", StringComparison.OrdinalIgnoreCase) ||
+            sqlRaw.Equals("begin transaction", StringComparison.OrdinalIgnoreCase) ||
+            sqlRaw.Equals("start transaction", StringComparison.OrdinalIgnoreCase))
+        {
+            if (connection!.State != ConnectionState.Open)
+                connection.Open();
+
+            if (!connection.HasActiveTransaction)
+                connection.BeginTransaction();
+
+            return true;
+        }
+
+        if (sqlRaw.StartsWith("savepoint ", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.CreateSavepoint(sqlRaw[10..].Trim());
+            return true;
+        }
+
+        if (sqlRaw.StartsWith("rollback to savepoint ", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.RollbackTransaction(sqlRaw[22..].Trim());
+            return true;
+        }
+
+        if (sqlRaw.StartsWith("release savepoint ", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.ReleaseSavepoint(sqlRaw[18..].Trim());
+            return true;
+        }
+
+        if (sqlRaw.Equals("commit", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.CommitTransaction();
+            return true;
+        }
+
+        if (sqlRaw.Equals("rollback", StringComparison.OrdinalIgnoreCase))
+        {
+            connection!.RollbackTransaction();
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Sqlite/SqliteConnectionMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteConnectionMock.cs
@@ -29,8 +29,8 @@ public sealed class SqliteConnectionMock
     /// PT: Cria um mock de transação SQLite.
     /// </summary>
     /// <returns>EN: Transaction instance. PT: Instância da transação.</returns>
-    protected override DbTransaction CreateTransaction()
-        => new SqliteTransactionMock(this);
+    protected override DbTransaction CreateTransaction(IsolationLevel isolationLevel)
+        => new SqliteTransactionMock(this, isolationLevel);
 
     /// <summary>
     /// EN: Creates a SQLite command mock for the transaction.

--- a/src/DbSqlLikeMem.Sqlite/SqliteTransactionMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteTransactionMock.cs
@@ -50,6 +50,39 @@ public class SqliteTransactionMock(
     }
 
     /// <summary>
+    /// EN: Creates a savepoint in the active transaction.
+    /// PT: Cria um savepoint na transação ativa.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Save(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.CreateSavepoint(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Rolls back to a named savepoint.
+    /// PT: Executa rollback para um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Rollback(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.RollbackTransaction(savepointName);
+    }
+
+    /// <summary>
+    /// EN: Releases a named savepoint.
+    /// PT: Libera um savepoint nomeado.
+    /// </summary>
+    /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
+    public void Release(string savepointName)
+    {
+        lock (cnn.Db.SyncRoot)
+            cnn.ReleaseSavepoint(savepointName);
+    }
+
+    /// <summary>
     /// EN: Disposes the transaction resources.
     /// PT: Descarta os recursos da transação.
     /// </summary>

--- a/src/DbSqlLikeMem/Models/DbMock.cs
+++ b/src/DbSqlLikeMem/Models/DbMock.cs
@@ -362,6 +362,16 @@ public abstract class DbMock
 
     #endregion
 
+
+    internal virtual IReadOnlyList<ITableMock> ListAllTablesBestEffort()
+    {
+        var allTables = new List<ITableMock>();
+        foreach (var schema in Values)
+            allTables.AddRange(schema.Tables.Values);
+        allTables.AddRange(_globalTemporaryTables.Values);
+        return allTables;
+    }
+
     #region Backup / Restore (best-effort)
 
     internal virtual void BackupAllTablesBestEffort()


### PR DESCRIPTION
### Motivation
- Implement P11 (transactional reliability and concurrency) across MySQL, SQL Server, Oracle, PostgreSQL (Npgsql), SQLite and DB2 following the incremental provider-by-provider pattern used in P7–P10. 
- Provide deterministic savepoint semantics, a simplified isolation model and reliable commit/rollback semantics in the in-memory mock so tests are reproducible. 
- Keep provider differences isolated (dialect/connection/transaction layer) and avoid duplicating DML executor logic.

### Description
- Core: added snapshot-based savepoint lifecycle to `DbConnectionMockBase` (create savepoint / rollback to savepoint / release savepoint), `CurrentIsolationLevel` and `HasActiveTransaction`, plus `CreateSavepoint`, `RollbackTransaction(savepointName)` and `ReleaseSavepoint` APIs and thread-safety via `Db.SyncRoot` when `ThreadSafe = true`.
- Storage: added `ListAllTablesBestEffort()` to `DbMock` and snapshot/restore helpers so savepoints capture table rows and `NextIdentity` deterministically and restore indexes on rollback.
- Providers: changed `BeginTransaction`/`CreateTransaction` to accept `IsolationLevel`, updated all provider `ConnectionMock` to forward the isolation, added `Save`/`Rollback(savepointName)`/`Release` helpers to provider `TransactionMock`s, and implemented provider command handling for transaction-control SQL in `*CommandMock.cs` (BEGIN/START, SAVEPOINT, ROLLBACK TO SAVEPOINT, RELEASE SAVEPOINT, COMMIT, ROLLBACK).
- Tests & docs: added per-provider reliability tests that cover savepoint rollback, isolation visibility, provider-specific release behavior and concurrent inserts with `ThreadSafe=true`, and updated `docs/providers-and-features.md` with a P11 compatibility matrix (SQL Server explicitly marks `RELEASE SAVEPOINT` as not supported in this mock with a clear message).

### Testing
- Attempted to run transaction tests with `dotnet test --filter "*TransactionTests*"`, but the environment lacks the .NET SDK/CLI (`dotnet: command not found`), so automated unit tests were not executed here (failure: environment limitation).
- New automated tests were added for each provider: `MySqlTransactionReliabilityTests`, `SqlServerTransactionReliabilityTests`, `OracleTransactionReliabilityTests`, `PostgreSqlTransactionReliabilityTests`, `SqliteTransactionReliabilityTests`, and `Db2TransactionReliabilityTests` (files committed), and should be run in CI using `dotnet test` per project.
- Repository-level verification performed: created/committed changes and updated documentation; please run `dotnet test` in a CI or local environment to validate all tests (expected passing after build in a full .NET environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e563c30d0832caadf97814284eb34)