### PR TITLE
Remove Dapper from core; add DapperLateBinding and move Dapper PackageReferences to test projects

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj
+++ b/src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj
@@ -7,6 +7,14 @@
 		<PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>
 
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Dapper" Version="2.1.66" />
+	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/DbSqlLikeMem.Db2/Db2ConnectionMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2ConnectionMock.cs
@@ -1,5 +1,4 @@
-﻿using Dapper;
-using System.Data.Common;
+﻿using System.Data.Common;
 
 namespace DbSqlLikeMem.Db2;
 
@@ -12,8 +11,8 @@ public sealed class Db2ConnectionMock
     static Db2ConnectionMock()
     {
         // O ODP.NET rejeita DbType.Guid, então mapeamos Guid para Object no fluxo Dapper.
-        SqlMapper.AddTypeMap(typeof(Guid), DbType.Object);
-        SqlMapper.AddTypeMap(typeof(Guid?), DbType.Object);
+        DapperLateBinding.AddTypeMap(typeof(Guid), DbType.Object);
+        DapperLateBinding.AddTypeMap(typeof(Guid?), DbType.Object);
         Db2AstQueryExecutorRegister.Register();
     }
 

--- a/src/DbSqlLikeMem.Db2/Db2LinqProvider.cs
+++ b/src/DbSqlLikeMem.Db2/Db2LinqProvider.cs
@@ -93,58 +93,6 @@ public sealed class Db2QueryProvider(
         var sql = translation.Sql ?? string.Empty;
         var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        static MethodInfo FindDapperMethodWithOptionalTail(
-            string name,
-            int genericArgCount)
-        {
-            var sqlMapper = typeof(Dapper.SqlMapper);
-
-            // Queremos o método cujo prefixo de parâmetros seja:
-            // (IDbConnection, string, object)
-            // e o resto (se existir) seja OPTIONAL.
-            var candidates = sqlMapper
-                .GetMethods(BindingFlags.Public | BindingFlags.Static)
-                .Where(m => m.Name == name
-                    && m.IsGenericMethodDefinition
-                    && m.GetGenericArguments().Length == genericArgCount)
-                .Select(m => new { Method = m, Params = m.GetParameters() })
-                .Where(x => x.Params.Length >= 3
-                    && typeof(IDbConnection).IsAssignableFrom(x.Params[0].ParameterType)
-                    && x.Params[1].ParameterType == typeof(string)
-                    && (x.Params[2].ParameterType == typeof(object)
-                        || x.Params[2].ParameterType.IsAssignableFrom(typeof(object)))
-                    && x.Params.Skip(3).All(p => p.IsOptional))
-                .ToList();
-
-            if (candidates.Count == 0)
-                throw new InvalidOperationException(
-                    $"Não encontrei overload de Dapper.SqlMapper.{name} com prefixo (IDbConnection, string, object) e cauda opcional.");
-
-            // Se houver mais de um, escolhe o mais “completo” (mais params), porque é o padrão do Dapper.
-            return candidates
-                .OrderByDescending(x => x.Params.Length)
-                .First()
-                .Method;
-        }
-
-        static object?[] BuildInvokeArgs(
-            ParameterInfo[] ps,
-            IDbConnection cnn,
-            string sql,
-            object? paramObj)
-        {
-            // Preenche os 3 primeiros e o resto com Missing (pra usar defaults dos opcionais)
-            var args = new object?[ps.Length];
-            args[0] = cnn;
-            args[1] = sql;
-            args[2] = paramObj ?? new { };
-
-            for (int i = 3; i < ps.Length; i++)
-                args[i] = Type.Missing;
-
-            return args;
-        }
-
         // IEnumerable (mas não string)
         if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
             && typeof(TResult) != typeof(string))
@@ -153,20 +101,20 @@ public sealed class Db2QueryProvider(
                 ? typeof(TResult).GetGenericArguments().First()
                 : typeof(object);
 
-            var def = FindDapperMethodWithOptionalTail("Query", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
             var mi = def.MakeGenericMethod(elementType);
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs)!;
 
             return (TResult)data;
         }
         else
         {
-            var def = FindDapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
             var mi = def.MakeGenericMethod(typeof(TResult));
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs);
 
             return (TResult)data!;

