### PR TITLE
Use resource-based SqlExceptionMessages for provider errors and tests

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertStrategyExtrasTests.cs
@@ -85,7 +85,7 @@ public sealed class Db2InsertStrategyExtrasTests(
 
         // Act & Assert
         var ex = Assert.Throws<Db2MockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Duplicate entry", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.DuplicateKey(string.Empty, string.Empty).Split('\'')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 
@@ -124,7 +124,7 @@ public class Db2DeleteStrategyForeignKeyTests
 
         // Act & Assert
         var ex = Assert.Throws<Db2MockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Cannot delete or update a parent row", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ReferencedRow(string.Empty).Split('(')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2UpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2UpdateStrategyCoverageTests.cs
@@ -52,6 +52,6 @@ public sealed class Db2UpdateStrategyCoverageTests(
         };
 
         var ex = Assert.Throws<Db2MockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Coluna não aceita NULL", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ColumnDoesNotAcceptNull(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
@@ -1,3 +1,4 @@
+using DbSqlLikeMem.Resources;
 ﻿using IBM.Data.Db2;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
@@ -110,7 +111,7 @@ public class Db2CommandMock(
         {
             var q = SqlQueryParser.Parse(sqlRaw, connection.Db.Dialect);
             if (q is not SqlCreateTemporaryTableQuery ct)
-                throw new InvalidOperationException("Invalid CREATE TEMPORARY TABLE statement.");
+                throw new InvalidOperationException(SqlExceptionMessages.InvalidCreateTemporaryTableStatement());
             return connection.ExecuteCreateTemporaryTableAsSelect(ct, Parameters, connection.Db.Dialect);
         }
 
@@ -119,7 +120,7 @@ public class Db2CommandMock(
         {
             var q = SqlQueryParser.Parse(sqlRaw, connection.Db.Dialect);
             if (q is not SqlCreateViewQuery cv)
-                throw new InvalidOperationException("Invalid CREATE VIEW statement.");
+                throw new InvalidOperationException(SqlExceptionMessages.InvalidCreateViewStatement());
             return connection.ExecuteCreateView(cv, Parameters, connection.Db.Dialect);
         }
 
@@ -144,8 +145,8 @@ public class Db2CommandMock(
             SqlMergeQuery mergeQ => connection.ExecuteMerge(mergeQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery cv => connection.ExecuteCreateView(cv, Parameters, connection.Db.Dialect),
             SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
-            SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
-            SqlUnionQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT/UNION."),
+            SqlSelectQuery _ => throw new InvalidOperationException(SqlExceptionMessages.UseExecuteReaderForSelect()),
+            SqlUnionQuery _ => throw new InvalidOperationException(SqlExceptionMessages.UseExecuteReaderForSelectUnion()),
             _ => throw SqlUnsupported.ForCommandType(connection!.Db.Dialect, "ExecuteNonQuery", query.GetType())
         };
     }
@@ -159,7 +160,7 @@ public class Db2CommandMock(
             .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         if (parts.Length < 3 || !parts[0].Equals("DROP", StringComparison.OrdinalIgnoreCase) || !parts[1].Equals("VIEW", StringComparison.OrdinalIgnoreCase))
-            throw new InvalidOperationException("Invalid DROP VIEW statement.");
+            throw new InvalidOperationException(SqlExceptionMessages.InvalidDropViewStatement());
 
         var i = 2;
         var ifExists = false;
@@ -172,7 +173,7 @@ public class Db2CommandMock(
         }
 
         if (i >= parts.Length)
-            throw new InvalidOperationException("Invalid DROP VIEW statement.");
+            throw new InvalidOperationException(SqlExceptionMessages.InvalidDropViewStatement());
 
         var viewName = parts[i].Trim().Trim('`', '"').NormalizeName();
         connection.DropView(viewName, ifExists);
@@ -257,7 +258,7 @@ public class Db2CommandMock(
         }
 
         if (tables.Count == 0 && queries.Count > 0)
-            throw new InvalidOperationException("ExecuteReader foi chamado, mas nenhuma query SELECT foi encontrada.");
+            throw new InvalidOperationException(SqlExceptionMessages.ExecuteReaderWithoutSelectQuery());
 
         connection.Metrics.Selects += tables.Sum(t => t.Count);
 

--- a/src/DbSqlLikeMem.Db2/Db2DataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2DataParameterCollectionMock.cs
@@ -1,3 +1,4 @@
+using DbSqlLikeMem.Resources;
 ﻿using IBM.Data.Db2;
 using System.Collections;
 using System.Data.Common;
@@ -23,7 +24,7 @@ public class Db2DataParameterCollectionMock
     {
         var normalizedParameterName = NormalizeParameterName(parameter.ParameterName);
         if (!string.IsNullOrEmpty(normalizedParameterName) && NormalizedIndexOf(normalizedParameterName) != -1)
-            throw new ArgumentException($"Parameter '{parameter.ParameterName}' has already been defined.");
+            throw new ArgumentException(SqlExceptionMessages.ParameterAlreadyDefined(parameter.ParameterName));
         if (index < Items.Count)
         {
             foreach (var pair in DicItems.ToList())
@@ -65,7 +66,7 @@ public class Db2DataParameterCollectionMock
     {
         var index = IndexOf(parameterName);
         if (index == -1)
-            throw new ArgumentException($"Parameter '{parameterName}' not found in the collection", nameof(parameterName));
+            throw new ArgumentException(SqlExceptionMessages.ParameterNotFoundInCollection(parameterName), nameof(parameterName));
         return Items[index];
     }
 

--- a/src/DbSqlLikeMem.Db2/Extensions/Db2ExceptionFactory.cs
+++ b/src/DbSqlLikeMem.Db2/Extensions/Db2ExceptionFactory.cs
@@ -1,3 +1,5 @@
+using DbSqlLikeMem.Resources;
+
 ﻿namespace DbSqlLikeMem.Db2;
 
 internal static class Db2ExceptionFactory
@@ -6,31 +8,31 @@ internal static class Db2ExceptionFactory
     /// Auto-generated summary.
     /// </summary>
     public static Exception DuplicateKey(string tbl, string key, object? val)
-    => new Db2MockException($"Duplicate entry '{val}' for key '{key}'", 1062);
+    => new Db2MockException(SqlExceptionMessages.DuplicateKey(val, key), 1062);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception UnknownColumn(string col)
-        => new Db2MockException($"Unknown column '{col}'", 1054);
+        => new Db2MockException(SqlExceptionMessages.UnknownColumn(col), 1054);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ColumnCannotBeNull(string col)
-        => new Db2MockException($"Column '{col}' cannot be null", 1048);
+        => new Db2MockException(SqlExceptionMessages.ColumnCannotBeNull(col), 1048);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ForeignKeyFails(string col, string refTbl)
         => new Db2MockException(
-            $"Cannot add or update a child row: a foreign key constraint fails ({col} → {refTbl})", 1452);
+            SqlExceptionMessages.ForeignKeyFails(col, refTbl), 1452);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ReferencedRow(string tbl)
         => new Db2MockException(
-            $"Cannot delete or update a parent row: a foreign key constraint fails (child referencing '{tbl}')", 1451);
+            SqlExceptionMessages.ReferencedRow(tbl), 1451);
 }

--- a/src/DbSqlLikeMem.Db2/Extensions/Db2ValueHelper.cs
+++ b/src/DbSqlLikeMem.Db2/Extensions/Db2ValueHelper.cs
@@ -1,3 +1,4 @@
+using DbSqlLikeMem.Resources;
 ﻿using IBM.Data.Db2;
 using System.Text.Json;
 
@@ -38,7 +39,7 @@ internal static class Db2ValueHelper
                 .Replace("\r\n", string.Empty, StringComparison.Ordinal)
                 .Replace(";", string.Empty, StringComparison.Ordinal);
             if (pars == null || !pars.Contains(name))
-                throw new Db2MockException($"Parâmetro {name} não encontrado.");
+                throw new Db2MockException(SqlExceptionMessages.ParameterNotFound(name));
             return ((DB2Parameter)pars[name]).Value;
         }
 
@@ -46,7 +47,7 @@ internal static class Db2ValueHelper
         if (token.Equals("null", StringComparison.OrdinalIgnoreCase))
             return isNullable 
                 ? null
-                : throw new Db2MockException("Coluna não aceita NULL");
+                : throw new Db2MockException(SqlExceptionMessages.ColumnDoesNotAcceptNull());
 
         // ---------- lista ( ..., ... )  para IN ------------------------
         var m = _list.Match(token);
@@ -139,10 +140,10 @@ internal static class Db2ValueHelper
             return value;
 
         if (cdef.Size is int size && value is string s && s.Length > size)
-            throw new Db2MockException($"Data too long for column '{CurrentColumn}'", 1406);
+            throw new Db2MockException(SqlExceptionMessages.DataTooLongForColumn(CurrentColumn), 1406);
 
         if (cdef.DecimalPlaces is int scale && value is decimal d && GetDecimalScale(d) > scale)
-            throw new Db2MockException($"Data truncated for column '{CurrentColumn}'", 1265);
+            throw new Db2MockException(SqlExceptionMessages.DataTruncatedForColumn(CurrentColumn), 1265);
 
         return value;
     }

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyExtrasTests.cs
@@ -85,7 +85,7 @@ public sealed class MySqlInsertStrategyExtrasTests(
 
         // Act & Assert
         var ex = Assert.Throws<MySqlMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Duplicate entry", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.DuplicateKey(string.Empty, string.Empty).Split('\'')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 
@@ -124,7 +124,7 @@ public class MySqlDeleteStrategyForeignKeyTests
 
         // Act & Assert
         var ex = Assert.Throws<MySqlMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Cannot delete or update a parent row", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ReferencedRow(string.Empty).Split('(')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyCoverageTests.cs
@@ -52,6 +52,6 @@ public sealed class MySqlUpdateStrategyCoverageTests(
         };
 
         var ex = Assert.Throws<MySqlMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Coluna não aceita NULL", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ColumnDoesNotAcceptNull(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/DbSqlLikeMem.MySql/Extensions/MySqlExceptionFactory.cs
+++ b/src/DbSqlLikeMem.MySql/Extensions/MySqlExceptionFactory.cs
@@ -1,3 +1,5 @@
+using DbSqlLikeMem.Resources;
+
 namespace DbSqlLikeMem.MySql;
 
 internal static class MySqlExceptionFactory
@@ -6,31 +8,31 @@ internal static class MySqlExceptionFactory
     /// Auto-generated summary.
     /// </summary>
     public static Exception DuplicateKey(string tbl, string key, object? val)
-    => new MySqlMockException($"Duplicate entry '{val}' for key '{key}'", 1062);
+    => new MySqlMockException(SqlExceptionMessages.DuplicateKey(val, key), 1062);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception UnknownColumn(string col)
-        => new MySqlMockException($"Unknown column '{col}'", 1054);
+        => new MySqlMockException(SqlExceptionMessages.UnknownColumn(col), 1054);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ColumnCannotBeNull(string col)
-        => new MySqlMockException($"Column '{col}' cannot be null", 1048);
+        => new MySqlMockException(SqlExceptionMessages.ColumnCannotBeNull(col), 1048);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ForeignKeyFails(string col, string refTbl)
         => new MySqlMockException(
-            $"Cannot add or update a child row: a foreign key constraint fails ({col} → {refTbl})", 1452);
+            SqlExceptionMessages.ForeignKeyFails(col, refTbl), 1452);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ReferencedRow(string tbl)
         => new MySqlMockException(
-            $"Cannot delete or update a parent row: a foreign key constraint fails (child referencing '{tbl}')", 1451);
+            SqlExceptionMessages.ReferencedRow(tbl), 1451);
 }

