### PR TITLE
Fix nullable and XML documentation warnings in hash set, MySQL mocks and CSV tests

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/CsvLoaderAndIndexTests.cs
@@ -67,7 +67,7 @@ public sealed class CsvLoaderAndIndexTests(
         var idxDef = tb.CreateIndex("ix_name", ["name"]);
 
         var ix = tb.Lookup(idxDef, "John");
-        Assert.Equal([0, 1], [.. ix.Select(_ => _.Key)!.OrderBy(_ => _)]);
+        Assert.Equal([0, 1], [.. ix!.Select(_ => _.Key).OrderBy(_ => _)]);
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.MySql.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/CsvLoaderAndIndexTests.cs
@@ -67,7 +67,7 @@ public sealed class CsvLoaderAndIndexTests(
         var idxDef = tb.CreateIndex("ix_name", ["name"]);
 
         var ix = tb.Lookup(idxDef, "John" );
-        Assert.Equal([0, 1], [.. ix.Select(_=>_.Key)!.OrderBy(_=>_)]);
+        Assert.Equal([0, 1], [.. ix!.Select(_ => _.Key).OrderBy(_ => _)]);
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.MySql/MySqlBatchMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlBatchMock.cs
@@ -66,9 +66,6 @@ public sealed class MySqlBatchMock :
     public MySqlTransactionMock? Transaction { get; set; }
 #endif
 
-    /// <summary>
-    /// The collection of commands that will be executed in the batch.
-    /// </summary>
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Mock API member implementation for compatibility with MySQL provider contracts.
@@ -88,11 +85,6 @@ public sealed class MySqlBatchMock :
     public MySqlBatchCommandCollectionMock BatchCommands { get; }
 #endif
 
-    /// <summary>
-    /// Executes all the commands in the batch, returning a <see cref="MySqlDataReader"/> that can iterate
-    /// over the result sets. If multiple resultsets are returned, use <see cref="MySqlDataReader.NextResult"/>
-    /// to access them.
-    /// </summary>
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Mock API member implementation for compatibility with MySQL provider contracts.
@@ -108,13 +100,6 @@ public sealed class MySqlBatchMock :
 #endif
         (MySqlDataReaderMock) ExecuteDbDataReader(commandBehavior);
 
-    /// <summary>
-    /// Executes all the commands in the batch, returning a <see cref="MySqlDataReader"/> that can iterate
-    /// over the result sets. If multiple resultsets are returned, use <see cref="MySqlDataReader.NextResultAsync(CancellationToken)"/>
-    /// to access them.
-    /// </summary>
-    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-    /// <returns>A <see cref="Task{MySqlDataReaderMock}"/> containing the result of the asynchronous operation.</returns>
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Mock API member implementation for compatibility with MySQL provider contracts.
@@ -166,7 +151,7 @@ public sealed class MySqlBatchMock :
             cancellationToken).ConfigureAwait(false);
     }
 
