### PR TITLE
Fix CS0114/CS0162/CS1591 warnings in transaction mocks and tests

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Db2TransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2TransactionReliabilityTests.cs
@@ -64,13 +64,7 @@ public sealed class Db2TransactionReliabilityTests
         using var transaction = (Db2TransactionMock)connection.BeginTransaction();
         transaction.Save("sp_release");
 
-        if (true)
-        {
-            transaction.Release("sp_release");
-            return;
-        }
-
-        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+        transaction.Release("sp_release");
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Db2/Db2TransactionMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2TransactionMock.cs
@@ -54,7 +54,11 @@ public class Db2TransactionMock(
     /// PT: Cria um savepoint na transação ativa.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Save(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Save(string savepointName)
+#else
+    public new void Save(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.CreateSavepoint(savepointName);
@@ -65,7 +69,11 @@ public class Db2TransactionMock(
     /// PT: Executa rollback para um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Rollback(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Rollback(string savepointName)
+#else
+    public new void Rollback(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.RollbackTransaction(savepointName);
@@ -76,7 +84,11 @@ public class Db2TransactionMock(
     /// PT: Libera um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Release(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Release(string savepointName)
+#else
+    public new void Release(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.ReleaseSavepoint(savepointName);

--- a/src/DbSqlLikeMem.MySql.Test/MySqlTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlTransactionReliabilityTests.cs
@@ -64,13 +64,7 @@ public sealed class MySqlTransactionReliabilityTests
         using var transaction = (MySqlTransactionMock)connection.BeginTransaction();
         transaction.Save("sp_release");
 
-        if (true)
-        {
-            transaction.Release("sp_release");
-            return;
-        }
-
-        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+        transaction.Release("sp_release");
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs
@@ -316,6 +316,10 @@ public sealed class MySqlUpdateStrategyTests(
     }
 
 
+    /// <summary>
+    /// EN: Recomputes persisted generated columns during update and preserves unique index consistency.
+    /// PT: Recalcula colunas geradas persistidas durante update e preserva a consistência de índices únicos.
+    /// </summary>
     [Fact]
     public void Update_ShouldRecomputePersistedGeneratedColumn_AndAllowUniqueIndex()
     {

--- a/src/DbSqlLikeMem.MySql/MySqlTransactionMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlTransactionMock.cs
@@ -53,7 +53,11 @@ public class MySqlTransactionMock(
     /// PT: Cria um savepoint na transação ativa.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Save(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Save(string savepointName)
+#else
+    public new void Save(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.CreateSavepoint(savepointName);
@@ -64,7 +68,11 @@ public class MySqlTransactionMock(
     /// PT: Executa rollback para um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Rollback(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Rollback(string savepointName)
+#else
+    public new void Rollback(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.RollbackTransaction(savepointName);
@@ -75,7 +83,11 @@ public class MySqlTransactionMock(
     /// PT: Libera um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Release(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Release(string savepointName)
+#else
+    public new void Release(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.ReleaseSavepoint(savepointName);

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlTransactionReliabilityTests.cs
@@ -64,13 +64,7 @@ public sealed class PostgreSqlTransactionReliabilityTests
         using var transaction = (NpgsqlTransactionMock)connection.BeginTransaction();
         transaction.Save("sp_release");
 
-        if (true)
-        {
-            transaction.Release("sp_release");
-            return;
-        }
-
-        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+        transaction.Release("sp_release");
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlTransactionMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlTransactionMock.cs
@@ -54,7 +54,11 @@ public sealed class NpgsqlTransactionMock(
     /// PT: Cria um savepoint na transação ativa.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Save(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Save(string savepointName)
+#else
+    public new void Save(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.CreateSavepoint(savepointName);
@@ -65,7 +69,11 @@ public sealed class NpgsqlTransactionMock(
     /// PT: Executa rollback para um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Rollback(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Rollback(string savepointName)
+#else
+    public new void Rollback(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.RollbackTransaction(savepointName);
@@ -76,7 +84,11 @@ public sealed class NpgsqlTransactionMock(
     /// PT: Libera um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Release(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Release(string savepointName)
+#else
+    public new void Release(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.ReleaseSavepoint(savepointName);

--- a/src/DbSqlLikeMem.Oracle.Test/OracleTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleTransactionReliabilityTests.cs
@@ -64,13 +64,7 @@ public sealed class OracleTransactionReliabilityTests
         using var transaction = (OracleTransactionMock)connection.BeginTransaction();
         transaction.Save("sp_release");
 
-        if (true)
-        {
-            transaction.Release("sp_release");
-            return;
-        }
-
-        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+        transaction.Release("sp_release");
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Oracle/OracleTransactionMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleTransactionMock.cs
@@ -54,7 +54,11 @@ public sealed class OracleTransactionMock(
     /// PT: Cria um savepoint na transação ativa.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Save(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Save(string savepointName)
+#else
+    public new void Save(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.CreateSavepoint(savepointName);
@@ -65,7 +69,11 @@ public sealed class OracleTransactionMock(
     /// PT: Executa rollback para um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Rollback(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Rollback(string savepointName)
+#else
+    public new void Rollback(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.RollbackTransaction(savepointName);
@@ -76,7 +84,11 @@ public sealed class OracleTransactionMock(
     /// PT: Libera um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Release(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Release(string savepointName)
+#else
+    public new void Release(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.ReleaseSavepoint(savepointName);

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerTransactionReliabilityTests.cs
@@ -64,12 +64,6 @@ public sealed class SqlServerTransactionReliabilityTests
         using var transaction = (SqlServerTransactionMock)connection.BeginTransaction();
         transaction.Save("sp_release");
 
-        if (false)
-        {
-            transaction.Release("sp_release");
-            return;
-        }
-
         Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
     }
 

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs
@@ -316,6 +316,10 @@ public sealed class SqlServerUpdateStrategyTests(
     }
 
 
+    /// <summary>
+    /// EN: Recomputes persisted generated columns during update and preserves unique index consistency.
+    /// PT: Recalcula colunas geradas persistidas durante update e preserva a consistência de índices únicos.
+    /// </summary>
     [Fact]
     public void Update_ShouldRecomputePersistedGeneratedColumn_AndAllowUniqueIndex()
     {

--- a/src/DbSqlLikeMem.SqlServer/SqlServerTransactionMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerTransactionMock.cs
@@ -54,7 +54,11 @@ public sealed class SqlServerTransactionMock(
     /// PT: Cria um savepoint na transação ativa.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Save(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Save(string savepointName)
+#else
+    public new void Save(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.CreateSavepoint(savepointName);
@@ -65,7 +69,11 @@ public sealed class SqlServerTransactionMock(
     /// PT: Executa rollback para um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Rollback(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Rollback(string savepointName)
+#else
+    public new void Rollback(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.RollbackTransaction(savepointName);
@@ -76,7 +84,11 @@ public sealed class SqlServerTransactionMock(
     /// PT: Libera um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Release(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Release(string savepointName)
+#else
+    public new void Release(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.ReleaseSavepoint(savepointName);

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteTransactionReliabilityTests.cs
@@ -64,13 +64,7 @@ public sealed class SqliteTransactionReliabilityTests
         using var transaction = (SqliteTransactionMock)connection.BeginTransaction();
         transaction.Save("sp_release");
 
-        if (true)
-        {
-            transaction.Release("sp_release");
-            return;
-        }
-
-        Assert.Throws<NotSupportedException>(() => transaction.Release("sp_release"));
+        transaction.Release("sp_release");
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Sqlite/SqliteTransactionMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteTransactionMock.cs
@@ -54,7 +54,11 @@ public class SqliteTransactionMock(
     /// PT: Cria um savepoint na transação ativa.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Save(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Save(string savepointName)
+#else
+    public new void Save(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.CreateSavepoint(savepointName);
@@ -65,7 +69,11 @@ public class SqliteTransactionMock(
     /// PT: Executa rollback para um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Rollback(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Rollback(string savepointName)
+#else
+    public new void Rollback(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.RollbackTransaction(savepointName);
@@ -76,7 +84,11 @@ public class SqliteTransactionMock(
     /// PT: Libera um savepoint nomeado.
     /// </summary>
     /// <param name="savepointName">EN: Savepoint name. PT: Nome do savepoint.</param>
-    public void Release(string savepointName)
+    #if NET6_0_OR_GREATER
+    public override void Release(string savepointName)
+#else
+    public new void Release(string savepointName)
+#endif
     {
         lock (cnn.Db.SyncRoot)
             cnn.ReleaseSavepoint(savepointName);


### PR DESCRIPTION
### Motivation
- Remove spurious compiler warnings reported during solution builds: `CS0114` (method hiding), `CS0162` (unreachable code from constant condition branches) and `CS1591` (missing XML docs on public test members). 

### Description
- For each provider transaction mock (`Db2`, `MySql`, `Npgsql`, `Oracle`, `Sqlite`, `SqlServer`) the savepoint APIs `Save`, `Rollback(string)` and `Release(string)` were changed to use `public override` under `#if NET6_0_OR_GREATER` and `public new` otherwise to avoid `CS0114` while preserving multi-target compatibility. 
- Simplified provider-specific tests that used constant `if (true)` / `if (false)` branches for savepoint `Release` by removing the dead branches and leaving the expected behavior per provider, eliminating `CS0162` warnings. 
- Added XML documentation comments to the previously undocumented public test methods `Update_ShouldRecomputePersistedGeneratedColumn_AndAllowUniqueIndex` in MySql and SqlServer test strategy files to address `CS1591`. 
- Changes span transaction mock files and reliability/strategy tests across providers to keep behavior unchanged while silencing compiler warnings. 

### Testing
- Attempted to run an automated full build with `dotnet build DbSqlLikeMem.sln -c Debug`, but the environment does not have `dotnet` installed so the build could not be executed (`dotnet: command not found`).
- Verified modifications with repository inspections (`rg`, file diffs and `git status`) and committed the changes locally; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e615ce96c832c85f0e542e65cc071)