### PR TITLE
Fix XML documentation warnings by adding missing public member comments / Corrigir avisos de documentação XML adicionando comentários ausentes

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/SqlDatabaseMetadataProviderTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/SqlDatabaseMetadataProviderTests.cs
@@ -51,6 +51,10 @@ public sealed class SqlDatabaseMetadataProviderTests
     }
 
 
+    /// <summary>
+    /// Verifies MySQL list query uses database name parsed from connection string.
+    /// Verifica se a consulta de listagem MySQL usa o nome do banco extraído da connection string.
+    /// </summary>
     [Fact]
     public async Task ListObjectsAsync_ForMySql_UsesDatabaseNameFromConnectionString()
     {

--- a/src/DbSqlLikeMem.VisualStudioExtension.XamlHarness/MainWindow.xaml.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.XamlHarness/MainWindow.xaml.cs
@@ -6,8 +6,16 @@ using DbSqlLikeMem.VisualStudioExtension.UI;
 
 namespace DbSqlLikeMem.VisualStudioExtension.XamlHarness;
 
+/// <summary>
+/// Main test harness window for visual validation of extension dialogs.
+/// Janela principal de teste para validação visual das janelas da extensão.
+/// </summary>
 public partial class MainWindow : Window
 {
+    /// <summary>
+    /// Initializes the main harness window.
+    /// Inicializa a janela principal do harness.
+    /// </summary>
     public MainWindow()
     {
         InitializeComponent();

--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowViewModel.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowViewModel.cs
@@ -241,6 +241,10 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
         return (firstMapping?.FileNamePattern ?? "{NamePascal}{Type}Factory.cs", firstMapping?.OutputDirectory ?? "Generated");
     }
 
+    /// <summary>
+    /// Gets the persisted filter text and mode for the informed object-type node.
+    /// Obtém o texto e o modo de filtro persistidos para o nó de tipo de objeto informado.
+    /// </summary>
     public (string FilterText, FilterMode FilterMode) GetObjectTypeFilter(ExplorerNode objectTypeNode)
     {
         if (objectTypeNode.Kind != ExplorerNodeKind.ObjectType || objectTypeNode.ConnectionId is null || objectTypeNode.ObjectType is null)
@@ -254,6 +258,10 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
             : (string.Empty, FilterMode.Like);
     }
 
+    /// <summary>
+    /// Sets or clears the filter for the informed object-type node and refreshes the explorer tree.
+    /// Define ou limpa o filtro para o nó de tipo de objeto informado e atualiza a árvore do explorador.
+    /// </summary>
     public void SetObjectTypeFilter(ExplorerNode objectTypeNode, string filterText, FilterMode filterMode)
     {
         if (objectTypeNode.Kind != ExplorerNodeKind.ObjectType || objectTypeNode.ConnectionId is null || objectTypeNode.ObjectType is null)
@@ -275,6 +283,10 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
         RefreshTree();
     }
 
+    /// <summary>
+    /// Clears the filter for the informed object-type node and refreshes the explorer tree.
+    /// Limpa o filtro para o nó de tipo de objeto informado e atualiza a árvore do explorador.
+    /// </summary>
     public void ClearObjectTypeFilter(ExplorerNode objectTypeNode)
     {
         if (objectTypeNode.Kind != ExplorerNodeKind.ObjectType || objectTypeNode.ConnectionId is null || objectTypeNode.ObjectType is null)
@@ -318,6 +330,10 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
         SetStatusMessage("Cancelamento solicitado.");
     }
 
+    /// <summary>
+    /// Exports current extension state to a JSON file.
+    /// Exporta o estado atual da extensão para um arquivo JSON.
+    /// </summary>
     public async Task ExportStateAsync(string filePath)
     {
         if (string.IsNullOrWhiteSpace(filePath))
@@ -330,6 +346,10 @@ public sealed class DbSqlLikeMemToolWindowViewModel : INotifyPropertyChanged
         SetStatusMessage("Configurações exportadas com sucesso.");
     }
 
+    /// <summary>
+    /// Imports extension state from a JSON file and refreshes the UI.
+    /// Importa o estado da extensão de um arquivo JSON e atualiza a interface.
+    /// </summary>
     public async Task ImportStateAsync(string filePath)
     {
         if (string.IsNullOrWhiteSpace(filePath))

--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/ObjectTypeFilterDialog.xaml.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/ObjectTypeFilterDialog.xaml.cs
@@ -4,8 +4,16 @@ using DbSqlLikeMem.VisualStudioExtension.Core.Models;
 
 namespace DbSqlLikeMem.VisualStudioExtension.UI;
 
+/// <summary>
+/// Dialog used to configure object-type filtering in the explorer.
+/// Janela usada para configurar o filtro por tipo de objeto no explorador.
+/// </summary>
 public partial class ObjectTypeFilterDialog : Window
 {
+    /// <summary>
+    /// Initializes the dialog with current filter values.
+    /// Inicializa a janela com os valores atuais de filtro.
+    /// </summary>
     public ObjectTypeFilterDialog(string filterText, FilterMode filterMode)
     {
         InitializeComponent();
@@ -13,8 +21,16 @@ public partial class ObjectTypeFilterDialog : Window
         FilterModeCombo.SelectedIndex = filterMode == FilterMode.Equals ? 1 : 0;
     }
 
+    /// <summary>
+    /// Gets the filter text entered by the user.
+    /// Obtém o texto de filtro informado pelo usuário.
+    /// </summary>
     public string FilterText { get; private set; } = string.Empty;
 
+    /// <summary>
+    /// Gets the matching mode selected by the user.
+    /// Obtém o modo de comparação selecionado pelo usuário.
+    /// </summary>
     public FilterMode FilterMode { get; private set; } = FilterMode.Like;
 
     private void OnSaveClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
### Motivation
- Address reported `CS1591` (missing XML comments) by documenting the actual public members that triggered warnings instead of suppressing them via `NoWarn`.
- Corrigir os avisos `CS1591` adicionando documentação XML nos membros públicos em vez de ocultá-los com `NoWarn`.

### Description
- Removed the test-project warning suppression line (`<NoWarn>$(NoWarn);CS1587;CS1591</NoWarn>`) from `src/Directory.Build.props` so warnings are no longer globally suppressed for test projects.
- Added English-then-Portuguese XML documentation for public members in `DbSqlLikeMemToolWindowViewModel` (`GetObjectTypeFilter`, `SetObjectTypeFilter`, `ClearObjectTypeFilter`, `ExportStateAsync`, `ImportStateAsync`).
- Added XML documentation for `ObjectTypeFilterDialog` (class, constructor, `FilterText`, `FilterMode`) and for the `MainWindow` harness (class and constructor).
- Added an XML comment for the public test `ListObjectsAsync_ForMySql_UsesDatabaseNameFromConnectionString` in `SqlDatabaseMetadataProviderTests`.

### Testing
- Attempted to run `dotnet build src/DbSqlLikeMem.slnx -v minimal` to verify warnings were resolved; this could not be executed in the current environment because `dotnet` is not installed (`command not found`).
- No other automated build or test commands were available in this environment to further validate the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f95ace73c832c822795018978a281)