--- a/src/DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj
+++ b/src/DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj
@@ -6,6 +6,18 @@
 		<TargetFrameworks>net48;net6.0;net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Dapper" Version="2.1.66" />
+	</ItemGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>

--- a/src/DbSqlLikeMem.MySql/MySqlLinqProvider.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlLinqProvider.cs
@@ -89,58 +89,6 @@ public sealed class MySqlQueryProvider(
         var sql = translation.Sql ?? string.Empty;
         var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        static MethodInfo FindDapperMethodWithOptionalTail(
-            string name,
-            int genericArgCount)
-        {
-            var sqlMapper = typeof(Dapper.SqlMapper);
-
-            // Queremos o método cujo prefixo de parâmetros seja:
-            // (IDbConnection, string, object)
-            // e o resto (se existir) seja OPTIONAL.
-            var candidates = sqlMapper
-                .GetMethods(BindingFlags.Public | BindingFlags.Static)
-                .Where(m => m.Name == name
-                    && m.IsGenericMethodDefinition
-                    && m.GetGenericArguments().Length == genericArgCount)
-                .Select(m => new { Method = m, Params = m.GetParameters() })
-                .Where(x => x.Params.Length >= 3
-                    && typeof(IDbConnection).IsAssignableFrom(x.Params[0].ParameterType)
-                    && x.Params[1].ParameterType == typeof(string)
-                    && (x.Params[2].ParameterType == typeof(object)
-                        || x.Params[2].ParameterType.IsAssignableFrom(typeof(object)))
-                    && x.Params.Skip(3).All(p => p.IsOptional))
-                .ToList();
-
-            if (candidates.Count == 0)
-                throw new InvalidOperationException(
-                    $"Não encontrei overload de Dapper.SqlMapper.{name} com prefixo (IDbConnection, string, object) e cauda opcional.");
-
-            // Se houver mais de um, escolhe o mais “completo” (mais params), porque é o padrão do Dapper.
-            return candidates
-                .OrderByDescending(x => x.Params.Length)
-                .First()
-                .Method;
-        }
-
-        static object?[] BuildInvokeArgs(
-            ParameterInfo[] ps,
-            IDbConnection cnn,
-            string sql,
-            object? paramObj)
-        {
-            // Preenche os 3 primeiros e o resto com Missing (pra usar defaults dos opcionais)
-            var args = new object?[ps.Length];
-            args[0] = cnn;
-            args[1] = sql;
-            args[2] = paramObj ?? new { };
-
-            for (int i = 3; i < ps.Length; i++)
-                args[i] = Type.Missing;
-
-            return args;
-        }
-
         // IEnumerable (mas não string)
         if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
             && typeof(TResult) != typeof(string))
@@ -149,20 +97,20 @@ public sealed class MySqlQueryProvider(
                 ? typeof(TResult).GetGenericArguments().First()
                 : typeof(object);
 
-            var def = FindDapperMethodWithOptionalTail("Query", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
             var mi = def.MakeGenericMethod(elementType);
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs)!;
 
             return (TResult)data;
         }
         else
         {
-            var def = FindDapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
             var mi = def.MakeGenericMethod(typeof(TResult));
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs);
 
             return (TResult)data!;

--- a/src/DbSqlLikeMem.Npgsql.Test/DbSqlLikeMem.Npgsql.Test.csproj
+++ b/src/DbSqlLikeMem.Npgsql.Test/DbSqlLikeMem.Npgsql.Test.csproj
@@ -6,6 +6,18 @@
 		<TargetFrameworks>net48;net6.0;net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Dapper" Version="2.1.66" />
