### PR TITLE
Migrate NuGet publish workflow to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -28,25 +29,6 @@ jobs:
       - name: Pack
         run: dotnet pack src/DbSqlLikeMem.slnx -c Release -o ./artifacts
 
-      - name: Resolve NuGet API key
-        id: nuget_key
-        shell: bash
-        env:
-          NUGET_API_KEY_SECRET: ${{ secrets.NUGET_API_KEY }}
-          NUGET_ORG_API_KEY_SECRET: ${{ secrets.NUGET_ORG_API_KEY }}
-          NUGET_API_KEY_VAR: ${{ vars.NUGET_API_KEY }}
-          NUGET_ORG_API_KEY_VAR: ${{ vars.NUGET_ORG_API_KEY }}
-        run: |
-          NUGET_KEY="${NUGET_API_KEY_SECRET:-${NUGET_ORG_API_KEY_SECRET:-${NUGET_API_KEY_VAR:-${NUGET_ORG_API_KEY_VAR:-}}}}"
-
-          if [ -z "$NUGET_KEY" ]; then
-            echo "::error::NuGet API key is empty. Configure one of: secrets.NUGET_API_KEY, secrets.NUGET_ORG_API_KEY, vars.NUGET_API_KEY or vars.NUGET_ORG_API_KEY."
-            echo "::error::This workflow runs in Environment '${{ vars.NUGET_PUBLISH_ENVIRONMENT || 'nuget-publish' }}'. If your key is an Environment secret, add it there and ensure tag/branch rules allow this run."
-            exit 1
-          fi
-
-          echo "NUGET_API_KEY=$NUGET_KEY" >> "$GITHUB_ENV"
-
       - name: Publish to NuGet.org
         shell: bash
         run: |
@@ -59,6 +41,5 @@ jobs:
           fi
 
           dotnet nuget push "${packages[@]}" \
-            --api-key "$NUGET_API_KEY" \
             --source "https://api.nuget.org/v3/index.json" \
             --skip-duplicate

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -4,10 +4,11 @@
 
 ### Via GitHub Actions (recomendado)
 
-1. Crie uma API key em https://www.nuget.org/ (Account settings → API Keys).
-2. No repositório do GitHub, adicione o secret `NUGET_API_KEY`.
-3. Atualize a versão em `src/Directory.Build.props` (`Version`).
-4. Crie e envie uma tag de release:
+Este repositório está configurado para **Trusted Publishing** no nuget.org (OIDC), sem necessidade de API key no workflow.
+
+1. No nuget.org, configure o Trusted Publisher para este repositório/workflow.
+2. Atualize a versão em `src/Directory.Build.props` (`Version`).
+3. Crie e envie uma tag de release:
 
 ```bash
 git tag v0.1.0
@@ -18,6 +19,8 @@ Workflow responsável:
 - `.github/workflows/nuget-publish.yml`
 
 Esse pipeline empacota e publica os projetos do solution no nuget.org.
+
+> Observação: para publicação local/manual (fora do GitHub Actions), API key continua sendo necessária.
 
 ### Publicação manual (local)
 


### PR DESCRIPTION
### Motivation

- Replace fragile API-key-based NuGet publishing with GitHub Actions Trusted Publishing (OIDC) to avoid key management and common 403 authentication failures.  
- Make documentation match the CI change and clarify that manual/local publishing still requires an API key.

### Description

- Add `id-token: write` permission to `/.github/workflows/nuget-publish.yml` to enable OIDC-based authentication.  
- Remove the API key resolution step and drop the `--api-key` argument from `dotnet nuget push` so CI uses the repository identity instead of secrets.  
- Update `docs/publishing.md` to document Trusted Publishing (OIDC) for the workflow and note that local/manual publishing still requires an API key.

### Testing

- Verified the diff of the changed files with `git diff -- .github/workflows/nuget-publish.yml docs/publishing.md` and confirmed the API-key logic was removed and `id-token: write` was added.  
- Inspected the workflow and docs contents with `nl -ba .github/workflows/nuget-publish.yml` and `nl -ba docs/publishing.md` to validate the resulting text.  
- Attempted a YAML parse with the small Python snippet `python - <<'PY' ...` which failed due to missing `PyYAML` in the environment, so structural validation was done via manual inspection.  
- Ran `git status --short` and branch checks to ensure the changes are present in the working tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f1b07c76c832c8fad0dc862e5105e)