--- a/src/DbSqlLikeMem.MySql/Extensions/MySqlValueHelper.cs
+++ b/src/DbSqlLikeMem.MySql/Extensions/MySqlValueHelper.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using DbSqlLikeMem.Resources;
 
 namespace DbSqlLikeMem.MySql;
 
@@ -37,7 +38,7 @@ internal static class MySqlValueHelper
                 .Replace("\r\n", string.Empty)
                 .Replace(";", string.Empty);
             if (pars == null || !pars.Contains(name))
-                throw new MySqlMockException($"Parâmetro {name} não encontrado.");
+                throw new MySqlMockException(SqlExceptionMessages.ParameterNotFound(name));
             return ((MySqlParameter)pars[name]).Value;
         }
 
@@ -45,7 +46,7 @@ internal static class MySqlValueHelper
         if (token.Equals("null", StringComparison.OrdinalIgnoreCase))
             return isNullable 
                 ? null
-                : throw new MySqlMockException("Coluna não aceita NULL");
+                : throw new MySqlMockException(SqlExceptionMessages.ColumnDoesNotAcceptNull());
 
         // ---------- lista ( ..., ... )  para IN ------------------------
         var m = _list.Match(token);
@@ -138,10 +139,10 @@ internal static class MySqlValueHelper
             return value;
 
         if (cdef.Size is int size && value is string s && s.Length > size)
-            throw new MySqlMockException($"Data too long for column '{CurrentColumn}'", 1406);
+            throw new MySqlMockException(SqlExceptionMessages.DataTooLongForColumn(CurrentColumn), 1406);
 
         if (cdef.DecimalPlaces is int scale && value is decimal d && GetDecimalScale(d) > scale)
