### PR TITLE
Fix NuGet publish glob expansion on Windows Bash runner

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -50,7 +50,15 @@ jobs:
       - name: Publish to NuGet.org
         shell: bash
         run: |
-          dotnet nuget push "./artifacts/*.nupkg" \
+          shopt -s nullglob
+          packages=(./artifacts/*.nupkg)
+
+          if [ ${#packages[@]} -eq 0 ]; then
+            echo "::error::No NuGet packages were found in ./artifacts."
+            exit 1
+          fi
+
+          dotnet nuget push "${packages[@]}" \
             --api-key "$NUGET_API_KEY" \
             --source "https://api.nuget.org/v3/index.json" \
             --skip-duplicate


### PR DESCRIPTION
### Motivation
- The publish step passed a quoted glob (`"./artifacts/*.nupkg"`) which is not expanded by Bash on the Windows runner and resulted in `File does not exist (./artifacts/*.nupkg)`.

### Description
- Enable Bash `nullglob` and collect matching `.nupkg` files into an array with `packages=(./artifacts/*.nupkg)` so the shell expands the glob correctly.
- Add an explicit check that fails with a clear error when no packages are found, and pass the expanded `"${packages[@]}"` list to `dotnet nuget push`.

### Testing
- Inspected the updated workflow file contents with `nl -ba .github/workflows/nuget-publish.yml` and confirmed the new `nullglob`/array logic is present, which succeeded. 
- Verified the patched step range with `nl -ba .github/workflows/nuget-publish.yml | sed -n '45,75p'` to ensure the published command now receives expanded package paths, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f029e4e7c832cb84ff044b71b9fc0)