+	</ItemGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlLinqProvider.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlLinqProvider.cs
@@ -93,58 +93,6 @@ public sealed class NpgsqlQueryProvider(
         var sql = translation.Sql ?? string.Empty;
         var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        static MethodInfo FindDapperMethodWithOptionalTail(
-            string name,
-            int genericArgCount)
-        {
-            var sqlMapper = typeof(Dapper.SqlMapper);
-
-            // Queremos o método cujo prefixo de parâmetros seja:
-            // (IDbConnection, string, object)
-            // e o resto (se existir) seja OPTIONAL.
-            var candidates = sqlMapper
-                .GetMethods(BindingFlags.Public | BindingFlags.Static)
-                .Where(m => m.Name == name
-                    && m.IsGenericMethodDefinition
-                    && m.GetGenericArguments().Length == genericArgCount)
-                .Select(m => new { Method = m, Params = m.GetParameters() })
-                .Where(x => x.Params.Length >= 3
-                    && typeof(IDbConnection).IsAssignableFrom(x.Params[0].ParameterType)
-                    && x.Params[1].ParameterType == typeof(string)
-                    && (x.Params[2].ParameterType == typeof(object)
-                        || x.Params[2].ParameterType.IsAssignableFrom(typeof(object)))
-                    && x.Params.Skip(3).All(p => p.IsOptional))
-                .ToList();
-
-            if (candidates.Count == 0)
-                throw new InvalidOperationException(
-                    $"Não encontrei overload de Dapper.SqlMapper.{name} com prefixo (IDbConnection, string, object) e cauda opcional.");
-
-            // Se houver mais de um, escolhe o mais “completo” (mais params), porque é o padrão do Dapper.
-            return candidates
-                .OrderByDescending(x => x.Params.Length)
-                .First()
-                .Method;
-        }
-
-        static object?[] BuildInvokeArgs(
-            ParameterInfo[] ps,
-            IDbConnection cnn,
-            string sql,
-            object? paramObj)
-        {
-            // Preenche os 3 primeiros e o resto com Missing (pra usar defaults dos opcionais)
-            var args = new object?[ps.Length];
-            args[0] = cnn;
-            args[1] = sql;
-            args[2] = paramObj ?? new { };
-
-            for (int i = 3; i < ps.Length; i++)
-                args[i] = Type.Missing;
-
-            return args;
-        }
-
         // IEnumerable (mas não string)
         if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
             && typeof(TResult) != typeof(string))
@@ -153,20 +101,20 @@ public sealed class NpgsqlQueryProvider(
                 ? typeof(TResult).GetGenericArguments().First()
                 : typeof(object);
 
-            var def = FindDapperMethodWithOptionalTail("Query", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
             var mi = def.MakeGenericMethod(elementType);
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs)!;
 
             return (TResult)data;
         }
         else
         {
-            var def = FindDapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
             var mi = def.MakeGenericMethod(typeof(TResult));
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs);
 
             return (TResult)data!;

--- a/src/DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj
+++ b/src/DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj
@@ -6,6 +6,18 @@
 		<TargetFrameworks>net48;net6.0;net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Dapper" Version="2.1.66" />
+	</ItemGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>

--- a/src/DbSqlLikeMem.Oracle/OracleConnectionMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleConnectionMock.cs
@@ -1,5 +1,4 @@
 using System.Data.Common;
-using Dapper;
 
 namespace DbSqlLikeMem.Oracle;
 
@@ -14,8 +13,8 @@ public class OracleConnectionMock
     static OracleConnectionMock()
     {
         // O ODP.NET rejeita DbType.Guid, então mapeamos Guid para Object no fluxo Dapper.
-        SqlMapper.AddTypeMap(typeof(Guid), DbType.Object);
-        SqlMapper.AddTypeMap(typeof(Guid?), DbType.Object);
+        DapperLateBinding.AddTypeMap(typeof(Guid), DbType.Object);
+        DapperLateBinding.AddTypeMap(typeof(Guid?), DbType.Object);
         OracleAstQueryExecutorRegister.Register();
     }
 