-    private ValueTask<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior,
+    private new ValueTask<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior,
         //IOBehavior ioBehavior, 
         CancellationToken cancellationToken)
     {

--- a/src/DbSqlLikeMem.MySql/MySqlDataAdapterMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDataAdapterMock.cs
@@ -18,11 +18,11 @@ public sealed class MySqlDataAdapterMock : DbDataAdapter, IDbDataAdapter
     /// Mock API member implementation for compatibility with MySQL provider contracts.
     /// Implementação de membro da API mock para compatibilidade com os contratos do provedor MySQL.
     /// </summary>
-    public new MySqlCommandMock DeleteCommand
+    public new MySqlCommandMock? DeleteCommand
     {
         get
         {
-            return (MySqlCommandMock)base.DeleteCommand;
+            return base.DeleteCommand as MySqlCommandMock;
         }
         set
         {
@@ -34,11 +34,11 @@ public sealed class MySqlDataAdapterMock : DbDataAdapter, IDbDataAdapter
     /// Mock API member implementation for compatibility with MySQL provider contracts.
     /// Implementação de membro da API mock para compatibilidade com os contratos do provedor MySQL.
     /// </summary>
-    public new MySqlCommandMock InsertCommand
+    public new MySqlCommandMock? InsertCommand
     {
         get
         {
-            return (MySqlCommandMock)base.InsertCommand;
+            return base.InsertCommand as MySqlCommandMock;
         }
         set
         {
@@ -46,16 +46,16 @@ public sealed class MySqlDataAdapterMock : DbDataAdapter, IDbDataAdapter
         }
     }
 
-    [Category("Fill")]
     /// <summary>
-    /// Mock API member implementation for compatibility with MySQL provider contracts.
-    /// Implementação de membro da API mock para compatibilidade com os contratos do provedor MySQL.
+    /// EN: Mock API member implementation for compatibility with MySQL provider contracts.
+    /// PT: Implementação de membro da API mock para compatibilidade com os contratos do provedor MySQL.
     /// </summary>
-    public new MySqlCommandMock SelectCommand
+    [Category("Fill")]
+    public new MySqlCommandMock? SelectCommand
     {
         get
         {
-            return (MySqlCommandMock)base.SelectCommand;
+            return base.SelectCommand as MySqlCommandMock;
         }
         set
         {
@@ -67,11 +67,11 @@ public sealed class MySqlDataAdapterMock : DbDataAdapter, IDbDataAdapter
     /// Mock API member implementation for compatibility with MySQL provider contracts.
     /// Implementação de membro da API mock para compatibilidade com os contratos do provedor MySQL.
     /// </summary>
-    public new MySqlCommandMock UpdateCommand
+    public new MySqlCommandMock? UpdateCommand
     {
         get
         {
-            return (MySqlCommandMock)base.UpdateCommand;
+            return base.UpdateCommand as MySqlCommandMock;
         }
         set
         {
@@ -289,7 +289,7 @@ public sealed class MySqlDataAdapterMock : DbDataAdapter, IDbDataAdapter
     protected override IDataParameter GetBatchedParameter(int commandIdentifier, int parameterIndex)
     {
         ArgumentNullExceptionCompatible.ThrowIfNull(commandBatch, nameof(commandBatch));
-        object? parameter = commandBatch[commandIdentifier].Parameters[parameterIndex];
+        object? parameter = commandBatch![commandIdentifier].Parameters[parameterIndex];
         return (IDataParameter)parameter!;
     }
 
@@ -297,15 +297,15 @@ public sealed class MySqlDataAdapterMock : DbDataAdapter, IDbDataAdapter
     /// Mock API member implementation for compatibility with MySQL provider contracts.
     /// Implementação de membro da API mock para compatibilidade com os contratos do provedor MySQL.
     /// </summary>
-    protected override RowUpdatedEventArgs CreateRowUpdatedEvent(DataRow dataRow, IDbCommand command, StatementType statementType, DataTableMapping tableMapping)
-        => new MySqlRowUpdatedEventArgs(dataRow, command, statementType, tableMapping);
+    protected override RowUpdatedEventArgs CreateRowUpdatedEvent(DataRow dataRow, IDbCommand? command, StatementType statementType, DataTableMapping tableMapping)
+        => new MySqlRowUpdatedEventArgs(dataRow, command!, statementType, tableMapping);
 
     /// <summary>
     /// Mock API member implementation for compatibility with MySQL provider contracts.
     /// Implementação de membro da API mock para compatibilidade com os contratos do provedor MySQL.
     /// </summary>
-    protected override RowUpdatingEventArgs CreateRowUpdatingEvent(DataRow dataRow, IDbCommand command, StatementType statementType, DataTableMapping tableMapping)
-        => new MySqlRowUpdatingEventArgs(dataRow, command, statementType, tableMapping);
+    protected override RowUpdatingEventArgs CreateRowUpdatingEvent(DataRow dataRow, IDbCommand? command, StatementType statementType, DataTableMapping tableMapping)
+        => new MySqlRowUpdatingEventArgs(dataRow, command!, statementType, tableMapping);
 
     /// <summary>
     /// Mock API member implementation for compatibility with MySQL provider contracts.

--- a/src/DbSqlLikeMem.MySql/MySqlDataSourceMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDataSourceMock.cs
@@ -21,18 +21,17 @@ public sealed class MySqlDataSourceMock(MySqlDbMock? db = null)
 #endif
         string ConnectionString => string.Empty;
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Creates a database connection bound to the configured mock database.
     /// Cria uma conexão de banco vinculada ao banco de dados mock configurado.
     /// </summary>
-#if NET8_0_OR_GREATER
-    protected override
+    protected override DbConnection CreateDbConnection() => new MySqlConnectionMock(db);
 #else
     /// <summary>
     /// Creates a database connection bound to the configured mock database.
     /// Cria uma conexão de banco vinculada ao banco de dados mock configurado.
     /// </summary>
-    public
+    public DbConnection CreateDbConnection() => new MySqlConnectionMock(db);
 #endif
-         DbConnection CreateDbConnection() => new MySqlConnectionMock(db);
 }

--- a/src/DbSqlLikeMem.Npgsql.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/CsvLoaderAndIndexTests.cs
@@ -67,7 +67,7 @@ public sealed class CsvLoaderAndIndexTests(
         var idxDef = tb.CreateIndex("ix_name", ["name"]);
 
         var ix = tb.Lookup(idxDef, "John");
-        Assert.Equal([0, 1], [.. ix.Select(_ => _.Key)!.OrderBy(_ => _)]);
+        Assert.Equal([0, 1], [.. ix!.Select(_ => _.Key).OrderBy(_ => _)]);
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Oracle.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/CsvLoaderAndIndexTests.cs
@@ -68,7 +68,7 @@ public sealed class CsvLoaderAndIndexTests(
         var idxDef = tb.CreateIndex("ix_name", ["name"]);
 
         var ix = tb.Lookup(idxDef, "John");
-        Assert.Equal([0, 1], [.. ix.Select(_ => _.Key)!.OrderBy(_ => _)]);
+        Assert.Equal([0, 1], [.. ix!.Select(_ => _.Key).OrderBy(_ => _)]);
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.SqlServer.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/CsvLoaderAndIndexTests.cs
@@ -67,7 +67,7 @@ public sealed class CsvLoaderAndIndexTests(
         var idxDef = tb.CreateIndex("ix_name", ["name"]);
 
         var ix = tb.Lookup(idxDef, "John");
-        Assert.Equal([0, 1], [.. ix.Select(_ => _.Key)!.OrderBy(_ => _)]);
+        Assert.Equal([0, 1], [.. ix!.Select(_ => _.Key).OrderBy(_ => _)]);
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Sqlite.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/CsvLoaderAndIndexTests.cs
@@ -67,7 +67,7 @@ public sealed class CsvLoaderAndIndexTests(
         var idxDef = tb.CreateIndex("ix_name", ["name"]);
 
         var ix = tb.Lookup(idxDef, "John");
-        Assert.Equal([0, 1], [.. ix.Select(_ => _.Key)!.OrderBy(_ => _)]);
+        Assert.Equal([0, 1], [.. ix!.Select(_ => _.Key).OrderBy(_ => _)]);
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem/Models/ReadOnlyHashSet.cs
+++ b/src/DbSqlLikeMem/Models/ReadOnlyHashSet.cs
@@ -1,4 +1,5 @@
 ﻿using DbSqlLikeMem.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
 namespace DbSqlLikeMem.Models;
@@ -345,7 +346,7 @@ public class ReadOnlyHashSet<T> : IReadOnlyHashSet<T>
     //   T:System.Runtime.Serialization.SerializationException:
     //     The System.Runtime.Serialization.SerializationInfo object associated with the
     //     current System.Collections.Generic.HashSet`1 object is invalid.
-    public virtual void OnDeserialization(object sender)
+    public virtual void OnDeserialization(object? sender)
         => _set.OnDeserialization(sender);
     //
     // Summary:
@@ -402,7 +403,7 @@ public class ReadOnlyHashSet<T> : IReadOnlyHashSet<T>
     //
     // Returns:
     //     A value indicating whether the search was successful.
-    public bool TryGetValue(T equalValue, out T actualValue)
+    public bool TryGetValue(T equalValue, [MaybeNullWhen(false)] out T actualValue)
         => _set.TryGetValue(equalValue, out actualValue);
 
     IEnumerator<T> IEnumerable<T>.GetEnumerator()


### PR DESCRIPTION
### Motivation
- EN: Add missing/adjusted nullability and XML-doc fixes to silence compiler warnings and align APIs with framework contracts; PT: Ajustar nulabilidade e documentação XML para suprimir avisos do compilador e alinhar as assinaturas com os contratos do framework.
- Fix signature mismatches and possible-null flows detected in `ReadOnlyHashSet<T>` and MySQL mock types to improve nullable-reference correctness.
- Update provider-specific CSV index tests to remove nullable flow warnings by null-forgiving the lookup before LINQ projection.

### Description
- Aligned `ReadOnlyHashSet<T>.OnDeserialization` to accept `object?` and annotated `TryGetValue` with `[MaybeNullWhen(false)]`, and added `using System.Diagnostics.CodeAnalysis;` to support the attribute (`src/DbSqlLikeMem/Models/ReadOnlyHashSet.cs`).
- Adjusted `MySqlDataAdapterMock` command properties to nullable (`MySqlCommandMock?`) and switched casts to safe `as` casts, added EN/PT summary for `SelectCommand`, fixed potential null dereference in batched parameter access (`commandBatch!`), and changed `CreateRowUpdatedEvent`/`CreateRowUpdatingEvent` signatures to accept `IDbCommand?` while passing `command!` into event args (`src/DbSqlLikeMem.MySql/MySqlDataAdapterMock.cs`).
- Cleaned up XML documentation placement around preprocessor regions and made the internal helper in `MySqlBatchMock` explicitly hide the member with `new` for `ExecuteReaderAsync(CommandBehavior, CancellationToken)` to document intentional hiding (`src/DbSqlLikeMem.MySql/MySqlBatchMock.cs`).
- Fixed `MySqlDataSourceMock` so XML docs are placed directly on the method in each conditional-compile branch and ensured `CreateDbConnection()` returns `DbConnection` in both branches (`src/DbSqlLikeMem.MySql/MySqlDataSourceMock.cs`).
- Updated CSV index tests across provider test projects to null-forgive the `Lookup` result (use `ix!`) before calling `Select(...).OrderBy(...)` to remove nullable-flow warnings (`src/DbSqlLikeMem.*.Test/CsvLoaderAndIndexTests.cs`).

### Testing
- Attempted `dotnet build DbSqlLikeMem.sln` in this environment but it failed because the .NET SDK is not available (`command not found: dotnet`), so a full automated build/test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699487ee6970832ca8a3a792f36c8b52)