### PR TITLE
test/docs: restore duplicated tests and add rationale to preserve them

### DIFF
--- a/docs-test-duplication-rationale.md
+++ b/docs-test-duplication-rationale.md
@@ -1,0 +1,15 @@
+# Test duplication rationale (safety over reduction)
+
+Some test files intentionally repeat similar scenarios across classes/files.
+
+## Why we are keeping them
+- They protect against regressions in different wiring paths (for example, class-level fixtures, setup styles, and command/query call shapes).
+- They are used as a safety net while SQL compatibility and parser behavior are still evolving per provider.
+- Removing them without full mutation/coverage baseline could create blind spots.
+
+## Current policy
+- Prefer **keeping** duplicates unless there is clear evidence they are redundant and coverage-equivalent.
+- Before deduplicating, require:
+  1. Coverage comparison (before/after),
+  2. At least one full provider test run,
+  3. Explicit reviewer approval.


### PR DESCRIPTION
### Motivation
- The previous deduplication removed repeated provider-specific tests and raised concern about losing coverage for provider-specific wiring and SQL compatibility cases.
- Preserve safety by restoring the tests until coverage-equivalence can be validated and reviewers explicitly approve removal.

### Description
- Restored the duplicated test methods in `src/DbSqlLikeMem.*.Test/DapperUserTests2.cs` across all provider test projects so each project again contains the `QueryUserShouldReturnCorrectData`, `QueryMultipleShouldReturnMultipleUserResultSets`, and `QueryWithJoinShouldReturnJoinedData` scenarios.
- Restored the SqlServer-specific file `src/DbSqlLikeMem.SqlServer.Test/SqlServerSubqueryFromAndJoinsTests.cs` that had been removed by the prior change.
- Added `docs-test-duplication-rationale.md` to document the policy to keep intentional duplicates until coverage and provider test runs demonstrate safe deduplication.

### Testing
- Ran a Python inspection script that enumerates public test methods in `src/DbSqlLikeMem.*.Test/DapperUserTests2.cs` and verified each provider contains the expected test methods; the script completed successfully.
- Confirmed the SqlServer subquery tests file is present again via file inspection.
- Attempted to run provider test suites but `dotnet test` was unavailable in this environment, so runtime test execution could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e639176ec832c97025bab525b07f1)