### PR TITLE
Fix NuGet publish key resolution in GitHub Actions

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -30,10 +30,13 @@ jobs:
       - name: Publish to NuGet.org
         shell: bash
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          # Prefer GitHub Secret (secure), but allow fallback to repository/environment variable
+          # to avoid empty-key failures when the value was saved under Variables by mistake.
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY || vars.NUGET_API_KEY }}
         run: |
           if [ -z "$NUGET_API_KEY" ]; then
-            echo "::error::NUGET_API_KEY is empty. Configure it as a Repository secret or attach the job to a GitHub Environment that defines this secret."
+            echo "::error::NUGET_API_KEY is empty. Set it in Settings > Secrets and variables > Actions (recommended: Secrets)."
+            echo "::error::If you use Environment-level configuration, set 'environment:' in this job and define NUGET_API_KEY in that Environment."
             exit 1
           fi
 


### PR DESCRIPTION
### Motivation
- The NuGet publish job failed with `NUGET_API_KEY is empty` when the key was saved under repository Variables or when an Environment secret was used without binding `environment:` to the job, so the workflow needs a more robust resolution and clearer guidance.

### Description
- Updated `.github/workflows/nuget-publish.yml` to resolve `NUGET_API_KEY` from `secrets.NUGET_API_KEY` with a fallback to `vars.NUGET_API_KEY`.
- Improved the error output to instruct where to set the key in `Settings > Secrets and variables > Actions` and to explain how to use Environment-level secrets by adding `environment:` to the job.
- Committed the change and prepared a PR titled `Fix NuGet publish key resolution in GitHub Actions`.

### Testing
- Ran `git status --short && git diff -- .github/workflows/nuget-publish.yml` to verify the diff and the change is present (succeeded).
- Created the commit successfully with `git commit` (succeeded).
- Attempted to validate the YAML with a small Python snippet using `yaml.safe_load`, but it failed because the environment lacks the `PyYAML` module (automated check failed due to missing dependency).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e81eaa52c832cbce84f3f0c6d6cb3)