-            throw new MySqlMockException($"Data truncated for column '{CurrentColumn}'", 1265);
+            throw new MySqlMockException(SqlExceptionMessages.DataTruncatedForColumn(CurrentColumn), 1265);
 
         return value;
     }

--- a/src/DbSqlLikeMem.MySql/MySqlDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDataParameterCollectionMock.cs
@@ -1,3 +1,5 @@
+using DbSqlLikeMem.Resources;
+
 namespace DbSqlLikeMem.MySql;
 /// <summary>
 /// EN: Mock parameter collection for MySQL commands.
@@ -19,7 +21,7 @@ public class MySqlDataParameterCollectionMock
     {
         var normalizedParameterName = NormalizeParameterName(parameter.ParameterName);
         if (!string.IsNullOrEmpty(normalizedParameterName) && NormalizedIndexOf(normalizedParameterName) != -1)
-            throw new ArgumentException($"Parameter '{parameter.ParameterName}' has already been defined.");
+            throw new ArgumentException(SqlExceptionMessages.ParameterAlreadyDefined(parameter.ParameterName));
         if (index < Items.Count)
         {
             foreach (var pair in DicItems.ToList())
@@ -61,7 +63,7 @@ public class MySqlDataParameterCollectionMock
     {
         var index = IndexOf(parameterName);
         if (index == -1)
-            throw new ArgumentException($"Parameter '{parameterName}' not found in the collection", nameof(parameterName));
+            throw new ArgumentException(SqlExceptionMessages.ParameterNotFoundInCollection(parameterName), nameof(parameterName));
         return Items[index];
     }
 

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyExtrasTests.cs
@@ -85,7 +85,7 @@ public sealed class PostgreSqlInsertStrategyExtrasTests(
 
         // Act & Assert
         var ex = Assert.Throws<NpgsqlMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Duplicate entry", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.DuplicateKey(string.Empty, string.Empty).Split('\'')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 
@@ -124,7 +124,7 @@ public class PostgreSqlDeleteStrategyForeignKeyTests
 
         // Act & Assert
         var ex = Assert.Throws<NpgsqlMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Cannot delete or update a parent row", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ReferencedRow(string.Empty).Split('(')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyCoverageTests.cs
@@ -52,6 +52,6 @@ public sealed class PostgreSqlUpdateStrategyCoverageTests(
         };
 
         var ex = Assert.Throws<NpgsqlMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Coluna não aceita NULL", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ColumnDoesNotAcceptNull(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/DbSqlLikeMem.Npgsql/Extensions/NpgsqlExceptionFactory.cs
+++ b/src/DbSqlLikeMem.Npgsql/Extensions/NpgsqlExceptionFactory.cs
@@ -1,3 +1,5 @@
+using DbSqlLikeMem.Resources;
+
 namespace DbSqlLikeMem.Npgsql;
 
 internal static class NpgsqlExceptionFactory
@@ -6,31 +8,31 @@ internal static class NpgsqlExceptionFactory
     /// Auto-generated summary.
     /// </summary>
     public static Exception DuplicateKey(string tbl, string key, object? val)
-    => new NpgsqlMockException($"Duplicate entry '{val}' for key '{key}'", 1062);
+    => new NpgsqlMockException(SqlExceptionMessages.DuplicateKey(val, key), 1062);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception UnknownColumn(string col)
-        => new NpgsqlMockException($"Unknown column '{col}'", 1054);
+        => new NpgsqlMockException(SqlExceptionMessages.UnknownColumn(col), 1054);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ColumnCannotBeNull(string col)
-        => new NpgsqlMockException($"Column '{col}' cannot be null", 1048);
+        => new NpgsqlMockException(SqlExceptionMessages.ColumnCannotBeNull(col), 1048);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ForeignKeyFails(string col, string refTbl)
         => new NpgsqlMockException(
-            $"Cannot add or update a child row: a foreign key constraint fails ({col} → {refTbl})", 1452);
+            SqlExceptionMessages.ForeignKeyFails(col, refTbl), 1452);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ReferencedRow(string tbl)
         => new NpgsqlMockException(
-            $"Cannot delete or update a parent row: a foreign key constraint fails (child referencing '{tbl}')", 1451);
+            SqlExceptionMessages.ReferencedRow(tbl), 1451);
 }

--- a/src/DbSqlLikeMem.Npgsql/Extensions/NpgsqlValueHelper.cs
+++ b/src/DbSqlLikeMem.Npgsql/Extensions/NpgsqlValueHelper.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Npgsql;
+using DbSqlLikeMem.Resources;
 
 namespace DbSqlLikeMem.Npgsql;
 
@@ -38,7 +39,7 @@ internal static class NpgsqlValueHelper
                 .Replace("\r\n", string.Empty)
                 .Replace(";", string.Empty);
             if (pars == null || !pars.Contains(name))
-                throw new NpgsqlMockException($"Parâmetro {name} não encontrado.");
+                throw new NpgsqlMockException(SqlExceptionMessages.ParameterNotFound(name));
             return ((NpgsqlParameter)pars[name]).Value;
         }
 
@@ -46,7 +47,7 @@ internal static class NpgsqlValueHelper
         if (token.Equals("null", StringComparison.OrdinalIgnoreCase))
             return isNullable 
                 ? null
-                : throw new NpgsqlMockException("Coluna não aceita NULL");
+                : throw new NpgsqlMockException(SqlExceptionMessages.ColumnDoesNotAcceptNull());
 
         // ---------- lista ( ..., ... )  para IN ------------------------
         var m = _list.Match(token);

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
@@ -1,6 +1,7 @@
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using Npgsql;
+using DbSqlLikeMem.Resources;
 
 namespace DbSqlLikeMem.Npgsql;
 
@@ -114,7 +115,7 @@ public class NpgsqlCommandMock(
             SqlCreateTemporaryTableQuery tempQ => connection.ExecuteCreateTemporaryTableAsSelect(tempQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery viewQ => connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect),
             SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
-            SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
+            SqlSelectQuery _ => throw new InvalidOperationException(SqlExceptionMessages.UseExecuteReaderForSelect()),
             _ => throw SqlUnsupported.ForCommandType(connection!.Db.Dialect, "ExecuteNonQuery", query.GetType())
         };
     }
@@ -187,7 +188,7 @@ public class NpgsqlCommandMock(
         }
 
         if (tables.Count == 0 && queries.Count > 0)
-            throw new InvalidOperationException("ExecuteReader foi chamado, mas nenhuma query SELECT foi encontrada.");
+            throw new InvalidOperationException(SqlExceptionMessages.ExecuteReaderWithoutSelectQuery());
         connection.Metrics.Selects += tables.Sum(t => t.Count);
 
         return new NpgsqlDataReaderMock(tables);

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDataParameterCollectionMock.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Data.Common;
 using Npgsql;
 using NpgsqlTypes;
