### PR TITLE
Fix MySqlBatchMock compile errors for NET6 batch APIs

### DIFF
--- a/src/DbSqlLikeMem.MySql/MySqlBatchMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlBatchMock.cs
@@ -146,12 +146,12 @@ public sealed class MySqlBatchMock :
     {
         //this.ResetCommandTimeout();
         //using var registration = ((ICancellableCommand)this).RegisterCancel(cancellationToken);
-        return await ExecuteReaderAsync(behavior,
+        return await ExecuteReaderCoreAsync(behavior,
             //AsyncIOBehavior, 
             cancellationToken).ConfigureAwait(false);
     }
 
-    private ValueTask<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior,
+    private ValueTask<DbDataReader> ExecuteReaderCoreAsync(CommandBehavior behavior,
         //IOBehavior ioBehavior, 
         CancellationToken cancellationToken)
     {
@@ -165,7 +165,7 @@ public sealed class MySqlBatchMock :
             batchCommand.Batch = this;
 
         var tables = new List<TableResultMock>();
-        foreach (var batchCommand in BatchCommands)
+        foreach (var batchCommand in BatchCommands.Commands)
         {
             using var command = CreateExecutableCommand(batchCommand);
 
@@ -183,7 +183,7 @@ public sealed class MySqlBatchMock :
                     }
 
                     if (reader.FieldCount > 0)
-                        tables.Add(new TableResultMock(rows));
+                        tables.Add(CreateTableResult(rows, reader));
                 } while (reader.NextResult());
             }
             catch (InvalidOperationException ex) when (ex.Message == SqlExceptionMessages.ExecuteReaderWithoutSelectQuery())
@@ -404,7 +404,7 @@ public sealed class MySqlBatchMock :
         cancellationToken.ThrowIfCancellationRequested();
 
         var total = 0;
-        foreach (var batchCommand in BatchCommands)
+        foreach (var batchCommand in BatchCommands.Commands)
         {
             using var command = CreateExecutableCommand(batchCommand);
             total += await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -422,22 +422,51 @@ public sealed class MySqlBatchMock :
         if (BatchCommands.Count == 0)
             return null;
 
-        using var command = CreateExecutableCommand(BatchCommands[0]);
+        using var command = CreateExecutableCommand((MySqlBatchCommandMock)BatchCommands[0]);
         return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private MySqlCommandMock CreateExecutableCommand(MySqlBatchCommandMock batchCommand)
     {
-        var command = Connection!.CreateCommand();
+        var command = (MySqlCommandMock)Connection!.CreateCommand();
         command.Transaction = Transaction;
         command.CommandType = batchCommand.CommandType;
         command.CommandText = batchCommand.CommandText;
         command.CommandTimeout = Timeout;
 
         foreach (MySqlParameter parameter in batchCommand.Parameters)
-            command.Parameters.Add(parameter.ParameterName, parameter.MySqlDbType).Value = parameter.Value;
+            command.Parameters.Add(new MySqlParameter(parameter.ParameterName, parameter.MySqlDbType)
+            {
+                Value = parameter.Value,
+            });
 
         return command;
+    }
+
+    private static TableResultMock CreateTableResult(IReadOnlyCollection<object[]> rows, IDataRecord schemaRecord)
+    {
+        var table = new TableResultMock();
+
+        for (var col = 0; col < schemaRecord.FieldCount; col++)
+        {
+            table.Columns.Add(new TableResultColMock(
+                tableAlias: string.Empty,
+                columnAlias: schemaRecord.GetName(col),
+                columnName: schemaRecord.GetName(col),
+                columIndex: col,
+                dbType: schemaRecord.GetFieldType(col).ConvertTypeToDbType(),
+                isNullable: true));
+        }
+
+        foreach (var row in rows)
+        {
+            var rowData = new Dictionary<int, object?>();
+            for (var col = 0; col < row.Length; col++)
+                rowData[col] = row[col] == DBNull.Value ? null : row[col];
+            table.Add(rowData);
+        }
+
+        return table;
     }
 
     private bool IsValid(


### PR DESCRIPTION
### Motivation
- Resolve compile errors and API mismatches introduced by .NET 6 `DbBatch`/`DbBatchCommand` changes and incorrect usages in the MySQL mock.
- Ensure the MySQL batch mock builds `TableResultMock` instances with proper schema metadata so readers can consume results correctly.

### Description
- Renamed the internal reader helper from `ExecuteReaderAsync(...)` to `ExecuteReaderCoreAsync(...)` to avoid hiding the base API and updated the async call site to use the new helper (`ExecuteDbDataReaderAsync` → `ExecuteReaderCoreAsync`).
- Iterate the strongly-typed backing collection (`BatchCommands.Commands`) to avoid `DbBatchCommand` → `MySqlBatchCommandMock` conversion errors and cast indexed access where necessary for scalar execution.
- Cast `CreateCommand()` to `MySqlCommandMock` and change parameter creation to add `MySqlParameter` instances explicitly instead of using a non-existent `Add(name, type)` overload on the exposed `DbParameterCollection`.
- Replaced the invalid `new TableResultMock(rows)` call with a `CreateTableResult(...)` helper that populates `TableResultMock.Columns` from `IDataRecord` metadata and converts row values into the expected dictionary format.

### Testing
- Attempted to run `dotnet build DbSqlLikeMem.sln -v minimal`, but the `dotnet` SDK is not available in this environment and the build could not be executed (`bash: command not found: dotnet`).
- Performed local code inspection and repository checks (`rg`, file diffs, and committed changes) to validate the applied edits; no automated compilation or unit tests were run due to the missing .NET toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949b3a97f8832c8f5e0056f3c63cd6)