### PR TITLE
Support Environment-scoped NuGet API key in publish workflow

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   publish:
     runs-on: windows-latest
+    environment: ${{ vars.NUGET_PUBLISH_ENVIRONMENT || 'nuget-publish' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,7 +41,7 @@ jobs:
 
           if [ -z "$NUGET_KEY" ]; then
             echo "::error::NuGet API key is empty. Configure one of: secrets.NUGET_API_KEY, secrets.NUGET_ORG_API_KEY, vars.NUGET_API_KEY or vars.NUGET_ORG_API_KEY."
-            echo "::error::If you store it at Environment level, attach this job to that Environment and ensure the tag/branch is allowed by Environment rules."
+            echo "::error::This workflow runs in Environment '${{ vars.NUGET_PUBLISH_ENVIRONMENT || 'nuget-publish' }}'. If your key is an Environment secret, add it there and ensure tag/branch rules allow this run."
             exit 1
           fi
 

--- a/docs/wiki/pages/Publishing.md
+++ b/docs/wiki/pages/Publishing.md
@@ -4,6 +4,7 @@
 
 - Workflow: `.github/workflows/nuget-publish.yml`
 - Secret: `NUGET_API_KEY`
+- Optional environment secret support: job runs in Environment `nuget-publish` by default (or `vars.NUGET_PUBLISH_ENVIRONMENT` when set)
 - Tag: `v*`
 
 ## VSIX (Visual Studio)
@@ -26,6 +27,7 @@
 
 - Workflow: `.github/workflows/nuget-publish.yml`
 - Secret: `NUGET_API_KEY`
+- Suporte opcional a segredo de Environment: o job roda no Environment `nuget-publish` por padrão (ou `vars.NUGET_PUBLISH_ENVIRONMENT` quando definido)
 - Tag: `v*`
 
 ### VSIX (Visual Studio)


### PR DESCRIPTION
### Motivation
- Prevent the NuGet publish job from failing with an empty API key when the key is stored as a GitHub Environment secret and make it clearer where to put the key.

### Description
- Set the NuGet publish job `environment` to `${{ vars.NUGET_PUBLISH_ENVIRONMENT || 'nuget-publish' }}` so Environment-level secrets are available to the job.
- Keep the existing key resolution order between `secrets.*` and `vars.*` and continue exporting the resolved key to `GITHUB_ENV` for `dotnet nuget push`.
- Improve the empty-key error message to explicitly reference the active Environment name and advise about tag/branch rules.
- Update `docs/wiki/pages/Publishing.md` (EN and PT) to document the optional Environment secret support and the override variable.

### Testing
- Ran `git diff --check` to ensure no whitespace or merge-marker issues, and it passed.
- Ran `git status --short` to confirm the expected files were modified, and it showed the updated workflow and docs files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eae2230ac832cb897b4a25e50c00e)