+using DbSqlLikeMem.Resources;
 
 namespace DbSqlLikeMem.Npgsql;
 
@@ -25,7 +26,7 @@ public class NpgsqlDataParameterCollectionMock
     {
         var normalizedParameterName = NormalizeParameterName(parameter.ParameterName);
         if (!string.IsNullOrEmpty(normalizedParameterName) && NormalizedIndexOf(normalizedParameterName) != -1)
-            throw new ArgumentException($"Parameter '{parameter.ParameterName}' has already been defined.");
+            throw new ArgumentException(SqlExceptionMessages.ParameterAlreadyDefined(parameter.ParameterName));
         if (index < Items.Count)
         {
             foreach (var pair in DicItems.ToList())
@@ -67,7 +68,7 @@ public class NpgsqlDataParameterCollectionMock
     {
         var index = IndexOf(parameterName);
         if (index == -1)
-            throw new ArgumentException($"Parameter '{parameterName}' not found in the collection", nameof(parameterName));
+            throw new ArgumentException(SqlExceptionMessages.ParameterNotFoundInCollection(parameterName), nameof(parameterName));
         return Items[index];
     }
 

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyExtrasTests.cs
@@ -86,7 +86,7 @@ public sealed class OracleInsertStrategyExtrasTests(
 
         // Act & Assert
         var ex = Assert.Throws<OracleMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Duplicate entry", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.DuplicateKey(string.Empty, string.Empty).Split('\'')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 
@@ -125,7 +125,7 @@ public class OracleDeleteStrategyForeignKeyTests
 
         // Act & Assert
         var ex = Assert.Throws<OracleMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Cannot delete or update a parent row", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ReferencedRow(string.Empty).Split('(')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyCoverageTests.cs
@@ -53,6 +53,6 @@ public sealed class OracleUpdateStrategyCoverageTests(
         };
 
         var ex = Assert.Throws<OracleMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Coluna não aceita NULL", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ColumnDoesNotAcceptNull(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/DbSqlLikeMem.Oracle/Extensions/OracleExceptionFactory.cs
+++ b/src/DbSqlLikeMem.Oracle/Extensions/OracleExceptionFactory.cs
@@ -1,3 +1,5 @@
+using DbSqlLikeMem.Resources;
+
 namespace DbSqlLikeMem.Oracle;
 
 internal static class OracleExceptionFactory
@@ -6,31 +8,31 @@ internal static class OracleExceptionFactory
     /// Auto-generated summary.
     /// </summary>
     public static Exception DuplicateKey(string tbl, string key, object? val)
-    => new OracleMockException($"Duplicate entry '{val}' for key '{key}'", 1062);
+    => new OracleMockException(SqlExceptionMessages.DuplicateKey(val, key), 1062);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception UnknownColumn(string col)
-        => new OracleMockException($"Unknown column '{col}'", 1054);
+        => new OracleMockException(SqlExceptionMessages.UnknownColumn(col), 1054);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ColumnCannotBeNull(string col)
-        => new OracleMockException($"Column '{col}' cannot be null", 1048);
+        => new OracleMockException(SqlExceptionMessages.ColumnCannotBeNull(col), 1048);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ForeignKeyFails(string col, string refTbl)
         => new OracleMockException(
-            $"Cannot add or update a child row: a foreign key constraint fails ({col} → {refTbl})", 1452);
+            SqlExceptionMessages.ForeignKeyFails(col, refTbl), 1452);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ReferencedRow(string tbl)
         => new OracleMockException(
-            $"Cannot delete or update a parent row: a foreign key constraint fails (child referencing '{tbl}')", 1451);
+            SqlExceptionMessages.ReferencedRow(tbl), 1451);
 }

--- a/src/DbSqlLikeMem.Oracle/Extensions/OracleValueHelper.cs
+++ b/src/DbSqlLikeMem.Oracle/Extensions/OracleValueHelper.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Oracle.ManagedDataAccess.Client;
+using DbSqlLikeMem.Resources;
 
 namespace DbSqlLikeMem.Oracle;
 
@@ -38,7 +39,7 @@ internal static class OracleValueHelper
                 .Replace("\r\n", string.Empty)
                 .Replace(";", string.Empty);
             if (pars == null || !pars.Contains(name))
-                throw new OracleMockException($"Parâmetro {name} não encontrado.");
+                throw new OracleMockException(SqlExceptionMessages.ParameterNotFound(name));
             return ((OracleParameter)pars[name]).Value;
         }
 
@@ -46,7 +47,7 @@ internal static class OracleValueHelper
         if (token.Equals("null", StringComparison.OrdinalIgnoreCase))
             return isNullable 
                 ? null
-                : throw new OracleMockException("Coluna não aceita NULL");
+                : throw new OracleMockException(SqlExceptionMessages.ColumnDoesNotAcceptNull());
 
         // ---------- lista ( ..., ... )  para IN ------------------------
         var m = _list.Match(token);

--- a/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
@@ -1,6 +1,7 @@
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using Oracle.ManagedDataAccess.Client;
+using DbSqlLikeMem.Resources;
 
 namespace DbSqlLikeMem.Oracle;
 
@@ -111,7 +112,7 @@ public class OracleCommandMock(
             SqlMergeQuery mergeQ => connection.ExecuteMerge(mergeQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery viewQ => connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect),
             SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
-            SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
+            SqlSelectQuery _ => throw new InvalidOperationException(SqlExceptionMessages.UseExecuteReaderForSelect()),
             _ => throw SqlUnsupported.ForCommandType(connection!.Db.Dialect, "ExecuteNonQuery", query.GetType())
         };
     }
@@ -181,7 +182,7 @@ public class OracleCommandMock(
         }
 
         if (tables.Count == 0 && queries.Count > 0)
-            throw new InvalidOperationException("ExecuteReader foi chamado, mas nenhuma query SELECT foi encontrada.");
+            throw new InvalidOperationException(SqlExceptionMessages.ExecuteReaderWithoutSelectQuery());
 
         connection.Metrics.Selects += tables.Sum(t => t.Count);
 

--- a/src/DbSqlLikeMem.Oracle/OracleDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDataParameterCollectionMock.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Data.Common;
 using Oracle.ManagedDataAccess.Client;
+using DbSqlLikeMem.Resources;
 
 namespace DbSqlLikeMem.Oracle;
 /// <summary>
