### PR TITLE
Fix VS2022 extension debug profiles and move tool window command to View > Other Windows

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMemExtension.vsct
+++ b/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMemExtension.vsct
@@ -6,7 +6,7 @@
   <Commands package="guidDbSqlLikeMemPackage">
     <Groups>
       <Group guid="guidDbSqlLikeMemCmdSet" id="DbSqlLikeMemGroup" priority="0x0600">
-        <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_VIEW" />
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_VIEW_OTHERWINDOWS" />
       </Group>
     </Groups>
 

--- a/src/DbSqlLikeMem.VisualStudioExtension/Properties/launchSettings.json
+++ b/src/DbSqlLikeMem.VisualStudioExtension/Properties/launchSettings.json
@@ -1,24 +1,16 @@
 {
   "profiles": {
-    "DbSqlLikeMem.VisualStudioExtension": {
-      "commandName": "Project"
-    },
-    "Profile 1": {
-      "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\Microsoft Visual Studio\\2026\\Community\\Common7\\IDE\\devenv.exe",
-      "commandLineArgs": "/rootsuffix Exp",
-      "workingDirectory": "C:\\Program Files\\Microsoft Visual Studio\\2026\\Community\\Common7\\IDE\\"
-    },
-    "Profile com log": {
-      "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\Microsoft Visual Studio\\2026\\Community\\Common7\\IDE\\devenv.exe",
-      "commandLineArgs": "/rootsuffix Exp /log",
-      "workingDirectory": "C:\\Program Files\\Microsoft Visual Studio\\2026\\Community\\Common7\\IDE\\"
-    },
-    "Profile 2022": {
+    "VS 2022 Experimental": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\Common7\\IDE\\devenv.exe",
-      "commandLineArgs": "/rootsuffix Exp"
+      "commandLineArgs": "/rootsuffix Exp",
+      "workingDirectory": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\Common7\\IDE\\"
+    },
+    "VS 2022 Experimental (Log)": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\Common7\\IDE\\devenv.exe",
+      "commandLineArgs": "/rootsuffix Exp /log",
+      "workingDirectory": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\Common7\\IDE\\"
     }
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure the VSIX tool window command appears in the expected Visual Studio menu location for tool windows (`View > Other Windows`).
- Provide a correct debug profile that launches Visual Studio 2022 Experimental Instance for debugging the VSIX, and remove obsolete/incorrect profiles that referenced VS 2026 or project launch settings.

### Description

- Updated the VS command table to place the extension group under `IDM_VS_MENU_VIEW_OTHERWINDOWS` instead of `IDM_VS_MENU_VIEW` in `src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMemExtension.vsct`.
- Replaced and simplified debug launch profiles in `src/DbSqlLikeMem.VisualStudioExtension/Properties/launchSettings.json` to add `VS 2022 Experimental` and `VS 2022 Experimental (Log)` profiles that use `devenv.exe` from Visual Studio 2022 with `/rootsuffix Exp` and `/log` as appropriate.
- Files modified: `src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMemExtension.vsct` and `src/DbSqlLikeMem.VisualStudioExtension/Properties/launchSettings.json`.

### Testing

- Inspected the updated VSCT and launch settings with `sed`/`cat` and confirmed the `Parent` element and new profiles were present (succeeded).
- Attempted to run a local build with `dotnet build src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj -c Debug`, but the `dotnet` CLI is unavailable in this environment (failed).
- Committed the changes to the repository (`git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e8a268508832c852dfac1a17eef34)