### PR TITLE
Fix VS tool window context menu selection and expose connection actions

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowControl.xaml
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowControl.xaml
@@ -49,9 +49,13 @@
 
         <TreeView x:Name="ExplorerTree"
                   Grid.Row="4"
+                  PreviewMouseRightButtonDown="OnExplorerTreePreviewMouseRightButtonDown"
                   ItemsSource="{Binding Nodes}">
             <TreeView.ContextMenu>
                 <ContextMenu Opened="OnExplorerContextMenuOpened">
+                    <MenuItem x:Name="EditConnectionMenuItem" Header="Editar conexão" Click="OnEditConnectionClick" />
+                    <MenuItem x:Name="RemoveConnectionMenuItem" Header="Remover conexão" Click="OnRemoveConnectionClick" />
+                    <Separator x:Name="ConnectionActionsSeparator" />
                     <MenuItem x:Name="ConfigureMappingsMenuItem" Header="Configurar mapeamentos" Click="OnConfigureMappingsClick" />
                     <MenuItem x:Name="ConfigureTemplatesMenuItem" Header="Configurar templates" Click="OnConfigureTemplatesClick" />
                     <Separator />

--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowControl.xaml.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowControl.xaml.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 using DbSqlLikeMem.VisualStudioExtension.Services;
 using EnvDTE;
 using DteProject = EnvDTE.Project;
@@ -104,10 +106,47 @@ public partial class DbSqlLikeMemToolWindowControl : UserControl
 
     private void OnExplorerContextMenuOpened(object sender, RoutedEventArgs e)
     {
+        var isConnectionNodeSelected = ExplorerTree.SelectedItem is ExplorerNode selectedConnection && selectedConnection.Kind == ExplorerNodeKind.Connection;
         var isObjectTypeNodeSelected = ExplorerTree.SelectedItem is ExplorerNode selected && selected.Kind == ExplorerNodeKind.ObjectType;
+
+        EditConnectionMenuItem.Visibility = isConnectionNodeSelected ? Visibility.Visible : Visibility.Collapsed;
+        RemoveConnectionMenuItem.Visibility = isConnectionNodeSelected ? Visibility.Visible : Visibility.Collapsed;
+        ConnectionActionsSeparator.Visibility = isConnectionNodeSelected ? Visibility.Visible : Visibility.Collapsed;
 
         ConfigureMappingsMenuItem.Visibility = isObjectTypeNodeSelected ? Visibility.Visible : Visibility.Collapsed;
         ConfigureTemplatesMenuItem.Visibility = isObjectTypeNodeSelected ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void OnExplorerTreePreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        var source = e.OriginalSource as DependencyObject;
+        if (source is null)
+        {
+            return;
+        }
+
+        var treeViewItem = FindParent<TreeViewItem>(source);
+        if (treeViewItem is not null)
+        {
+            treeViewItem.IsSelected = true;
+            treeViewItem.Focus();
+        }
+    }
+
+    private static T? FindParent<T>(DependencyObject child) where T : DependencyObject
+    {
+        var current = child;
+        while (current is not null)
+        {
+            if (current is T parent)
+            {
+                return parent;
+            }
+
+            current = VisualTreeHelper.GetParent(current);
+        }
+
+        return null;
     }
 
     private void OnConfigureMappingsClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
### Motivation
- Expose existing connection actions in the tool window context menu so users can `Editar conexão` and `Remover conexão` directly from the tree.  
- Ensure right-click targets the item under the mouse to avoid invoking actions on an old selection.  

### Description
- Added context menu entries `EditConnectionMenuItem`, `RemoveConnectionMenuItem` and `ConnectionActionsSeparator` to `DbSqlLikeMemToolWindowControl.xaml`.  
- Added `PreviewMouseRightButtonDown=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eabe78570832c907725494d71b561)