### PR TITLE
Add bilingual XML summaries to trigger strategy tests

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2TriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2TriggerStrategyTests.cs
@@ -1,7 +1,15 @@
 namespace DbSqlLikeMem.Db2.Test.Strategy;
 
+/// <summary>
+/// EN: Contains trigger behavior tests for the Db2 strategy.
+/// PT: Contém testes de comportamento de gatilhos para a estratégia Db2.
+/// </summary>
 public sealed class Db2TriggerStrategyTests
 {
+    /// <summary>
+    /// EN: Ensures that an AFTER INSERT trigger is executed for a non-temporary table.
+    /// PT: Garante que um gatilho AFTER INSERT seja executado para uma tabela não temporária.
+    /// </summary>
     [Fact]
     public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
     {
@@ -20,6 +28,10 @@ public sealed class Db2TriggerStrategyTests
         Assert.Equal(1, calls);
     }
 
+    /// <summary>
+    /// EN: Ensures that an AFTER INSERT trigger is not executed for a temporary table.
+    /// PT: Garante que um gatilho AFTER INSERT não seja executado para uma tabela temporária.
+    /// </summary>
     [Fact]
     public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
     {

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTriggerStrategyTests.cs
@@ -1,7 +1,15 @@
 namespace DbSqlLikeMem.MySql.Test.Strategy;
 
+/// <summary>
+/// EN: Contains trigger behavior tests for the MySQL strategy.
+/// PT: Contém testes de comportamento de gatilhos para a estratégia MySQL.
+/// </summary>
 public sealed class MySqlTriggerStrategyTests
 {
+    /// <summary>
+    /// EN: Ensures that an AFTER INSERT trigger is executed for a non-temporary table.
+    /// PT: Garante que um gatilho AFTER INSERT seja executado para uma tabela não temporária.
+    /// </summary>
     [Fact]
     public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
     {
@@ -20,6 +28,10 @@ public sealed class MySqlTriggerStrategyTests
         Assert.Equal(1, calls);
     }
 
+    /// <summary>
+    /// EN: Ensures that an AFTER INSERT trigger is not executed for a temporary table.
+    /// PT: Garante que um gatilho AFTER INSERT não seja executado para uma tabela temporária.
+    /// </summary>
     [Fact]
     public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTriggerStrategyTests.cs
@@ -1,7 +1,15 @@
 namespace DbSqlLikeMem.Npgsql.Test.Strategy;
 
+/// <summary>
+/// EN: Contains trigger behavior tests for the PostgreSQL strategy.
+/// PT: Contém testes de comportamento de gatilhos para a estratégia PostgreSQL.
+/// </summary>
 public sealed class PostgreSqlTriggerStrategyTests
 {
+    /// <summary>
+    /// EN: Ensures that an AFTER INSERT trigger is executed for a non-temporary table.
+    /// PT: Garante que um gatilho AFTER INSERT seja executado para uma tabela não temporária.
+    /// </summary>
     [Fact]
     public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
     {
@@ -20,6 +28,10 @@ public sealed class PostgreSqlTriggerStrategyTests
         Assert.Equal(1, calls);
     }
 
+    /// <summary>
+    /// EN: Ensures that triggers are not executed for a temporary table.
+    /// PT: Garante que os gatilhos não sejam executados para uma tabela temporária.
+    /// </summary>
     [Fact]
     public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTriggerStrategyTests.cs
@@ -1,7 +1,15 @@
 namespace DbSqlLikeMem.Oracle.Test.Strategy;
 
+/// <summary>
+/// EN: Contains trigger behavior tests for the Oracle strategy.
+/// PT: Contém testes de comportamento de gatilhos para a estratégia Oracle.
+/// </summary>
 public sealed class OracleTriggerStrategyTests
 {
+    /// <summary>
+    /// EN: Ensures that an AFTER INSERT trigger is executed for a non-temporary table.
+    /// PT: Garante que um gatilho AFTER INSERT seja executado para uma tabela não temporária.
+    /// </summary>
     [Fact]
     public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
     {
@@ -20,6 +28,10 @@ public sealed class OracleTriggerStrategyTests
         Assert.Equal(1, calls);
     }
 
+    /// <summary>
+    /// EN: Ensures that triggers are not executed for a temporary table.
+    /// PT: Garante que os gatilhos não sejam executados para uma tabela temporária.
+    /// </summary>
     [Fact]
     public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTriggerStrategyTests.cs
@@ -1,7 +1,15 @@
 namespace DbSqlLikeMem.SqlServer.Test.Strategy;
 
+/// <summary>
+/// EN: Contains trigger behavior tests for the SQL Server strategy.
+/// PT: Contém testes de comportamento de gatilhos para a estratégia SQL Server.
+/// </summary>
 public sealed class SqlServerTriggerStrategyTests
 {
+    /// <summary>
+    /// EN: Ensures that insert, update, and delete triggers are executed for a non-temporary table.
+    /// PT: Garante que os gatilhos de insert, update e delete sejam executados para uma tabela não temporária.
+    /// </summary>
     [Fact]
     public void NonTemporaryTable_ShouldExecuteInsertUpdateDeleteTriggers()
     {
@@ -41,6 +49,10 @@ public sealed class SqlServerTriggerStrategyTests
         ], events);
     }
 
+    /// <summary>
+    /// EN: Ensures that triggers are not executed for a temporary table.
+    /// PT: Garante que os gatilhos não sejam executados para uma tabela temporária.
+    /// </summary>
     [Fact]
     public void TemporaryTable_ShouldNotExecuteTriggers()
     {

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteTriggerStrategyTests.cs
@@ -1,7 +1,15 @@
 namespace DbSqlLikeMem.Sqlite.Test.Strategy;
 
+/// <summary>
+/// EN: Contains trigger behavior tests for the SQLite strategy.
+/// PT: Contém testes de comportamento de gatilhos para a estratégia SQLite.
+/// </summary>
 public sealed class SqliteTriggerStrategyTests
 {
+    /// <summary>
+    /// EN: Ensures that an AFTER INSERT trigger is executed for a non-temporary table.
+    /// PT: Garante que um gatilho AFTER INSERT seja executado para uma tabela não temporária.
+    /// </summary>
     [Fact]
     public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
     {
@@ -20,6 +28,10 @@ public sealed class SqliteTriggerStrategyTests
         Assert.Equal(1, calls);
     }
 
+    /// <summary>
+    /// EN: Ensures that triggers are not executed for a temporary table.
+    /// PT: Garante que os gatilhos não sejam executados para uma tabela temporária.
+    /// </summary>
     [Fact]
     public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
     {


### PR DESCRIPTION
### Motivation
- Silence CS1591 warnings by adding missing XML documentation to publicly visible test classes and methods in trigger strategy tests.
- Follow the project documentation pattern requested: English first (`EN:`) then Portuguese (`PT:`).

### Description
- Added class-level and method-level `/// <summary>` XML comments (English then Portuguese) to trigger tests for Db2, MySQL, PostgreSQL (`Npgsql`), Oracle, SQL Server, and SQLite.
- Updated the following files: `Db2TriggerStrategyTests.cs`, `MySqlTriggerStrategyTests.cs`, `PostgreSqlTriggerStrategyTests.cs`, `OracleTriggerStrategyTests.cs`, `SqlServerTriggerStrategyTests.cs`, and `SqliteTriggerStrategyTests.cs`.
- The changes are documentation-only and do not alter test logic or runtime behavior.

### Testing
- Attempted to run `dotnet build DbSqlLikeMem.sln -v minimal` to verify warning reduction, but the command failed in this environment with `dotnet: command not found` so build verification could not be performed.
- No unit tests were executed in this environment; changes are limited to comments and should be safe to validate via a normal `dotnet build` in a development environment with the SDK installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fbab3a79c832c9395250c765774d4)