### PR TITLE
Fix nullability and member-hiding warnings

### DIFF
--- a/src/DbSqlLikeMem.MySql/MySqlBatchMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlBatchMock.cs
@@ -151,7 +151,7 @@ public sealed class MySqlBatchMock :
             cancellationToken).ConfigureAwait(false);
     }
 
-    private new ValueTask<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior,
+    private ValueTask<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior,
         //IOBehavior ioBehavior, 
         CancellationToken cancellationToken)
     {

--- a/src/DbSqlLikeMem/Compatibility/FrameworkPolyfills.cs
+++ b/src/DbSqlLikeMem/Compatibility/FrameworkPolyfills.cs
@@ -85,7 +85,7 @@ namespace System.Diagnostics.CodeAnalysis
 }
 #endif
 
-#if NET48 || NETSTANDARD2_1
+#if NET48
 
 namespace System.Diagnostics.CodeAnalysis
 {

--- a/src/DbSqlLikeMem/Interfaces/IReadOnlyHashSet.cs
+++ b/src/DbSqlLikeMem/Interfaces/IReadOnlyHashSet.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace DbSqlLikeMem.Interfaces;
 
@@ -28,5 +29,5 @@ public interface IReadOnlyHashSet<T> : IReadOnlyCollection<T>, IDeserializationC
 
     bool SetEquals(IEnumerable<T> other);
 
-    bool TryGetValue(T equalValue, out T actualValue);
+    bool TryGetValue(T equalValue, [MaybeNullWhen(false)] out T actualValue);
 }


### PR DESCRIPTION
### Motivation
- Remove a conflicting polyfill for `MaybeNullWhenAttribute` that collided with the type provided by `netstandard2.1` and produced CS0436.
- Align the `TryGetValue` API nullability annotations between the interface and implementation to eliminate CS8767.
- Remove an unnecessary `new` modifier on `MySqlBatchMock.ExecuteReaderAsync` to eliminate CS0109.

### Description
- Restrict the compatibility polyfill in `FrameworkPolyfills.cs` so `MaybeNullWhenAttribute` is only defined under `#if NET48` instead of `#if NET48 || NETSTANDARD2_1`.
- Add `using System.Diagnostics.CodeAnalysis;` and annotate `IReadOnlyHashSet<T>.TryGetValue` with `[MaybeNullWhen(false)] out T actualValue` in `IReadOnlyHashSet.cs` to match implementation nullability.
- Remove the `new` modifier from `MySqlBatchMock.ExecuteReaderAsync(CommandBehavior, CancellationToken)` in `MySqlBatchMock.cs` so the member no longer hides an accessible member.

### Testing
- Attempted an automated build with `dotnet build src/DbSqlLikeMem/DbSqlLikeMem.csproj -v minimal`, but it failed because the `dotnet` CLI is not available in this environment (`bash: command not found: dotnet`).
- No automated unit tests were executed due to the missing `dotnet` tool, so no build/test pass status is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948bd8ae40832cbc7c5bb2e4f7bc8a)