@@ -24,7 +25,7 @@ public class OracleDataParameterCollectionMock
     {
         var normalizedParameterName = NormalizeParameterName(parameter.ParameterName);
         if (!string.IsNullOrEmpty(normalizedParameterName) && NormalizedIndexOf(normalizedParameterName) != -1)
-            throw new ArgumentException($"Parameter '{parameter.ParameterName}' has already been defined.");
+            throw new ArgumentException(SqlExceptionMessages.ParameterAlreadyDefined(parameter.ParameterName));
         if (index < Items.Count)
         {
             foreach (var pair in DicItems.ToList())
@@ -66,7 +67,7 @@ public class OracleDataParameterCollectionMock
     {
         var index = IndexOf(parameterName);
         if (index == -1)
-            throw new ArgumentException($"Parameter '{parameterName}' not found in the collection", nameof(parameterName));
+            throw new ArgumentException(SqlExceptionMessages.ParameterNotFoundInCollection(parameterName), nameof(parameterName));
         return Items[index];
     }
 

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyExtrasTests.cs
@@ -85,7 +85,7 @@ public sealed class SqlServerInsertStrategyExtrasTests(
 
         // Act & Assert
         var ex = Assert.Throws<SqlServerMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Duplicate entry", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.DuplicateKey(string.Empty, string.Empty).Split('\'')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 
@@ -124,7 +124,7 @@ public class SqlServerDeleteStrategyForeignKeyTests
 
         // Act & Assert
         var ex = Assert.Throws<SqlServerMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Cannot delete or update a parent row", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ReferencedRow(string.Empty).Split('(')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyCoverageTests.cs
@@ -52,6 +52,6 @@ public sealed class SqlServerUpdateStrategyCoverageTests(
         };
 
         var ex = Assert.Throws<SqlServerMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Coluna não aceita NULL", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ColumnDoesNotAcceptNull(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/DbSqlLikeMem.SqlServer/Extensions/SqlServerExceptionFactory.cs
+++ b/src/DbSqlLikeMem.SqlServer/Extensions/SqlServerExceptionFactory.cs
@@ -1,3 +1,5 @@
+using DbSqlLikeMem.Resources;
+
 namespace DbSqlLikeMem.SqlServer;
 
 internal static class SqlServerExceptionFactory
@@ -6,31 +8,31 @@ internal static class SqlServerExceptionFactory
     /// Auto-generated summary.
     /// </summary>
     public static Exception DuplicateKey(string tbl, string key, object? val)
-    => new SqlServerMockException($"Duplicate entry '{val}' for key '{key}'", 1062);
+    => new SqlServerMockException(SqlExceptionMessages.DuplicateKey(val, key), 1062);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception UnknownColumn(string col)
-        => new SqlServerMockException($"Unknown column '{col}'", 1054);
+        => new SqlServerMockException(SqlExceptionMessages.UnknownColumn(col), 1054);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ColumnCannotBeNull(string col)
-        => new SqlServerMockException($"Column '{col}' cannot be null", 1048);
+        => new SqlServerMockException(SqlExceptionMessages.ColumnCannotBeNull(col), 1048);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ForeignKeyFails(string col, string refTbl)
         => new SqlServerMockException(
-            $"Cannot add or update a child row: a foreign key constraint fails ({col} → {refTbl})", 1452);
+            SqlExceptionMessages.ForeignKeyFails(col, refTbl), 1452);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ReferencedRow(string tbl)
         => new SqlServerMockException(
-            $"Cannot delete or update a parent row: a foreign key constraint fails (child referencing '{tbl}')", 1451);
+            SqlExceptionMessages.ReferencedRow(tbl), 1451);
 }

--- a/src/DbSqlLikeMem.SqlServer/Extensions/SqlServerValueHelper.cs
+++ b/src/DbSqlLikeMem.SqlServer/Extensions/SqlServerValueHelper.cs
@@ -1,5 +1,6 @@
 using Microsoft.Data.SqlClient;
 using System.Text.Json;
+using DbSqlLikeMem.Resources;
 
 namespace DbSqlLikeMem.SqlServer;
 
@@ -38,7 +39,7 @@ internal static class SqlServerValueHelper
                 .Replace("\r\n", string.Empty)
                 .Replace(";", string.Empty);
             if (pars == null || !pars.Contains(name))
-                throw new SqlServerMockException($"Parâmetro {name} não encontrado.");
+                throw new SqlServerMockException(SqlExceptionMessages.ParameterNotFound(name));
             return ((SqlParameter)pars[name]).Value;
         }
 
@@ -46,7 +47,7 @@ internal static class SqlServerValueHelper
         if (token.Equals("null", StringComparison.OrdinalIgnoreCase))
             return isNullable 
                 ? null
-                : throw new SqlServerMockException("Coluna não aceita NULL");
+                : throw new SqlServerMockException(SqlExceptionMessages.ColumnDoesNotAcceptNull());
 
         // ---------- lista ( ..., ... )  para IN ------------------------
         var m = _list.Match(token);

--- a/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
@@ -1,6 +1,7 @@
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Data.SqlClient;
+using DbSqlLikeMem.Resources;
 
 
 namespace DbSqlLikeMem.SqlServer;
@@ -113,7 +114,7 @@ public class SqlServerCommandMock(
             SqlCreateViewQuery viewQ => connection.ExecuteCreateView(viewQ, Parameters, connection.Db.Dialect),
             SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
             SqlMergeQuery mergeQ => connection.ExecuteMerge(mergeQ, Parameters, connection.Db.Dialect),
-            SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
+            SqlSelectQuery _ => throw new InvalidOperationException(SqlExceptionMessages.UseExecuteReaderForSelect()),
             _ => throw SqlUnsupported.ForCommandType(connection!.Db.Dialect, "ExecuteNonQuery", query.GetType())
         };
     }
@@ -186,7 +187,7 @@ public class SqlServerCommandMock(
         }
 
         if (tables.Count == 0 && queries.Count > 0)
-            throw new InvalidOperationException("ExecuteReader foi chamado, mas nenhuma query SELECT foi encontrada.");
+            throw new InvalidOperationException(SqlExceptionMessages.ExecuteReaderWithoutSelectQuery());
         connection.Metrics.Selects += tables.Sum(t => t.Count);
 
         return new SqlServerDataReaderMock(tables);

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDataParameterCollectionMock.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Data.Common;
 using Microsoft.Data.SqlClient;
+using DbSqlLikeMem.Resources;
 
 namespace DbSqlLikeMem.SqlServer;
 /// <summary>
