### PR TITLE
Add EN/PT XML summaries to MySqlBatchMockTests

### DIFF
--- a/src/DbSqlLikeMem.MySql.Test/MySqlBatchMockTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlBatchMockTests.cs
@@ -1,7 +1,15 @@
 namespace DbSqlLikeMem.MySql.Test;
 
+/// <summary>
+/// EN: Validates batch command execution behavior in <see cref="MySqlBatchMock"/>.
+/// PT: Valida o comportamento de execução de comandos em lote no <see cref="MySqlBatchMock"/>.
+/// </summary>
 public sealed class MySqlBatchMockTests
 {
+    /// <summary>
+    /// EN: Ensures ExecuteNonQuery executes all batch commands and returns the affected rows count.
+    /// PT: Garante que o ExecuteNonQuery execute todos os comandos do lote e retorne a quantidade de linhas afetadas.
+    /// </summary>
     [Fact]
     public void ExecuteNonQuery_ShouldExecuteAllBatchCommands()
     {
@@ -24,6 +32,10 @@ public sealed class MySqlBatchMockTests
         Assert.Equal(2, connection.GetTable("users").Count);
     }
 
+    /// <summary>
+    /// EN: Ensures ExecuteScalar returns the first command scalar result from the batch.
+    /// PT: Garante que o ExecuteScalar retorne o resultado escalar do primeiro comando do lote.
+    /// </summary>
     [Fact]
     public void ExecuteScalar_ShouldUseFirstBatchCommandResult()
     {
@@ -51,6 +63,10 @@ public sealed class MySqlBatchMockTests
         Assert.Equal("Ana", result);
     }
 
+    /// <summary>
+    /// EN: Ensures ExecuteReader returns multiple result sets produced by sequential batch commands.
+    /// PT: Garante que o ExecuteReader retorne múltiplos conjuntos de resultados produzidos por comandos em lote sequenciais.
+    /// </summary>
     [Fact]
     public void ExecuteReader_ShouldReturnResultsFromMultipleBatchCommands()
     {
@@ -82,6 +98,10 @@ public sealed class MySqlBatchMockTests
         Assert.Equal(1, reader.GetInt32(0));
     }
 
+    /// <summary>
+    /// EN: Ensures ExecuteReader supports batches that execute non-query commands before select queries.
+    /// PT: Garante que o ExecuteReader suporte lotes que executam comandos sem retorno antes de consultas select.
+    /// </summary>
     [Fact]
     public void ExecuteReader_ShouldAllowNonQueryBeforeSelect()
     {


### PR DESCRIPTION
### Motivation
- Add XML documentation to remove `CS1591` warnings for the `MySqlBatchMockTests` class and its public test methods.
- Follow project convention of placing English (`EN`) text first and Portuguese (`PT`) text second in summaries.

### Description
- Added a class-level `<summary>` and `<summary>` comments for each public test in `src/DbSqlLikeMem.MySql.Test/MySqlBatchMockTests.cs` with English first and Portuguese second.
- The summaries clarify intent for `ExecuteNonQuery`, `ExecuteScalar`, and `ExecuteReader` related tests and are formatted as XML doc comments (`/// <summary>`).

### Testing
- Attempted to run `dotnet test src/DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj --no-restore`, but the `dotnet` CLI is not available in this environment so tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699512ecc858832c83f4151542989025)