--- a/src/DbSqlLikeMem.Oracle/OracleLinqProvider.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleLinqProvider.cs
@@ -93,58 +93,6 @@ public sealed class OracleQueryProvider(
         var sql = translation.Sql ?? string.Empty;
         var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        static MethodInfo FindDapperMethodWithOptionalTail(
-            string name,
-            int genericArgCount)
-        {
-            var sqlMapper = typeof(Dapper.SqlMapper);
-
-            // Queremos o método cujo prefixo de parâmetros seja:
-            // (IDbConnection, string, object)
-            // e o resto (se existir) seja OPTIONAL.
-            var candidates = sqlMapper
-                .GetMethods(BindingFlags.Public | BindingFlags.Static)
-                .Where(m => m.Name == name
-                    && m.IsGenericMethodDefinition
-                    && m.GetGenericArguments().Length == genericArgCount)
-                .Select(m => new { Method = m, Params = m.GetParameters() })
-                .Where(x => x.Params.Length >= 3
-                    && typeof(IDbConnection).IsAssignableFrom(x.Params[0].ParameterType)
-                    && x.Params[1].ParameterType == typeof(string)
-                    && (x.Params[2].ParameterType == typeof(object)
-                        || x.Params[2].ParameterType.IsAssignableFrom(typeof(object)))
-                    && x.Params.Skip(3).All(p => p.IsOptional))
-                .ToList();
-
-            if (candidates.Count == 0)
-                throw new InvalidOperationException(
-                    $"Não encontrei overload de Dapper.SqlMapper.{name} com prefixo (IDbConnection, string, object) e cauda opcional.");
-
-            // Se houver mais de um, escolhe o mais “completo” (mais params), porque é o padrão do Dapper.
-            return candidates
-                .OrderByDescending(x => x.Params.Length)
-                .First()
-                .Method;
-        }
-
-        static object?[] BuildInvokeArgs(
-            ParameterInfo[] ps,
-            IDbConnection cnn,
-            string sql,
-            object? paramObj)
-        {
-            // Preenche os 3 primeiros e o resto com Missing (pra usar defaults dos opcionais)
-            var args = new object?[ps.Length];
-            args[0] = cnn;
-            args[1] = sql;
-            args[2] = paramObj ?? new { };
-
-            for (int i = 3; i < ps.Length; i++)
-                args[i] = Type.Missing;
-
-            return args;
-        }
-
         // IEnumerable (mas não string)
         if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
             && typeof(TResult) != typeof(string))
@@ -153,20 +101,20 @@ public sealed class OracleQueryProvider(
                 ? typeof(TResult).GetGenericArguments().First()
                 : typeof(object);
 
-            var def = FindDapperMethodWithOptionalTail("Query", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
             var mi = def.MakeGenericMethod(elementType);
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs)!;
 
             return (TResult)data;
         }
         else
         {
-            var def = FindDapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
             var mi = def.MakeGenericMethod(typeof(TResult));
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs);
 
             return (TResult)data!;

--- a/src/DbSqlLikeMem.SqlServer.Test/DbSqlLikeMem.SqlServer.Test.csproj
+++ b/src/DbSqlLikeMem.SqlServer.Test/DbSqlLikeMem.SqlServer.Test.csproj
@@ -7,6 +7,18 @@
 	</PropertyGroup>
 
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Dapper" Version="2.1.66" />
+	</ItemGroup>
+
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>

