### PR TITLE
Remove unnecessary `new` modifiers from transaction savepoint methods

### DIFF
--- a/src/DbSqlLikeMem.Db2/Db2TransactionMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2TransactionMock.cs
@@ -57,7 +57,7 @@ public class Db2TransactionMock(
     #if NET6_0_OR_GREATER
     public override void Save(string savepointName)
 #else
-    public new void Save(string savepointName)
+    public void Save(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -72,7 +72,7 @@ public class Db2TransactionMock(
     #if NET6_0_OR_GREATER
     public override void Rollback(string savepointName)
 #else
-    public new void Rollback(string savepointName)
+    public void Rollback(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -87,7 +87,7 @@ public class Db2TransactionMock(
     #if NET6_0_OR_GREATER
     public override void Release(string savepointName)
 #else
-    public new void Release(string savepointName)
+    public void Release(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)

--- a/src/DbSqlLikeMem.MySql/MySqlTransactionMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlTransactionMock.cs
@@ -56,7 +56,7 @@ public class MySqlTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Save(string savepointName)
 #else
-    public new void Save(string savepointName)
+    public void Save(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -71,7 +71,7 @@ public class MySqlTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Rollback(string savepointName)
 #else
-    public new void Rollback(string savepointName)
+    public void Rollback(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -86,7 +86,7 @@ public class MySqlTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Release(string savepointName)
 #else
-    public new void Release(string savepointName)
+    public void Release(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlTransactionMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlTransactionMock.cs
@@ -57,7 +57,7 @@ public sealed class NpgsqlTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Save(string savepointName)
 #else
-    public new void Save(string savepointName)
+    public void Save(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -72,7 +72,7 @@ public sealed class NpgsqlTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Rollback(string savepointName)
 #else
-    public new void Rollback(string savepointName)
+    public void Rollback(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -87,7 +87,7 @@ public sealed class NpgsqlTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Release(string savepointName)
 #else
-    public new void Release(string savepointName)
+    public void Release(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)

--- a/src/DbSqlLikeMem.Oracle/OracleTransactionMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleTransactionMock.cs
@@ -57,7 +57,7 @@ public sealed class OracleTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Save(string savepointName)
 #else
-    public new void Save(string savepointName)
+    public void Save(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -72,7 +72,7 @@ public sealed class OracleTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Rollback(string savepointName)
 #else
-    public new void Rollback(string savepointName)
+    public void Rollback(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -87,7 +87,7 @@ public sealed class OracleTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Release(string savepointName)
 #else
-    public new void Release(string savepointName)
+    public void Release(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)

--- a/src/DbSqlLikeMem.SqlServer/SqlServerTransactionMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerTransactionMock.cs
@@ -57,7 +57,7 @@ public sealed class SqlServerTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Save(string savepointName)
 #else
-    public new void Save(string savepointName)
+    public void Save(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -72,7 +72,7 @@ public sealed class SqlServerTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Rollback(string savepointName)
 #else
-    public new void Rollback(string savepointName)
+    public void Rollback(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -87,7 +87,7 @@ public sealed class SqlServerTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Release(string savepointName)
 #else
-    public new void Release(string savepointName)
+    public void Release(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)

--- a/src/DbSqlLikeMem.Sqlite/SqliteTransactionMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteTransactionMock.cs
@@ -57,7 +57,7 @@ public class SqliteTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Save(string savepointName)
 #else
-    public new void Save(string savepointName)
+    public void Save(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -72,7 +72,7 @@ public class SqliteTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Rollback(string savepointName)
 #else
-    public new void Rollback(string savepointName)
+    public void Rollback(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)
@@ -87,7 +87,7 @@ public class SqliteTransactionMock(
     #if NET6_0_OR_GREATER
     public override void Release(string savepointName)
 #else
-    public new void Release(string savepointName)
+    public void Release(string savepointName)
 #endif
     {
         lock (cnn.Db.SyncRoot)


### PR DESCRIPTION
### Motivation
- Eliminate CS0109 warnings caused by redundant `new` modifiers on savepoint-related methods in transaction mock classes.

### Description
- Removed the `new` keyword from `Save(string)`, `Rollback(string)`, and `Release(string)` in the non-`NET6_0_OR_GREATER` branches of transaction mock classes for Db2, MySql, Npgsql, Oracle, SqlServer, and Sqlite.
- Preserved the `#if NET6_0_OR_GREATER` conditional and the `override` declarations for .NET 6+ targets, changing only the fallback declarations.
- No behavioral changes were introduced; methods still call the same `cnn.*Savepoint`/`RollbackTransaction`/`ReleaseSavepoint` implementations.

### Testing
- Ran a repository search `rg -n "public new void (Save|Rollback|Release)\(" src` and confirmed there are no remaining matches.
- Attempted `dotnet build` but the build could not be executed in this environment because the `dotnet` CLI is unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e64f28bdc832ca13eb7ac5b9a4b64)