### PR TITLE
Add trigger execution support, tests across providers and update docs

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -61,6 +61,9 @@
 - Operadores JSON `->` e `->>`: não suportados.
 
 
+- Triggers em tabelas não temporárias: suportadas via `TableMock` (before/after insert, update e delete).
+- Tabelas temporárias (connection/global): triggers não são executadas.
+
 ## Extensões (VS Code e Visual Studio)
 
 As extensões agora suportam, além da geração tradicional para testes, fluxos separados para artefatos de aplicação:

--- a/docs/providers-and-features.md
+++ b/docs/providers-and-features.md
@@ -100,6 +100,13 @@ Decisões de compatibilidade implementadas para cobrir os cenários de relatóri
 - Data/time cobre unidades comuns (`year/month/day/hour/minute/second`), mas não trata timezone explícito, calendário ISO avançado nem regras específicas de cada engine real.
 - Subquery escalar retorna sempre a primeira célula da primeira linha, sem erro para múltiplas linhas (comportamento simplificado de mock).
 
+
+## Triggers em tabelas não temporárias
+
+- O runtime em memória executa triggers registradas via `TableMock.AddTrigger(...)` para eventos `Before/After Insert|Update|Delete`.
+- A execução ocorre apenas quando o dialeto expõe `SupportsTriggers = true`.
+- **Tabelas temporárias** (escopo conexão/global temporary) **não** executam triggers no executor, por regra explícita de compatibilidade.
+
 ## Regras candidatas para extrair do parser para os Dialects
 
 Para deixar o parser mais fiel por banco/versão, estas regras costumam dar bom ganho quando saem de `if` no parser e passam a ser capacidade do dialeto:

--- a/docs/sql-compatibility-matrix.md
+++ b/docs/sql-compatibility-matrix.md
@@ -19,6 +19,7 @@
 | Table hints SQL Server `WITH (...)` | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Index hints MySQL (`USE/IGNORE/FORCE INDEX`) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Operadores JSON `->` / `->>` | ⚠️ (dependente de parser/executor por cenário) | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Triggers em tabelas não temporárias (`TableMock`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ## Notas rápidas
 

--- a/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
@@ -138,6 +138,7 @@ public sealed class Db2DialectFeatureParserTests
         Assert.False(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
+        Assert.True(d.SupportsTriggers);
     }
 
 }

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2TriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2TriggerStrategyTests.cs
@@ -1,0 +1,41 @@
+namespace DbSqlLikeMem.Db2.Test.Strategy;
+
+public sealed class Db2TriggerStrategyTests
+{
+    [Fact]
+    public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
+    {
+        var db = new Db2DbMock();
+        var table = db.AddTable("users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(table);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var connection = new Db2ConnectionMock(db);
+        using var cmd = new Db2CommandMock(connection) { CommandText = "INSERT INTO users (id) VALUES (1)" };
+        cmd.ExecuteNonQuery();
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
+    {
+        var db = new Db2DbMock();
+        using var connection = new Db2ConnectionMock(db);
+
+        var table = connection.AddTemporaryTable("temp_users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(table);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var cmd = new Db2CommandMock(connection) { CommandText = "INSERT INTO temp_users (id) VALUES (1)" };
+        cmd.ExecuteNonQuery();
+
+        Assert.Equal(0, calls);
+    }
+}

--- a/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
@@ -76,6 +76,7 @@ public sealed class MySqlDialectFeatureParserTests
         Assert.False(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
+        Assert.True(d.SupportsTriggers);
     }
 
 

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTriggerStrategyTests.cs
@@ -1,0 +1,41 @@
+namespace DbSqlLikeMem.MySql.Test.Strategy;
+
+public sealed class MySqlTriggerStrategyTests
+{
+    [Fact]
+    public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
+    {
+        var db = new MySqlDbMock();
+        var table = db.AddTable("users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(table);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var connection = new MySqlConnectionMock(db);
+        using var cmd = new MySqlCommandMock(connection) { CommandText = "INSERT INTO users (id) VALUES (1)" };
+        cmd.ExecuteNonQuery();
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
+    {
+        var db = new MySqlDbMock();
+        using var connection = new MySqlConnectionMock(db);
+
+        var table = connection.AddTemporaryTable("temp_users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(table);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var cmd = new MySqlCommandMock(connection) { CommandText = "INSERT INTO temp_users (id) VALUES (1)" };
+        cmd.ExecuteNonQuery();
+
+        Assert.Equal(0, calls);
+    }
+}

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
@@ -118,6 +118,7 @@ RETURNING id";
         Assert.False(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
+        Assert.True(d.SupportsTriggers);
     }
 
 

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTriggerStrategyTests.cs
@@ -1,0 +1,41 @@
+namespace DbSqlLikeMem.Npgsql.Test.Strategy;
+
+public sealed class PostgreSqlTriggerStrategyTests
+{
+    [Fact]
+    public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
+    {
+        var db = new NpgsqlDbMock();
+        var table = db.AddTable("users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(table);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var connection = new NpgsqlConnectionMock(db);
+        using var cmd = new NpgsqlCommandMock(connection) { CommandText = "INSERT INTO users (id) VALUES (1)" };
+        cmd.ExecuteNonQuery();
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
+    {
+        var db = new NpgsqlDbMock();
+        using var connection = new NpgsqlConnectionMock(db);
+
+        var table = connection.AddTemporaryTable("temp_users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(table);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var cmd = new NpgsqlCommandMock(connection) { CommandText = "INSERT INTO temp_users (id) VALUES (1)" };
+        cmd.ExecuteNonQuery();
+
+        Assert.Equal(0, calls);
+    }
+}

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
@@ -74,6 +74,7 @@ public sealed class OracleDialectFeatureParserTests
         Assert.True(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
+        Assert.True(d.SupportsTriggers);
     }
 
 

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTriggerStrategyTests.cs
@@ -1,0 +1,41 @@
+namespace DbSqlLikeMem.Oracle.Test.Strategy;
+
+public sealed class OracleTriggerStrategyTests
+{
+    [Fact]
+    public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
+    {
+        var db = new OracleDbMock();
+        var table = db.AddTable("users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(table);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var connection = new OracleConnectionMock(db);
+        using var cmd = new OracleCommandMock(connection) { CommandText = "INSERT INTO users (id) VALUES (1)" };
+        cmd.ExecuteNonQuery();
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
+    {
+        var db = new OracleDbMock();
+        using var connection = new OracleConnectionMock(db);
+
+        var table = connection.AddTemporaryTable("temp_users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(table);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var cmd = new OracleCommandMock(connection) { CommandText = "INSERT INTO temp_users (id) VALUES (1)" };
+        cmd.ExecuteNonQuery();
+
+        Assert.Equal(0, calls);
+    }
+}

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
@@ -95,6 +95,7 @@ public sealed class SqlServerDialectFeatureParserTests
         Assert.False(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
+        Assert.True(d.SupportsTriggers);
     }
 
 

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTriggerStrategyTests.cs
@@ -1,0 +1,67 @@
+namespace DbSqlLikeMem.SqlServer.Test.Strategy;
+
+public sealed class SqlServerTriggerStrategyTests
+{
+    [Fact]
+    public void NonTemporaryTable_ShouldExecuteInsertUpdateDeleteTriggers()
+    {
+        var db = new SqlServerDbMock();
+        var table = db.AddTable("users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+        table.Columns["name"] = new(1, DbType.String, false);
+
+        var triggerTable = Assert.IsType<TableMock>(table);
+        var events = new List<TableTriggerEvent>();
+        triggerTable.AddTrigger(TableTriggerEvent.BeforeInsert, _ => events.Add(TableTriggerEvent.BeforeInsert));
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => events.Add(TableTriggerEvent.AfterInsert));
+        triggerTable.AddTrigger(TableTriggerEvent.BeforeUpdate, _ => events.Add(TableTriggerEvent.BeforeUpdate));
+        triggerTable.AddTrigger(TableTriggerEvent.AfterUpdate, _ => events.Add(TableTriggerEvent.AfterUpdate));
+        triggerTable.AddTrigger(TableTriggerEvent.BeforeDelete, _ => events.Add(TableTriggerEvent.BeforeDelete));
+        triggerTable.AddTrigger(TableTriggerEvent.AfterDelete, _ => events.Add(TableTriggerEvent.AfterDelete));
+
+        using var connection = new SqlServerConnectionMock(db);
+
+        using (var insert = new SqlServerCommandMock(connection) { CommandText = "INSERT INTO users (id, name) VALUES (1, 'john')" })
+            insert.ExecuteNonQuery();
+
+        using (var update = new SqlServerCommandMock(connection) { CommandText = "UPDATE users SET name = 'mary' WHERE id = 1" })
+            update.ExecuteNonQuery();
+
+        using (var delete = new SqlServerCommandMock(connection) { CommandText = "DELETE FROM users WHERE id = 1" })
+            delete.ExecuteNonQuery();
+
+        Assert.Equal(
+        [
+            TableTriggerEvent.BeforeInsert,
+            TableTriggerEvent.AfterInsert,
+            TableTriggerEvent.BeforeUpdate,
+            TableTriggerEvent.AfterUpdate,
+            TableTriggerEvent.BeforeDelete,
+            TableTriggerEvent.AfterDelete
+        ], events);
+    }
+
+    [Fact]
+    public void TemporaryTable_ShouldNotExecuteTriggers()
+    {
+        var db = new SqlServerDbMock();
+        using var connection = new SqlServerConnectionMock(db);
+
+        var temp = connection.AddTemporaryTable("#users");
+        temp.Columns["id"] = new(0, DbType.Int32, false);
+        temp.Columns["name"] = new(1, DbType.String, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(temp);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var insert = new SqlServerCommandMock(connection)
+        {
+            CommandText = "INSERT INTO #users (id, name) VALUES (1, 'john')"
+        };
+
+        insert.ExecuteNonQuery();
+
+        Assert.Equal(0, calls);
+    }
+}

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
@@ -105,6 +105,7 @@ public sealed class SqliteDialectFeatureParserTests
         Assert.False(d.IsIntegerCastTypeName("NUMBER"));
 
         Assert.False(d.RegexInvalidPatternEvaluatesToFalse);
+        Assert.True(d.SupportsTriggers);
     }
 
 }

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteTriggerStrategyTests.cs
@@ -1,0 +1,41 @@
+namespace DbSqlLikeMem.Sqlite.Test.Strategy;
+
+public sealed class SqliteTriggerStrategyTests
+{
+    [Fact]
+    public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
+    {
+        var db = new SqliteDbMock();
+        var table = db.AddTable("users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(table);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var connection = new SqliteConnectionMock(db);
+        using var cmd = new SqliteCommandMock(connection) { CommandText = "INSERT INTO users (id) VALUES (1)" };
+        cmd.ExecuteNonQuery();
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
+    {
+        var db = new SqliteDbMock();
+        using var connection = new SqliteConnectionMock(db);
+
+        var table = connection.AddTemporaryTable("temp_users");
+        table.Columns["id"] = new(0, DbType.Int32, false);
+
+        var calls = 0;
+        var triggerTable = Assert.IsType<TableMock>(table);
+        triggerTable.AddTrigger(TableTriggerEvent.AfterInsert, _ => calls++);
+
+        using var cmd = new SqliteCommandMock(connection) { CommandText = "INSERT INTO temp_users (id) VALUES (1)" };
+        cmd.ExecuteNonQuery();
+
+        Assert.Equal(0, calls);
+    }
+}

--- a/src/DbSqlLikeMem/Base/DbConnectionMockBase.cs
+++ b/src/DbSqlLikeMem/Base/DbConnectionMockBase.cs
@@ -278,6 +278,24 @@ public abstract class DbConnectionMockBase(
             schemaName ?? Database);
     }
 
+    internal bool IsTemporaryTable(
+        ITableMock table,
+        string tableName,
+        string? schemaName = null)
+    {
+        if (TryGetTemporaryTable(tableName, out var connectionTemp, schemaName)
+            && connectionTemp != null
+            && ReferenceEquals(connectionTemp, table))
+            return true;
+
+        if (TryGetGlobalTemporaryTable(tableName, out var globalTemp, schemaName)
+            && globalTemp != null
+            && ReferenceEquals(globalTemp, table))
+            return true;
+
+        return false;
+    }
+
     /// <summary>
     /// EN: Lists the tables in the current schema.
     /// PT: Lista as tabelas do schema atual.

--- a/src/DbSqlLikeMem/Models/TableTrigger.cs
+++ b/src/DbSqlLikeMem/Models/TableTrigger.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace DbSqlLikeMem;
+
+/// <summary>
+/// EN: Trigger moments supported by in-memory tables.
+/// PT: Momentos de trigger suportados pelas tabelas em memória.
+/// </summary>
+public enum TableTriggerEvent
+{
+    BeforeInsert,
+    AfterInsert,
+    BeforeUpdate,
+    AfterUpdate,
+    BeforeDelete,
+    AfterDelete
+}
+
+/// <summary>
+/// EN: Trigger callback payload.
+/// PT: Payload do callback de trigger.
+/// </summary>
+/// <param name="Table">EN: Trigger table. PT: Tabela da trigger.</param>
+/// <param name="OldRow">EN: Previous row values. PT: Valores anteriores da linha.</param>
+/// <param name="NewRow">EN: New row values. PT: Novos valores da linha.</param>
+public sealed record TableTriggerContext(
+    ITableMock Table,
+    IReadOnlyDictionary<int, object?>? OldRow,
+    IReadOnlyDictionary<int, object?>? NewRow);

--- a/src/DbSqlLikeMem/Parser/Dialects.cs
+++ b/src/DbSqlLikeMem/Parser/Dialects.cs
@@ -62,6 +62,7 @@ internal interface ISqlDialect
     bool SupportsOnConflictClause { get; }
     bool SupportsReturning { get; }
     bool SupportsMerge { get; }
+    bool SupportsTriggers { get; }
 
     // Pagination
     bool SupportsOffsetFetch { get; }
@@ -396,6 +397,7 @@ internal abstract class SqlDialectBase : ISqlDialect
     /// Auto-generated summary.
     /// </summary>
     public virtual bool SupportsMerge => false;
+    public virtual bool SupportsTriggers => true;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>


### PR DESCRIPTION
### Motivation
- Ensure the in-memory engine exposes and validates trigger capabilities uniformly across all dialects and that triggers run on non-temporary tables but not on temporary tables. 
- Provide strategy-level tests to exercise before/after insert/update/delete trigger behavior and make the dialect capability contract (`SupportsTriggers`) explicit in parser feature tests. 
- Keep documentation accurate about trigger semantics so consumers and contributors understand runtime behavior. 

### Description
- Introduced trigger primitives: `TableTriggerEvent` and `TableTriggerContext` in `Models/TableTrigger.cs`. 
- Extended `TableMock` with trigger registration (`AddTrigger`) and execution (`ExecuteTriggers`) storage and invocation. 
- Added `IsTemporaryTable` helper to `DbConnectionMockBase` and updated list/table resolution paths to support temporary/global temporary checks. 
- Wired trigger invocation into DML strategies (`DbInsertStrategy`, `DbUpdateStrategy`, `DbDeleteStrategy`) with `Before`/`After` calls, row snapshot helpers, and short-circuiting when `SupportsTriggers` is false or the table is temporary. 
- Added `SupportsTriggers` capability to the dialect interface and defaulted it in `SqlDialectBase`. 
- Added strategy tests for triggers for MySQL, PostgreSQL (Npgsql), Oracle, SQLite, DB2, and SQL Server validating trigger execution on regular tables and absence on temporary tables. 
- Updated parser feature tests for all providers to assert `SupportsTriggers` in `RuntimeDialectRules_ShouldRemainStable`. 
- Updated documentation files (`docs/providers-and-features.md`, `docs/sql-compatibility-matrix.md`, `Features.md`) to document trigger behavior and the temporary-table exception. 

### Testing
- No automated .NET tests were executed in this environment because `dotnet --info` failed with `dotnet: command not found`, so the added unit tests were not run. 
- Performed repository and static checks (`rg`, scripted edits and file updates) to validate the code and docs changes were applied and committed successfully. 
- New unit tests were added under provider test projects and should be run in CI or a dev environment with the .NET SDK to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f4c2c3604832cb582d2bfdd286716)