@@ -23,7 +24,7 @@ public class SqlServerDataParameterCollectionMock
     {
         var normalizedParameterName = NormalizeParameterName(parameter.ParameterName);
         if (!string.IsNullOrEmpty(normalizedParameterName) && NormalizedIndexOf(normalizedParameterName) != -1)
-            throw new ArgumentException($"Parameter '{parameter.ParameterName}' has already been defined.");
+            throw new ArgumentException(SqlExceptionMessages.ParameterAlreadyDefined(parameter.ParameterName));
         if (index < Items.Count)
         {
             foreach (var pair in DicItems.ToList())
@@ -65,7 +66,7 @@ public class SqlServerDataParameterCollectionMock
     {
         var index = IndexOf(parameterName);
         if (index == -1)
-            throw new ArgumentException($"Parameter '{parameterName}' not found in the collection", nameof(parameterName));
+            throw new ArgumentException(SqlExceptionMessages.ParameterNotFoundInCollection(parameterName), nameof(parameterName));
         return Items[index];
     }
 

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertStrategyExtrasTests.cs
@@ -85,7 +85,7 @@ public sealed class SqliteInsertStrategyExtrasTests(
 
         // Act & Assert
         var ex = Assert.Throws<SqliteMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Duplicate entry", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.DuplicateKey(string.Empty, string.Empty).Split('\'')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 
@@ -124,7 +124,7 @@ public class SqliteDeleteStrategyForeignKeyTests
 
         // Act & Assert
         var ex = Assert.Throws<SqliteMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Cannot delete or update a parent row", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ReferencedRow(string.Empty).Split('(')[0].Trim(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteUpdateStrategyCoverageTests.cs
@@ -52,6 +52,6 @@ public sealed class SqliteUpdateStrategyCoverageTests(
         };
 
         var ex = Assert.Throws<SqliteMockException>(() => cmd.ExecuteNonQuery());
-        Assert.Contains("Coluna não aceita NULL", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(DbSqlLikeMem.Resources.SqlExceptionMessages.ColumnDoesNotAcceptNull(), ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/DbSqlLikeMem.Sqlite/Extensions/SqliteExceptionFactory.cs
+++ b/src/DbSqlLikeMem.Sqlite/Extensions/SqliteExceptionFactory.cs
@@ -1,3 +1,5 @@
+using DbSqlLikeMem.Resources;
+
 ﻿namespace DbSqlLikeMem.Sqlite;
 
 internal static class SqliteExceptionFactory
@@ -6,31 +8,31 @@ internal static class SqliteExceptionFactory
     /// Auto-generated summary.
     /// </summary>
     public static Exception DuplicateKey(string tbl, string key, object? val)
-    => new SqliteMockException($"Duplicate entry '{val}' for key '{key}'", 1062);
+    => new SqliteMockException(SqlExceptionMessages.DuplicateKey(val, key), 1062);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception UnknownColumn(string col)
-        => new SqliteMockException($"Unknown column '{col}'", 1054);
+        => new SqliteMockException(SqlExceptionMessages.UnknownColumn(col), 1054);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ColumnCannotBeNull(string col)
-        => new SqliteMockException($"Column '{col}' cannot be null", 1048);
+        => new SqliteMockException(SqlExceptionMessages.ColumnCannotBeNull(col), 1048);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ForeignKeyFails(string col, string refTbl)
         => new SqliteMockException(
-            $"Cannot add or update a child row: a foreign key constraint fails ({col} → {refTbl})", 1452);
+            SqlExceptionMessages.ForeignKeyFails(col, refTbl), 1452);
 
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public static Exception ReferencedRow(string tbl)
         => new SqliteMockException(
-            $"Cannot delete or update a parent row: a foreign key constraint fails (child referencing '{tbl}')", 1451);
+            SqlExceptionMessages.ReferencedRow(tbl), 1451);
 }

--- a/src/DbSqlLikeMem.Sqlite/Extensions/SqliteValueHelper.cs
+++ b/src/DbSqlLikeMem.Sqlite/Extensions/SqliteValueHelper.cs
@@ -1,3 +1,4 @@
+using DbSqlLikeMem.Resources;
 ﻿using Microsoft.Data.Sqlite;
 using System.Text.Json;
 
@@ -38,7 +39,7 @@ internal static class SqliteValueHelper
                 .Replace("\r\n", string.Empty)
                 .Replace(";", string.Empty);
             if (pars == null || !pars.Contains(name))
-                throw new SqliteMockException($"Parâmetro {name} não encontrado.");
+                throw new SqliteMockException(SqlExceptionMessages.ParameterNotFound(name));
             return ((SqliteParameter)pars[name]).Value;
         }
 
@@ -46,7 +47,7 @@ internal static class SqliteValueHelper
         if (token.Equals("null", StringComparison.OrdinalIgnoreCase))
             return isNullable 
                 ? null
-                : throw new SqliteMockException("Coluna não aceita NULL");
+                : throw new SqliteMockException(SqlExceptionMessages.ColumnDoesNotAcceptNull());
 
         // ---------- lista ( ..., ... )  para IN ------------------------
         var m = _list.Match(token);
@@ -139,10 +140,10 @@ internal static class SqliteValueHelper
             return value;
 
         if (cdef.Size is int size && value is string s && s.Length > size)
-            throw new SqliteMockException($"Data too long for column '{CurrentColumn}'", 1406);
+            throw new SqliteMockException(SqlExceptionMessages.DataTooLongForColumn(CurrentColumn), 1406);
 
         if (cdef.DecimalPlaces is int scale && value is decimal d && GetDecimalScale(d) > scale)
-            throw new SqliteMockException($"Data truncated for column '{CurrentColumn}'", 1265);
+            throw new SqliteMockException(SqlExceptionMessages.DataTruncatedForColumn(CurrentColumn), 1265);
 
         return value;
     }

--- a/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
@@ -1,3 +1,4 @@
+using DbSqlLikeMem.Resources;
 ﻿using Microsoft.Data.Sqlite;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
