### PR TITLE
Fix missing SqlParser reference and HAVING alias nullability warning

### DIFF
--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -298,7 +298,7 @@ internal abstract class AstQueryExecutorBase(
                 }
 #pragma warning restore CA1031
 
-                return (alias, ast);
+                return (Alias: alias!, Ast: ast);
             })
             .Where(x => x.HasValue)
             .Select(x => x!.Value)

--- a/src/DbSqlLikeMem/Strategies/DbInsertStrategy.cs
+++ b/src/DbSqlLikeMem/Strategies/DbInsertStrategy.cs
@@ -355,8 +355,7 @@ internal static class DbInsertStrategy
         {
             var colInfo = table.GetColumn(col);
             if (colInfo.GetGenValue != null) continue;
-            var parser = new SqlParser(exprRaw, dialect);
-            var expr = parser.ParseExpression();
+            var expr = SqlExpressionParser.ParseScalar(exprRaw, dialect);
             var resolved = Eval(expr);
             var coerced = Coerce(colInfo.DbType, resolved);
             targetRow[colInfo.Index] = coerced;


### PR DESCRIPTION
### Motivation
- Fix build errors/warnings introduced by recent changes: `CS0246` for a missing `SqlParser` type in `DbInsertStrategy` and `CS8619` nullability mismatch for HAVING alias tuples in `AstQueryExecutorBase`.

### Description
- Replace the obsolete `SqlParser` usage in `src/DbSqlLikeMem/Strategies/DbInsertStrategy.cs` with `SqlExpressionParser.ParseScalar(exprRaw, dialect)` to align with the current parser API.
- Return a non-null alias in `src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs` by changing the tuple construction to `return (Alias: alias!, Ast: ast);` after the existing null/whitespace guard.

### Testing
- Attempted to run `dotnet build DbSqlLikeMem.sln -v minimal`, but `dotnet` is not available in the execution environment so the build could not be executed; no automated tests were run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699482e88940832c813a18e32aac611f)