--- a/src/DbSqlLikeMem.SqlServer/SqlServerLinqProvider.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerLinqProvider.cs
@@ -93,58 +93,6 @@ public sealed class SqlServerQueryProvider(
         var sql = translation.Sql ?? string.Empty;
         var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        static MethodInfo FindDapperMethodWithOptionalTail(
-            string name,
-            int genericArgCount)
-        {
-            var sqlMapper = typeof(Dapper.SqlMapper);
-
-            // Queremos o método cujo prefixo de parâmetros seja:
-            // (IDbConnection, string, object)
-            // e o resto (se existir) seja OPTIONAL.
-            var candidates = sqlMapper
-                .GetMethods(BindingFlags.Public | BindingFlags.Static)
-                .Where(m => m.Name == name
-                    && m.IsGenericMethodDefinition
-                    && m.GetGenericArguments().Length == genericArgCount)
-                .Select(m => new { Method = m, Params = m.GetParameters() })
-                .Where(x => x.Params.Length >= 3
-                    && typeof(IDbConnection).IsAssignableFrom(x.Params[0].ParameterType)
-                    && x.Params[1].ParameterType == typeof(string)
-                    && (x.Params[2].ParameterType == typeof(object)
-                        || x.Params[2].ParameterType.IsAssignableFrom(typeof(object)))
-                    && x.Params.Skip(3).All(p => p.IsOptional))
-                .ToList();
-
-            if (candidates.Count == 0)
-                throw new InvalidOperationException(
-                    $"Não encontrei overload de Dapper.SqlMapper.{name} com prefixo (IDbConnection, string, object) e cauda opcional.");
-
-            // Se houver mais de um, escolhe o mais “completo” (mais params), porque é o padrão do Dapper.
-            return candidates
-                .OrderByDescending(x => x.Params.Length)
-                .First()
-                .Method;
-        }
-
-        static object?[] BuildInvokeArgs(
-            ParameterInfo[] ps,
-            IDbConnection cnn,
-            string sql,
-            object? paramObj)
-        {
-            // Preenche os 3 primeiros e o resto com Missing (pra usar defaults dos opcionais)
-            var args = new object?[ps.Length];
-            args[0] = cnn;
-            args[1] = sql;
-            args[2] = paramObj ?? new { };
-
-            for (int i = 3; i < ps.Length; i++)
-                args[i] = Type.Missing;
-
-            return args;
-        }
-
         // IEnumerable (mas não string)
         if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
             && typeof(TResult) != typeof(string))
@@ -153,20 +101,20 @@ public sealed class SqlServerQueryProvider(
                 ? typeof(TResult).GetGenericArguments().First()
                 : typeof(object);
 
-            var def = FindDapperMethodWithOptionalTail("Query", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
             var mi = def.MakeGenericMethod(elementType);
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs)!;
 
             return (TResult)data;
         }
         else
         {
-            var def = FindDapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
             var mi = def.MakeGenericMethod(typeof(TResult));
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs);
 
             return (TResult)data!;

--- a/src/DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj
+++ b/src/DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj
@@ -6,6 +6,18 @@
 		<TargetFrameworks>net48;net6.0;net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Dapper" Version="2.1.35" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Dapper" Version="2.1.66" />
+	</ItemGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>

--- a/src/DbSqlLikeMem.Sqlite/SqliteLinqProvider.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteLinqProvider.cs
@@ -93,58 +93,6 @@ public sealed class SqliteQueryProvider(
         var sql = translation.Sql ?? string.Empty;
         var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        static MethodInfo FindDapperMethodWithOptionalTail(
-            string name,
-            int genericArgCount)
-        {
-            var sqlMapper = typeof(Dapper.SqlMapper);
-
-            // Queremos o método cujo prefixo de parâmetros seja:
-            // (IDbConnection, string, object)
-            // e o resto (se existir) seja OPTIONAL.
-            var candidates = sqlMapper
-                .GetMethods(BindingFlags.Public | BindingFlags.Static)
-                .Where(m => m.Name == name
-                    && m.IsGenericMethodDefinition
-                    && m.GetGenericArguments().Length == genericArgCount)
-                .Select(m => new { Method = m, Params = m.GetParameters() })
-                .Where(x => x.Params.Length >= 3
-                    && typeof(IDbConnection).IsAssignableFrom(x.Params[0].ParameterType)
-                    && x.Params[1].ParameterType == typeof(string)
-                    && (x.Params[2].ParameterType == typeof(object)
-                        || x.Params[2].ParameterType.IsAssignableFrom(typeof(object)))
-                    && x.Params.Skip(3).All(p => p.IsOptional))
-                .ToList();
-
-            if (candidates.Count == 0)
-                throw new InvalidOperationException(
-                    $"Não encontrei overload de Dapper.SqlMapper.{name} com prefixo (IDbConnection, string, object) e cauda opcional.");
-
-            // Se houver mais de um, escolhe o mais “completo” (mais params), porque é o padrão do Dapper.
-            return candidates
-                .OrderByDescending(x => x.Params.Length)
-                .First()
-                .Method;
-        }
-
-        static object?[] BuildInvokeArgs(
-            ParameterInfo[] ps,
-            IDbConnection cnn,
-            string sql,
-            object? paramObj)
-        {
-            // Preenche os 3 primeiros e o resto com Missing (pra usar defaults dos opcionais)
-            var args = new object?[ps.Length];
-            args[0] = cnn;
-            args[1] = sql;
-            args[2] = paramObj ?? new { };
-
-            for (int i = 3; i < ps.Length; i++)
-                args[i] = Type.Missing;
-
-            return args;
-        }
-
         // IEnumerable (mas não string)
         if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
             && typeof(TResult) != typeof(string))