@@ -110,7 +111,7 @@ public class SqliteCommandMock(
         {
             var q = SqlQueryParser.Parse(sqlRaw, connection!.Db.Dialect);
             if (q is not SqlCreateTemporaryTableQuery ct)
-                throw new InvalidOperationException("Invalid CREATE TEMPORARY TABLE statement.");
+                throw new InvalidOperationException(SqlExceptionMessages.InvalidCreateTemporaryTableStatement());
             return connection.ExecuteCreateTemporaryTableAsSelect(ct, Parameters, connection.Db.Dialect);
         }
 
@@ -119,7 +120,7 @@ public class SqliteCommandMock(
         {
             var q = SqlQueryParser.Parse(sqlRaw, connection!.Db.Dialect);
             if (q is not SqlCreateViewQuery cv)
-                throw new InvalidOperationException("Invalid CREATE VIEW statement.");
+                throw new InvalidOperationException(SqlExceptionMessages.InvalidCreateViewStatement());
             return connection.ExecuteCreateView(cv, Parameters, connection.Db.Dialect);
         }
 
@@ -138,8 +139,8 @@ public class SqliteCommandMock(
             SqlDeleteQuery deleteQ => connection.ExecuteDeleteSmart(deleteQ, Parameters, connection.Db.Dialect),
             SqlCreateViewQuery cv => connection.ExecuteCreateView(cv, Parameters, connection.Db.Dialect),
             SqlDropViewQuery dropViewQ => connection.ExecuteDropView(dropViewQ, Parameters, connection.Db.Dialect),
-            SqlSelectQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT."),
-            SqlUnionQuery _ => throw new InvalidOperationException("Use ExecuteReader para comandos SELECT/UNION."),
+            SqlSelectQuery _ => throw new InvalidOperationException(SqlExceptionMessages.UseExecuteReaderForSelect()),
+            SqlUnionQuery _ => throw new InvalidOperationException(SqlExceptionMessages.UseExecuteReaderForSelectUnion()),
             _ => throw SqlUnsupported.ForCommandType(connection!.Db.Dialect, "ExecuteNonQuery", query.GetType())
         };
     }
@@ -218,7 +219,7 @@ public class SqliteCommandMock(
         }
 
         if (tables.Count == 0 && queries.Count > 0)
-            throw new InvalidOperationException("ExecuteReader foi chamado, mas nenhuma query SELECT foi encontrada.");
+            throw new InvalidOperationException(SqlExceptionMessages.ExecuteReaderWithoutSelectQuery());
 
         connection.Metrics.Selects += tables.Sum(t => t.Count);
 

--- a/src/DbSqlLikeMem.Sqlite/SqliteDataParameterCollectionMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDataParameterCollectionMock.cs
@@ -1,3 +1,4 @@
+using DbSqlLikeMem.Resources;
 ﻿using Microsoft.Data.Sqlite;
 using System.Collections;
 using System.Data.Common;
@@ -23,7 +24,7 @@ public class SqliteDataParameterCollectionMock
     {
         var normalizedParameterName = NormalizeParameterName(parameter.ParameterName);
         if (!string.IsNullOrEmpty(normalizedParameterName) && NormalizedIndexOf(normalizedParameterName) != -1)
-            throw new ArgumentException($"Parameter '{parameter.ParameterName}' has already been defined.");
+            throw new ArgumentException(SqlExceptionMessages.ParameterAlreadyDefined(parameter.ParameterName));
         if (index < Items.Count)
         {
             foreach (var pair in DicItems.ToList())
@@ -65,7 +66,7 @@ public class SqliteDataParameterCollectionMock
     {
         var index = IndexOf(parameterName);
         if (index == -1)
-            throw new ArgumentException($"Parameter '{parameterName}' not found in the collection", nameof(parameterName));
+            throw new ArgumentException(SqlExceptionMessages.ParameterNotFoundInCollection(parameterName), nameof(parameterName));
         return Items[index];
     }
 

--- a/src/DbSqlLikeMem/DbSqlLikeMem.csproj
+++ b/src/DbSqlLikeMem/DbSqlLikeMem.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Description>In-memory SQL-like database engine for unit tests.</Description>
+		<NeutralLanguage>en</NeutralLanguage>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/DbSqlLikeMem/Resources/SqlExceptionMessages.cs
+++ b/src/DbSqlLikeMem/Resources/SqlExceptionMessages.cs
@@ -1,0 +1,74 @@
+using System.Globalization;
+using System.Resources;
+
+namespace DbSqlLikeMem.Resources;
+
+public static class SqlExceptionMessages
+{
+    private static readonly ResourceManager ResourceManager =
+        new("DbSqlLikeMem.Resources.SqlExceptionMessages", typeof(SqlExceptionMessages).Assembly);
+
+    public static string DuplicateKey(object? value, string key) =>
+        Format(nameof(DuplicateKey), value, key);
+
+    public static string UnknownColumn(string column) =>
+        Format(nameof(UnknownColumn), column);
+
+    public static string ColumnCannotBeNull(string column) =>
+        Format(nameof(ColumnCannotBeNull), column);
+
+    public static string ForeignKeyFails(string column, string referencedTable) =>
+        Format(nameof(ForeignKeyFails), column, referencedTable);
+
+    public static string ReferencedRow(string table) =>
+        Format(nameof(ReferencedRow), table);
+
+
+    public static string ParameterAlreadyDefined(string parameterName) =>
+        Format(nameof(ParameterAlreadyDefined), parameterName);
+
+    public static string ParameterNotFoundInCollection(string parameterName) =>
+        Format(nameof(ParameterNotFoundInCollection), parameterName);
+
+    public static string InvalidCreateTemporaryTableStatement() =>
+        Format(nameof(InvalidCreateTemporaryTableStatement));
+
+    public static string InvalidCreateViewStatement() =>
+        Format(nameof(InvalidCreateViewStatement));
+
+    public static string InvalidDeleteExpectedFromKeyword() =>
+        Format(nameof(InvalidDeleteExpectedFromKeyword));
+
+    public static string UseExecuteReaderForSelect() =>
+        Format(nameof(UseExecuteReaderForSelect));
+
+    public static string UseExecuteReaderForSelectUnion() =>
+        Format(nameof(UseExecuteReaderForSelectUnion));
+
+    public static string ExecuteReaderWithoutSelectQuery() =>
+        Format(nameof(ExecuteReaderWithoutSelectQuery));
+
+    public static string InvalidDropViewStatement() =>
+        Format(nameof(InvalidDropViewStatement));
+
+    public static string ParameterNotFound(string parameterName) =>
+        Format(nameof(ParameterNotFound), parameterName);
+
+    public static string ColumnDoesNotAcceptNull() =>
+        Format(nameof(ColumnDoesNotAcceptNull));
+
+    public static string DataTooLongForColumn(string column) =>
+        Format(nameof(DataTooLongForColumn), column);
+
+    public static string DataTruncatedForColumn(string column) =>
+        Format(nameof(DataTruncatedForColumn), column);
+
+    private static string Format(string key, params object?[] args)
+    {
+        var template = ResourceManager.GetString(key, CultureInfo.CurrentUICulture)
+            ?? ResourceManager.GetString(key, CultureInfo.InvariantCulture)
+            ?? key;
+
+        return string.Format(CultureInfo.CurrentCulture, template, args);
+    }
+}

--- a/src/DbSqlLikeMem/Resources/SqlExceptionMessages.pt.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExceptionMessages.pt.resx
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DuplicateKey" xml:space="preserve">
+    <value>Entrada duplicada '{0}' para a chave '{1}'</value>
+  </data>
+  <data name="UnknownColumn" xml:space="preserve">
+    <value>Coluna desconhecida '{0}'</value>
+  </data>
+  <data name="ColumnCannotBeNull" xml:space="preserve">
+    <value>A coluna '{0}' não pode ser nula</value>
+  </data>
+  <data name="ForeignKeyFails" xml:space="preserve">
+    <value>Não é possível adicionar ou atualizar uma linha filha: a restrição de chave estrangeira falhou ({0} → {1})</value>
+  </data>
+  <data name="ReferencedRow" xml:space="preserve">
+    <value>Não é possível excluir ou atualizar uma linha pai: a restrição de chave estrangeira falhou (filho referenciando '{0}')</value>
+  </data>
+  <data name="ParameterAlreadyDefined" xml:space="preserve">
+    <value>Parâmetro '{0}' já foi definido.</value>
+  </data>
+  <data name="ParameterNotFoundInCollection" xml:space="preserve">
+    <value>Parâmetro '{0}' não encontrado na coleção</value>
+  </data>
+  <data name="InvalidCreateTemporaryTableStatement" xml:space="preserve">
+    <value>Instrução CREATE TEMPORARY TABLE inválida.</value>
+  </data>
+  <data name="InvalidCreateViewStatement" xml:space="preserve">
+    <value>Instrução CREATE VIEW inválida.</value>
+  </data>
+  <data name="InvalidDeleteExpectedFromKeyword" xml:space="preserve">
+    <value>Instrução DELETE inválida: era esperada a palavra-chave FROM.</value>
+  </data>
+  <data name="UseExecuteReaderForSelect" xml:space="preserve">
+    <value>Use ExecuteReader para comandos SELECT.</value>
+  </data>
+  <data name="UseExecuteReaderForSelectUnion" xml:space="preserve">
+    <value>Use ExecuteReader para comandos SELECT/UNION.</value>
+  </data>
+  <data name="ExecuteReaderWithoutSelectQuery" xml:space="preserve">
+    <value>ExecuteReader foi chamado, mas nenhuma query SELECT foi encontrada.</value>
+  </data>
+  <data name="InvalidDropViewStatement" xml:space="preserve">
+    <value>Instrução DROP VIEW inválida.</value>
+  </data>
+  <data name="ParameterNotFound" xml:space="preserve">
+    <value>Parâmetro {0} não encontrado.</value>
+  </data>
+  <data name="ColumnDoesNotAcceptNull" xml:space="preserve">
+    <value>Coluna não aceita NULL</value>
+  </data>
+  <data name="DataTooLongForColumn" xml:space="preserve">
+    <value>Dados longos demais para a coluna '{0}'</value>
+  </data>
+  <data name="DataTruncatedForColumn" xml:space="preserve">
+    <value>Dados truncados para a coluna '{0}'</value>
+  </data>
+</root>

--- a/src/DbSqlLikeMem/Resources/SqlExceptionMessages.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExceptionMessages.resx
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DuplicateKey" xml:space="preserve">
+    <value>Duplicate entry '{0}' for key '{1}'</value>
+  </data>
+  <data name="UnknownColumn" xml:space="preserve">
+    <value>Unknown column '{0}'</value>
+  </data>
+  <data name="ColumnCannotBeNull" xml:space="preserve">
+    <value>Column '{0}' cannot be null</value>
+  </data>
+  <data name="ForeignKeyFails" xml:space="preserve">
+    <value>Cannot add or update a child row: a foreign key constraint fails ({0} → {1})</value>
+  </data>
+  <data name="ReferencedRow" xml:space="preserve">
+    <value>Cannot delete or update a parent row: a foreign key constraint fails (child referencing '{0}')</value>
+  </data>
+  <data name="ParameterAlreadyDefined" xml:space="preserve">
+    <value>Parameter '{0}' has already been defined.</value>
+  </data>
+  <data name="ParameterNotFoundInCollection" xml:space="preserve">
+    <value>Parameter '{0}' not found in the collection</value>
+  </data>
+  <data name="InvalidCreateTemporaryTableStatement" xml:space="preserve">
+    <value>Invalid CREATE TEMPORARY TABLE statement.</value>
+  </data>
+  <data name="InvalidCreateViewStatement" xml:space="preserve">
+    <value>Invalid CREATE VIEW statement.</value>
+  </data>
+  <data name="InvalidDeleteExpectedFromKeyword" xml:space="preserve">
+    <value>Invalid DELETE statement: expected FROM keyword.</value>
+  </data>
+  <data name="UseExecuteReaderForSelect" xml:space="preserve">
+    <value>Use ExecuteReader for SELECT commands.</value>
+  </data>
+  <data name="UseExecuteReaderForSelectUnion" xml:space="preserve">
+    <value>Use ExecuteReader for SELECT/UNION commands.</value>
+  </data>
+  <data name="ExecuteReaderWithoutSelectQuery" xml:space="preserve">
+    <value>ExecuteReader was called, but no SELECT query was found.</value>
+  </data>
+  <data name="InvalidDropViewStatement" xml:space="preserve">
+    <value>Invalid DROP VIEW statement.</value>
+  </data>
+  <data name="ParameterNotFound" xml:space="preserve">
+    <value>Parameter {0} not found.</value>
+  </data>
+  <data name="ColumnDoesNotAcceptNull" xml:space="preserve">
+    <value>Column does not accept NULL</value>
+  </data>
+  <data name="DataTooLongForColumn" xml:space="preserve">
+    <value>Data too long for column '{0}'</value>
+  </data>
+  <data name="DataTruncatedForColumn" xml:space="preserve">
+    <value>Data truncated for column '{0}'</value>
+  </data>
+</root>


### PR DESCRIPTION
### Motivation
- Replace hardcoded error message fragments used in provider mocks and tests with centralized, localizable messages from `SqlExceptionMessages` so tests validate against resource-driven strings and support localization.
- Ensure exception factories, value helpers and command/parameter mocks emit the same messages the tests expect, avoiding brittle literal comparisons.

### Description
- Added `DbSqlLikeMem.Resources.SqlExceptionMessages` helper class and `SqlExceptionMessages.resx` / `SqlExceptionMessages.pt.resx` resource files to centralize error message templates.
- Updated provider exception factories (`*ExceptionFactory.cs`) to build exceptions using `SqlExceptionMessages` instead of hardcoded literals for duplicate keys, unknown columns, nullability, FK failures and related cases.
- Replaced hardcoded messages in value helpers and command/parameter mocks (Db2, MySql, Npgsql, Oracle, SqlServer, Sqlite) to throw exceptions or `InvalidOperationException` using the resource helper methods (e.g. `ColumnDoesNotAcceptNull()`, `DuplicateKey(...)`, `ExecuteReaderWithoutSelectQuery()`).
- Updated strategy tests across providers to assert against `SqlExceptionMessages` outputs instead of fixed strings (tests now derive expected fragments from `SqlExceptionMessages`), and set project neutral language in `DbSqlLikeMem.csproj` (`<NeutralLanguage>en</NeutralLanguage>`).

### Testing
- Searched test sources with `rg` to find and replace assertions that used literals like `Duplicate entry`, `Coluna não aceita NULL` and `Cannot delete or update a parent row`, and verified matches now reference `SqlExceptionMessages`.
- Committed the changes (12 test strategy files and multiple provider files) and confirmed the commit succeeded (`git commit` completed). 
- Attempted to run `dotnet test` for validation but the environment lacked the `dotnet` CLI (`dotnet: command not found`), so full automated test execution could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb378cf00832c8216efb00c8f6fbb)