### PR TITLE
Align VSIX tooling baseline with Visual Studio 2022

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
+++ b/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
@@ -5,7 +5,7 @@
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <UseCodebase>true</UseCodebase>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.11.35" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.2120" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />

--- a/src/DbSqlLikeMem.VisualStudioExtension/source.extension.vsixmanifest
+++ b/src/DbSqlLikeMem.VisualStudioExtension/source.extension.vsixmanifest
@@ -8,13 +8,13 @@
     <Locale>pt-BR</Locale>
     <InstalledByMsi>false</InstalledByMsi>
     <SupportedProducts>
-      <VisualStudio Version="[16.0,19.0)">
+      <VisualStudio Version="[17.0,19.0)">
         <Edition>Community</Edition>
       </VisualStudio>
-      <VisualStudio Version="[16.0,19.0)">
+      <VisualStudio Version="[17.0,19.0)">
         <Edition>Professional</Edition>
       </VisualStudio>
-      <VisualStudio Version="[16.0,19.0)">
+      <VisualStudio Version="[17.0,19.0)">
         <Edition>Enterprise</Edition>
       </VisualStudio>
     </SupportedProducts>


### PR DESCRIPTION
### Motivation
- Align the extension project and VSIX manifest with the Visual Studio 2022 baseline to reduce compatibility mismatches and mitigate WPF/host-shell noise when running under `devenv.exe`.

### Description
- Bumped `<MinimumVisualStudioVersion>` to `17.0`, upgraded `Microsoft.VSSDK.BuildTools` to `17.14.2120`, and changed the VSIX `SupportedProducts` Visual Studio ranges from `[16.0,19.0)` to `[17.0,19.0)` in `source.extension.vsixmanifest`.

### Testing
- Attempted `dotnet build src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj`, but the `dotnet` CLI is not available in this environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eaf24ac3c832c81422cb9ecea737a)