@@ -153,20 +101,20 @@ public sealed class SqliteQueryProvider(
                 ? typeof(TResult).GetGenericArguments().First()
                 : typeof(object);
 
-            var def = FindDapperMethodWithOptionalTail("Query", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
             var mi = def.MakeGenericMethod(elementType);
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs)!;
 
             return (TResult)data;
         }
         else
         {
-            var def = FindDapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
+            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
             var mi = def.MakeGenericMethod(typeof(TResult));
 
-            var invokeArgs = BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
+            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
             var data = mi.Invoke(null, invokeArgs);
 
             return (TResult)data!;

--- a/src/DbSqlLikeMem/DbSqlLikeMem.csproj
+++ b/src/DbSqlLikeMem/DbSqlLikeMem.csproj
@@ -4,14 +4,12 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Dapper" Version="2.1.35" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
-		<PackageReference Include="Dapper" Version="2.1.66" />
 		<PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
 		<PackageReference Include="System.Collections.Immutable" Version="10.0.3" />
 		<PackageReference Include="Roslynator.CSharp" Version="4.15.0" />
@@ -20,7 +18,6 @@
 	</ItemGroup>
 	
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'netstandard2.1'">
-		<PackageReference Include="Dapper" Version="2.1.35" />
 		<PackageReference Include="Roslynator.CSharp" Version="4.15.0" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="System.Collections.Immutable" Version="9.0.0" />

--- a/src/DbSqlLikeMem/Interop.DapperLateBinding.cs
+++ b/src/DbSqlLikeMem/Interop.DapperLateBinding.cs
@@ -1,0 +1,98 @@
+using System.Reflection;
+
+namespace DbSqlLikeMem;
+
+internal static class DapperLateBinding
+{
+    private const string SqlMapperTypeName = "Dapper.SqlMapper";
+    private static readonly string[] CandidateAssemblyNames = ["Dapper", "Dapper.StrongName"];
+
+    internal static MethodInfo FindSqlMapperMethodWithOptionalTail(string name, int genericArgCount)
+    {
+        var sqlMapper = ResolveSqlMapperType();
+
+        var candidates = sqlMapper
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.Name == name
+                && m.IsGenericMethodDefinition
+                && m.GetGenericArguments().Length == genericArgCount)
+            .Select(m => new { Method = m, Params = m.GetParameters() })
+            .Where(x => x.Params.Length >= 3
+                && typeof(IDbConnection).IsAssignableFrom(x.Params[0].ParameterType)
+                && x.Params[1].ParameterType == typeof(string)
+                && (x.Params[2].ParameterType == typeof(object)
+                    || x.Params[2].ParameterType.IsAssignableFrom(typeof(object)))
+                && x.Params.Skip(3).All(p => p.IsOptional))
+            .ToList();
+
+        if (candidates.Count == 0)
+            throw new InvalidOperationException(
+                $"Não encontrei overload de {SqlMapperTypeName}.{name} com prefixo (IDbConnection, string, object) e cauda opcional.");
+
+        return candidates
+            .OrderByDescending(x => x.Params.Length)
+            .First()
+            .Method;
+    }
+
+    internal static object?[] BuildInvokeArgs(
+        ParameterInfo[] ps,
+        IDbConnection cnn,
+        string sql,
+        object? paramObj)
+    {
+        var args = new object?[ps.Length];
+        args[0] = cnn;
+        args[1] = sql;
+        args[2] = paramObj ?? new { };
+
+        for (var i = 3; i < ps.Length; i++)
+            args[i] = Type.Missing;
+
+        return args;
+    }
+
+    internal static void AddTypeMap(Type type, DbType dbType)
+    {
+        if (!TryResolveSqlMapperType(out var sqlMapper))
+            return;
+
+        var mi = sqlMapper.GetMethod(
+            "AddTypeMap",
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: [typeof(Type), typeof(DbType)],
+            modifiers: null);
+
+        if (mi is null)
+            throw new MissingMethodException($"{SqlMapperTypeName}.AddTypeMap(Type, DbType) não encontrado.");
+
+        mi.Invoke(null, [type, dbType]);
+    }
+
+    private static Type ResolveSqlMapperType()
+    {
+        if (TryResolveSqlMapperType(out var t))
+            return t;
+
+        throw new InvalidOperationException(
+            "Dapper não foi encontrado em runtime. Adicione referência ao pacote Dapper ou Dapper.StrongName para habilitar execução LINQ via late-binding.");
+    }
+
+    private static bool TryResolveSqlMapperType(out Type? t)
+    {
+        foreach (var assemblyName in CandidateAssemblyNames)
+        {
+            t = Type.GetType($"{SqlMapperTypeName}, {assemblyName}", throwOnError: false);
+            if (t is not null)
+                return true;
+        }
+
+        t = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Select(a => a.GetType(SqlMapperTypeName, throwOnError: false))
+            .FirstOrDefault(x => x is not null);
+
+        return t is not null;
+    }
+}


### PR DESCRIPTION
### Motivation
- The core library must not carry a hard compile-time dependency on `Dapper` because runtime usage is done via late-binding.  
- Centralize and reuse reflection logic for invoking `Dapper.SqlMapper` to avoid duplicated reflection code across providers.  
- Ensure projects that actually compile against `Dapper` (tests that call `Query`/`Execute`) continue to have the package available per-TFM.

### Description
- Removed `Dapper` `PackageReference` entries from `src/DbSqlLikeMem/DbSqlLikeMem.csproj`.  
- Added explicit `Dapper` `PackageReference` entries (TFM-aware) to the test projects that use `<Using Include="Dapper" />`: `DbSqlLikeMem.Sqlite.Test`, `DbSqlLikeMem.SqlServer.Test`, `DbSqlLikeMem.Oracle.Test`, `DbSqlLikeMem.MySql.Test`, `DbSqlLikeMem.Npgsql.Test`, and `DbSqlLikeMem.Db2.Test`, keeping `net48`/`net6.0` => `2.1.35` and `net8.0`/`net10.0` => `2.1.66`.  
- Added `src/DbSqlLikeMem/Interop.DapperLateBinding.cs` implementing `DapperLateBinding` with `FindSqlMapperMethodWithOptionalTail`, `BuildInvokeArgs`, `AddTypeMap`, and assembly resolution helpers for both `Dapper` and `Dapper.StrongName`.  
- Replaced inline reflection / direct `SqlMapper` calls in LINQ providers and connection mocks to use the centralized `DapperLateBinding` helpers (e.g. `FindSqlMapperMethodWithOptionalTail`, `BuildInvokeArgs`, `AddTypeMap`), and updated usages in providers and mocks (Sqlite, SqlServer, Npgsql, MySql, Db2, Oracle).  
- Kept behavior and overload selection logic while removing the core compile-time package dependency.

### Testing
- Verified package references and `Using` entries with `rg` to confirm `Dapper` refs were removed from the core and added to the appropriate test projects (succeeded).  
- Verified the new `DapperLateBinding` usage and `Dapper` package placements via repository inspection and `git status` (changes committed).  
- Attempted to run `dotnet --info` / perform a build but the environment lacks the .NET SDK (`dotnet: command not found`), so no compilation tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fab35a074832cba16e2625b9897cf)