### PR TITLE
test: add missing Category traits to all Fact/Theory methods

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/CsvLoaderAndIndexTests.cs
@@ -12,6 +12,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de CsvLoader_ShouldLoadRows_ByColumnName.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void CsvLoader_ShouldLoadRows_ByColumnName()
     {
         var db = new Db2DbMock();
@@ -38,6 +39,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de GetColumn_ShouldThrow_UnknownColumn.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void GetColumn_ShouldThrow_UnknownColumn()
     {
         var db = new Db2DbMock();
@@ -53,6 +55,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de Index_Lookup_ShouldReturnRowPositions.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void Index_Lookup_ShouldReturnRowPositions()
     {
         var db = new Db2DbMock();
@@ -75,6 +78,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de BackupRestore_ShouldRollbackData.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void BackupRestore_ShouldRollbackData()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/DapperTests.cs
@@ -32,6 +32,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de TestSelectQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void TestSelectQuery()
     {
         var users = _connection.Query<UserObjectTest>("SELECT * FROM Users").ToList();
@@ -43,6 +44,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de QueryShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryShouldReturnCorrectData()
     {
         // Arrange
@@ -80,6 +82,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldInsertData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldInsertData()
     {
         // Arrange
@@ -110,6 +113,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldUpdateData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldUpdateData()
     {
         // Arrange
@@ -153,6 +157,7 @@ UPDATE users
     /// PT: Testa o comportamento de ExecuteShouldDeleteData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldDeleteData()
     {
         // Arrange
@@ -179,6 +184,7 @@ UPDATE users
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryMultipleShouldReturnMultipleResultSets()
     {
         var dt = DateTime.UtcNow;

--- a/src/DbSqlLikeMem.Db2.Test/DapperUserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/DapperUserTests.cs
@@ -43,6 +43,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de InsertUserShouldAddUserToTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void InsertUserShouldAddUserToTable()
     {
         // Arrange
@@ -91,6 +92,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -147,6 +149,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de UpdateUserShouldModifyUserInTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void UpdateUserShouldModifyUserInTable()
     {
         // Arrange
@@ -217,6 +220,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de DeleteUserShouldRemoveUserFromTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void DeleteUserShouldRemoveUserFromTable()
     {
         // Arrange
@@ -268,6 +272,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Db2.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.Db2.Test/DapperUserTests2.cs
@@ -48,6 +48,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -104,6 +105,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange
@@ -167,6 +169,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryWithJoinShouldReturnJoinedData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryWithJoinShouldReturnJoinedData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Db2.Test/Db2AdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2AdditionalBehaviorCoverageTests.cs
@@ -47,6 +47,7 @@ public sealed class Db2AdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNull_And_IsNotNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdditionalBehaviorCoverage")]
     public void Where_IsNull_And_IsNotNull_ShouldWork()
     {
         var nullIds = _cnn.Query<int>("SELECT id FROM users WHERE email IS NULL ORDER BY id").ToList();
@@ -61,6 +62,7 @@ public sealed class Db2AdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_EqualNull_ShouldReturnNoRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdditionalBehaviorCoverage")]
     public void Where_EqualNull_ShouldReturnNoRows()
     {
         // DB2: any comparison with NULL yields UNKNOWN (i.e., filtered out in WHERE)
@@ -76,6 +78,7 @@ public sealed class Db2AdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldPreserveLeftRows_WhenNoMatch.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdditionalBehaviorCoverage")]
     public void LeftJoin_ShouldPreserveLeftRows_WhenNoMatch()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -102,6 +105,7 @@ ORDER BY u.id
     /// PT: Testa o comportamento de OrderBy_Desc_ThenAsc_ShouldBeDeterministic.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdditionalBehaviorCoverage")]
     public void OrderBy_Desc_ThenAsc_ShouldBeDeterministic()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -119,6 +123,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdditionalBehaviorCoverage")]
     public void Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls()
     {
         var r = _cnn.QuerySingle<dynamic>("SELECT COUNT(*) c1, COUNT(email) c2 FROM users");
@@ -132,6 +137,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Having_ShouldFilterGroups.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdditionalBehaviorCoverage")]
     public void Having_ShouldFilterGroups()
     {
         var userIds = _cnn.Query<int>(@"
@@ -150,6 +156,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Where_In_WithParameterList_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdditionalBehaviorCoverage")]
     public void Where_In_WithParameterList_ShouldWork()
     {
         var ids = _cnn.Query<int>("SELECT id FROM users WHERE id IN @ids ORDER BY id", new { ids = param }).ToList();
@@ -161,6 +168,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Insert_WithColumnsOutOfOrder_ShouldMapCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdditionalBehaviorCoverage")]
     public void Insert_WithColumnsOutOfOrder_ShouldMapCorrectly()
     {
         _cnn.Execute("INSERT INTO users (name, id, email) VALUES (@name, @id, @email)", new { id = 4, name = "Zed", email = "zed@x.com" });
@@ -176,6 +184,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Delete_WithInParameterList_ShouldDeleteMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdditionalBehaviorCoverage")]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
         var deleted = _cnn.Execute("DELETE FROM users WHERE id IN @ids", new { ids = param });
@@ -190,6 +199,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Update_SetExpression_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdditionalBehaviorCoverage")]
     public void Update_SetExpression_ShouldUpdateRows()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/Db2AdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2AdvancedSqlGapTests.cs
@@ -47,6 +47,7 @@ public sealed class Db2AdvancedSqlGapTests : XUnitTestBase
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -67,6 +68,7 @@ ORDER BY tenantid, id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -87,6 +89,7 @@ ORDER BY u.id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
     public void DateAdd_IntervalDay_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -108,6 +111,7 @@ ORDER BY id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
     public void TimestampAdd_Day_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -131,6 +135,7 @@ ORDER BY id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
     public void Cast_StringToInt_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT CAST('42' AS SIGNED) AS v").ToList();
@@ -147,6 +152,7 @@ ORDER BY id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
     public void Regexp_Operator_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name REGEXP '^J' ORDER BY id").ToList();
@@ -164,6 +170,7 @@ ORDER BY id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
     public void OrderBy_Field_Function_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users ORDER BY FIELD(id, 3, 1, 2)").ToList();
@@ -179,6 +186,7 @@ ORDER BY id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {
         // Example expectation in DB2: behavior depends on column collation.

--- a/src/DbSqlLikeMem.Db2.Test/Db2AggregationTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2AggregationTests.cs
@@ -31,6 +31,7 @@ public sealed class Db2AggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Aggregation")]
     public void GroupBy_WithCountAndSum_ShouldWork()
     {
         const string sql = """
@@ -57,6 +58,7 @@ public sealed class Db2AggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Aggregation")]
     public void Having_ShouldFilterAggregates()
     {
         const string sql = """
@@ -76,6 +78,7 @@ public sealed class Db2AggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Aggregation")]
     public void Distinct_Order_Limit_Offset_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.Db2.Test/Db2DataParameterCollectionMockTest.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2DataParameterCollectionMockTest.cs
@@ -11,6 +11,7 @@ public sealed class Db2DataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2DataParameterCollectionMockTest")]
     public void ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames()
     {
         Assert.Equal("id", Db2DataParameterCollectionMock.NormalizeParameterName("@id"));
@@ -25,6 +26,7 @@ public sealed class Db2DataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Add_DuplicateName_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2DataParameterCollectionMockTest")]
     public void ParameterCollection_Add_DuplicateName_ShouldThrow()
     {
         var pars = new Db2DataParameterCollectionMock();
@@ -38,6 +40,7 @@ public sealed class Db2DataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_RemoveAt_ShouldReindexDictionary.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2DataParameterCollectionMockTest")]
     public void ParameterCollection_RemoveAt_ShouldReindexDictionary()
     {
         var pars = new Db2DataParameterCollectionMock();

--- a/src/DbSqlLikeMem.Db2.Test/Db2JoinTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2JoinTests.cs
@@ -39,6 +39,7 @@ public sealed class Db2JoinTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldKeepAllLeftRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Join")]
     public void LeftJoin_ShouldKeepAllLeftRows()
     {
         const string sql = """
@@ -59,6 +60,7 @@ public sealed class Db2JoinTests : XUnitTestBase
     /// PT: Testa o comportamento de RightJoin_ShouldKeepAllRightRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Join")]
     public void RightJoin_ShouldKeepAllRightRows()
     {
         const string sql = """
@@ -93,6 +95,7 @@ public sealed class Db2JoinTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ON_WithMultipleConditions_AND_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Join")]
     public void Join_ON_WithMultipleConditions_AND_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.Db2.Test/Db2LinqProviderTest.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2LinqProviderTest.cs
@@ -24,6 +24,7 @@ public sealed class Db2LinqProviderTest
     /// PT: Testa o comportamento de LinqProvider_ShouldQueryWhereAndReturnRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2LinqProviderTest")]
     public void LinqProvider_ShouldQueryWhereAndReturnRows()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/Db2MockTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2MockTests.cs
@@ -36,6 +36,7 @@ public sealed class Db2MockTests
     /// PT: Testa o comportamento de TestInsert.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Mock")]
     public void TestInsert()
     {
         using var command = new Db2CommandMock(_connection)
@@ -52,6 +53,7 @@ public sealed class Db2MockTests
     /// PT: Testa o comportamento de TestUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Mock")]
     public void TestUpdate()
     {
         using var command = new Db2CommandMock(_connection)
@@ -71,6 +73,7 @@ public sealed class Db2MockTests
     /// PT: Testa o comportamento de TestDelete.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Mock")]
     public void TestDelete()
     {
         using var command = new Db2CommandMock(_connection)
@@ -90,6 +93,7 @@ public sealed class Db2MockTests
     /// PT: Testa o comportamento de TestTransactionCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Mock")]
     public void TestTransactionCommit()
     {
         using (var transaction = _connection.BeginTransaction())
@@ -125,6 +129,7 @@ public sealed class Db2MockTests
     /// PT: Testa o comportamento de TestTransactionCommitInsertUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Mock")]
     public void TestTransactionCommitInsertUpdate()
     {
         using var cmd = _connection.CreateCommand();
@@ -147,6 +152,7 @@ public sealed class Db2MockTests
     /// PT: Testa o comportamento de TestTransactionRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Mock")]
     public void TestTransactionRollback()
     {
         using (var transaction = _connection.BeginTransaction())

--- a/src/DbSqlLikeMem.Db2.Test/Db2SelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2SelectAndWhereMoreCoverageTests.cs
@@ -41,6 +41,7 @@ public sealed class Db2SelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Between_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SelectAndWhereMoreCoverage")]
     public void Where_Between_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id BETWEEN 2 AND 3 ORDER BY id").ToList();
@@ -52,6 +53,7 @@ public sealed class Db2SelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NotIn_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SelectAndWhereMoreCoverage")]
     public void Where_NotIn_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id NOT IN (1,3)").ToList();
@@ -64,6 +66,7 @@ public sealed class Db2SelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ExistsSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SelectAndWhereMoreCoverage")]
     public void Where_ExistsSubquery_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -85,6 +88,7 @@ ORDER BY u.id").ToList();
     /// PT: Testa o comportamento de Select_CaseWhen_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SelectAndWhereMoreCoverage")]
     public void Select_CaseWhen_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -104,6 +108,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Select_IfNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SelectAndWhereMoreCoverage")]
     public void Select_IfNull_ShouldWork()
     {
         var row = _cnn.QuerySingle<dynamic>("SELECT IFNULL(email,'(none)') AS em FROM users WHERE id = 2");

--- a/src/DbSqlLikeMem.Db2.Test/Db2SqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2SqlCompatibilityGapTests.cs
@@ -44,6 +44,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Precedence_AND_ShouldBindStrongerThan_OR.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Where_Precedence_AND_ShouldBindStrongerThan_OR()
     {
         // DB2 precedence: AND binds stronger than OR.
@@ -57,6 +58,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_OR_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Where_OR_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id = 1 OR id = 3").ToList();
@@ -68,6 +70,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ParenthesesGrouping_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Where_ParenthesesGrouping_ShouldWork()
     {
         // (id=1 OR id=2) AND email IS NULL => only user 2
@@ -81,6 +84,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_Arithmetic_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Select_Expressions_Arithmetic_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, id + 1 AS nextId FROM users ORDER BY id").ToList();
@@ -92,6 +96,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_CASE_WHEN_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Select_Expressions_CASE_WHEN_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CASE WHEN email IS NULL THEN 0 ELSE 1 END AS hasEmail FROM users ORDER BY id").ToList();
@@ -103,6 +108,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IF_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Select_Expressions_IF_ShouldWork()
     {
         // DB2: IF(cond, then, else)
@@ -115,6 +121,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IIF_ShouldWork_AsAliasForIF.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Select_Expressions_IIF_ShouldWork_AsAliasForIF()
     {
         // Not native DB2, but requested as convenience.
@@ -127,6 +134,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_COALESCE_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Functions_COALESCE_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, COALESCE(NULL, email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -138,6 +146,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_IFNULL_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Functions_IFNULL_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, IFNULL(email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -149,6 +158,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_CONCAT_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Functions_CONCAT_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CONCAT(name, '#', id) AS tag FROM users ORDER BY id").ToList();
@@ -160,6 +170,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_ShouldBeConsistent.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Distinct_ShouldBeConsistent()
     {
         // duplicate names
@@ -173,6 +184,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ComplexOn_WithOr_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Join_ComplexOn_WithOr_ShouldWork()
     {
         // include orders joined when (o.userId = u.id OR o.userId = 0)
@@ -193,6 +205,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_Having_ShouldSupportAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void GroupBy_Having_ShouldSupportAggregates()
     {
         var rows = _cnn.Query<dynamic>(
@@ -210,6 +223,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de OrderBy_ShouldSupportAlias_And_Ordinal.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void OrderBy_ShouldSupportAlias_And_Ordinal()
     {
         var rows1 = _cnn.Query<dynamic>("SELECT id, id + 1 AS x FROM users ORDER BY x DESC").ToList();
@@ -225,6 +239,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Union_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -240,6 +255,7 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Union_Inside_SubSelect_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -258,6 +274,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Cte_With_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Cte_With_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -271,6 +288,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Typing_ImplicitCasts_And_Collation_ShouldMatchDb2Default.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
     public void Typing_ImplicitCasts_And_Collation_ShouldMatchDb2Default()
     {
         // Many DB2 installations use case-insensitive collations by default.

--- a/src/DbSqlLikeMem.Db2.Test/Db2TransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2TransactionReliabilityTests.cs
@@ -11,6 +11,7 @@ public sealed class Db2TransactionReliabilityTests
     /// PT: Garante que rollback para savepoint restaure o estado intermediário.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2TransactionReliability")]
     public void SavepointRollbackShouldRestoreIntermediateState()
     {
         var db = new Db2DbMock();
@@ -38,6 +39,7 @@ public sealed class Db2TransactionReliabilityTests
     /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2TransactionReliability")]
     public void IsolationLevelShouldBeExposedDeterministically()
     {
         var db = new Db2DbMock();
@@ -55,6 +57,7 @@ public sealed class Db2TransactionReliabilityTests
     /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2TransactionReliability")]
     public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
     {
         var db = new Db2DbMock();
@@ -72,6 +75,7 @@ public sealed class Db2TransactionReliabilityTests
     /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2TransactionReliability")]
     public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
     {
         var db = new Db2DbMock { ThreadSafe = true };

--- a/src/DbSqlLikeMem.Db2.Test/Db2TransactionTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2TransactionTests.cs
@@ -27,6 +27,7 @@ public sealed class Db2TransactionTests(
     /// PT: Testa o comportamento de TransactionCommitShouldPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Transaction")]
     public void TransactionCommitShouldPersistData()
     {
         // Arrange
@@ -59,6 +60,7 @@ public sealed class Db2TransactionTests(
     /// PT: Testa o comportamento de TransactionRollbackShouldNotPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2Transaction")]
     public void TransactionRollbackShouldNotPersistData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Db2.Test/Db2UnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2UnionLimitAndJsonCompatibilityTests.cs
@@ -30,6 +30,7 @@ public sealed class Db2UnionLimitAndJsonCompatibilityTests : XUnitTestBase
     /// PT: Testa o comportamento de UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2UnionLimitAndJsonCompatibility")]
     public void UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates()
     {
         // UNION ALL keeps duplicates
@@ -54,6 +55,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de Limit_OffsetCommaSyntax_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2UnionLimitAndJsonCompatibility")]
     public void Limit_OffsetCommaSyntax_ShouldWork()
     {
         // DB2 supports: LIMIT offset, count
@@ -66,6 +68,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de Limit_OffsetKeywordSyntax_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2UnionLimitAndJsonCompatibility")]
     public void Limit_OffsetKeywordSyntax_ShouldWork()
     {
         // DB2 supports: LIMIT count OFFSET offset
@@ -78,6 +81,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonExtract_SimpleObjectPath_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2UnionLimitAndJsonCompatibility")]
     public void JsonExtract_SimpleObjectPath_ShouldThrow_WhenNotSupportedByDialect()
     {
         Assert.Throws<NotSupportedException>(() =>
@@ -92,6 +96,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de OrderBy_NullsFirst_ShouldThrow_WhenDialectDoesNotSupportModifier.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2UnionLimitAndJsonCompatibility")]
     public void OrderBy_NullsFirst_ShouldThrow_WhenDialectDoesNotSupportModifier()
     {
         Assert.Throws<NotSupportedException>(() =>
@@ -104,6 +109,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonFunction_ShouldThrow_WhenNotSupportedByDialect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2UnionLimitAndJsonCompatibility")]
     public void JsonFunction_ShouldThrow_WhenNotSupportedByDialect()
     {
         Assert.Throws<NotSupportedException>(() =>
@@ -115,6 +121,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2UnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -131,6 +138,7 @@ SELECT 1 AS v
     /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2UnionLimitAndJsonCompatibility")]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
         Assert.Throws<InvalidOperationException>(() =>
@@ -148,6 +156,7 @@ SELECT 'x' AS v
     /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2UnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {
         var rows = _cnn.Query<dynamic>(@"

--- a/src/DbSqlLikeMem.Db2.Test/Db2WhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2WhereParserAndExecutorTests.cs
@@ -36,6 +36,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEquality_ShouldUseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_IndexedEquality_ShouldUseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -56,6 +57,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -83,6 +85,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex()
     {
         var table = _cnn.GetTable("users");
@@ -107,6 +110,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow()
     {
         var table = _cnn.GetTable("users");
@@ -128,6 +132,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -146,6 +151,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IN_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_IN_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id IN (1,3)").ToList();
@@ -159,6 +165,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNotNull_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_IsNotNull_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE email IS NOT NULL").ToList();
@@ -170,6 +177,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Operators_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_Operators_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id >= 2 AND id <= 3").ToList();
@@ -184,6 +192,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Like_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_Like_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name LIKE '%oh%'").ToList();
@@ -196,6 +205,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_FindInSet_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_FindInSet_ShouldWork()
     {
         // FIND_IN_SET('b', tags) -> John(a,b) e Jane(b,c)
@@ -208,6 +218,7 @@ public sealed class Db2WhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_AND_ShouldBeCaseInsensitive_InRealLife.
     /// </summary>
     [Fact]
+    [Trait("Category", "Db2WhereParserAndExecutor")]
     public void Where_AND_ShouldBeCaseInsensitive_InRealLife()
     {
         // esse teste é pra pegar o bug clássico: split só em " AND " / " and "

--- a/src/DbSqlLikeMem.Db2.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/ExistsTests.cs
@@ -12,6 +12,7 @@ public sealed class ExistsTests(
     /// PT: Testa o comportamento de Exists_ShouldFilterUsersWithOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_ShouldFilterUsersWithOrders()
     {
         using var cnn = new Db2ConnectionMock([]);
@@ -55,6 +56,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de NotExists_ShouldFilterUsersWithoutOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void NotExists_ShouldFilterUsersWithoutOrders()
     {
         using var cnn = new Db2ConnectionMock();
@@ -97,6 +99,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de Exists_WithExtraPredicate_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_WithExtraPredicate_ShouldWork()
     {
         using var cnn = new Db2ConnectionMock();

--- a/src/DbSqlLikeMem.Db2.Test/ExtendedDb2MockTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/ExtendedDb2MockTests.cs
@@ -12,6 +12,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de InsertAutoIncrementShouldAssignIdentityWhenNotSpecified.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void InsertAutoIncrementShouldAssignIdentityWhenNotSpecified()
     {
         var db = new Db2DbMock();
@@ -38,6 +39,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de InsertNullIntoNullableColumnShouldSucceed.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void InsertNullIntoNullableColumnShouldSucceed()
     {
         var db = new Db2DbMock();
@@ -57,6 +59,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de InsertNullIntoNonNullableColumnShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void InsertNullIntoNonNullableColumnShouldThrow()
     {
         var db = new Db2DbMock();
@@ -77,6 +80,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de CompositeIndexFilterShouldReturnCorrectRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void CompositeIndexFilterShouldReturnCorrectRows()
     {
         var db = new Db2DbMock();
@@ -102,6 +106,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de LikeFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void LikeFilterShouldReturnMatchingRows()
     {
         var db = new Db2DbMock();
@@ -122,6 +127,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de InFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void InFilterShouldReturnMatchingRows()
     {
         var db = new Db2DbMock();
@@ -143,6 +149,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de OrderByLimitOffsetDistinctShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void OrderByLimitOffsetDistinctShouldReturnExpectedRows()
     {
         var db = new Db2DbMock();
@@ -164,6 +171,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de HavingFilterShouldApplyAfterAggregation.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void HavingFilterShouldApplyAfterAggregation()
     {
         var db = new Db2DbMock();
@@ -188,6 +196,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletion.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletion()
     {
         // Parent
@@ -215,6 +224,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK()
     {
         // Parent
@@ -241,6 +251,7 @@ public sealed class ExtendedDb2MockTests(
     /// PT: Testa o comportamento de MultipleParameterSetsInsertShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedDb2Mock")]
     public void MultipleParameterSetsInsertShouldInsertAllRows()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/FluentTest.cs
+++ b/src/DbSqlLikeMem.Db2.Test/FluentTest.cs
@@ -27,6 +27,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de InsertUpdateDeleteFluentScenario.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void InsertUpdateDeleteFluentScenario()
     {
         using var cnn = BuildConnection();
@@ -70,6 +71,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de TestFluent.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void TestFluent()
     {
         using var cnn = new Db2ConnectionMock();

--- a/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
@@ -15,6 +15,7 @@ public sealed class Db2DialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void ParseSelect_WithRecursive_ShouldFollowDb2VersionSupport(int version)
     {
@@ -39,6 +40,7 @@ public sealed class Db2DialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void ParseInsert_OnConflict_ShouldBeRejected(int version)
     {
@@ -56,6 +58,7 @@ public sealed class Db2DialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void ParseSelect_WithMySqlIndexHints_ShouldBeRejected(int version)
     {
@@ -70,6 +73,7 @@ public sealed class Db2DialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void ParseUnsupportedSql_ShouldUseStandardNotSupportedMessage(int version)
     {
@@ -85,6 +89,7 @@ public sealed class Db2DialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void ParseSelect_UnionOrderBy_ShouldParseAsUnion(int version)
     {
@@ -103,6 +108,7 @@ public sealed class Db2DialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void ParseSelect_WithCteSimple_ShouldParse(int version)
     {
@@ -125,6 +131,7 @@ public sealed class Db2DialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void RuntimeDialectRules_ShouldRemainStable(int version)
     {

--- a/src/DbSqlLikeMem.Db2.Test/Parser/SqlExprPrinterTest.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/SqlExprPrinterTest.cs
@@ -12,6 +12,7 @@ public sealed class SqlExprPrinterTest(
     /// PT: Testa o comportamento de ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByDb2Version(nameof(Expressions))]
     public void ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse(string expr, int version)
     {

--- a/src/DbSqlLikeMem.Db2.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/SqlExpressionParserTests.cs
@@ -16,6 +16,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByDb2Version(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
     {
@@ -92,6 +93,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de ParseWhere_ShouldThrow_ForUnsupportedExpressions.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByDb2Version(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
     {
@@ -126,6 +128,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Precedence_OR_ShouldBindLooserThan_AND.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
     {
@@ -154,6 +157,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Parentheses_ShouldOverridePrecedence.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void Parentheses_ShouldOverridePrecedence(int version)
     {
@@ -175,6 +179,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Not_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void Not_ShouldWork(int version)
     {
@@ -192,6 +197,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de IsNotNull_ShouldProduce_IsNullExpr_Negated.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
     {
@@ -205,6 +211,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de In_ShouldParse_List.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void In_ShouldParse_List(int version)
     {
@@ -218,6 +225,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Like_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void Like_ShouldParse(int version)
     {
@@ -231,6 +239,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Identifier_WithAliasDotColumn_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
     {
@@ -253,6 +262,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Parameter_Tokens_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void Parameter_Tokens_ShouldParse(int version)
     {
@@ -267,6 +277,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Backtick_Identifier_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void Backtick_Identifier_ShouldThrow(int version)
     {
@@ -279,6 +290,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de DoubleQuoted_String_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void DoubleQuoted_Identifier_ShouldParse(int version)
     {
@@ -293,6 +305,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de NullSafe_Operator_ShouldThrow.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void NullSafe_Operator_ShouldThrow(int version)
     {
@@ -305,6 +318,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)
     {

--- a/src/DbSqlLikeMem.Db2.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -629,6 +629,7 @@ select id
     /// PT: Testa o comportamento de Parse_ShouldHandle_MultiStatementStrings_BySplitting.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataDb2Version]
     public void Parse_ShouldHandle_MultiStatementStrings_BySplitting(int version)
     {
@@ -652,6 +653,7 @@ select id
     /// PT: Testa o comportamento de Parse_Corpus.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByDb2Version(nameof(Statements))]
     public void Parse_Corpus(string sql, string why, SqlCaseExpectation expectation, int minVersion, int version)
     {

--- a/src/DbSqlLikeMem.Db2.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Query/QueryExecutorExtrasTests.cs
@@ -28,6 +28,7 @@ public sealed class QueryExecutorExtrasTests(
     /// PT: Testa o comportamento de GroupByAndAggregationsShouldComputeCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void GroupByAndAggregationsShouldComputeCorrectly()
     {
         // Arrange
@@ -65,6 +66,7 @@ GROUP BY grp";
     /// PT: Testa o comportamento de OrderByLimitOffsetShouldPageCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void OrderByLimitOffsetShouldPageCorrectly()
     {
         // Arrange
@@ -114,6 +116,7 @@ public class SqlTranslatorTests
     /// PT: Testa o comportamento de TranslateBasicWhereAndOrderBySqlCorrect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void TranslateBasicWhereAndOrderBySqlCorrect()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Db2.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -12,6 +12,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de CreateTableAsSelect_ShouldCreateNewTableWithRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void CreateTableAsSelect_ShouldCreateNewTableWithRows()
     {
         var db = new Db2DbMock();
@@ -44,6 +45,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de InsertIntoSelect_ShouldInsertRowsFromQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void InsertIntoSelect_ShouldInsertRowsFromQuery()
     {
         var db = new Db2DbMock();
@@ -75,6 +77,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de UpdateJoinDerivedSelect_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void UpdateJoinDerivedSelect_ShouldUpdateRows()
     {
         var db = new Db2DbMock();
@@ -114,6 +117,7 @@ WHERE u.tenantid = 10";
     /// PT: Testa o comportamento de DeleteJoinDerivedSelect_ShouldDeleteRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void DeleteJoinDerivedSelect_ShouldDeleteRows()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.Db2.Test/SqlValueHelperTests .cs
@@ -14,6 +14,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_ByName.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldReadDapperParameter_ByName()
     {
         using var cnn = new Db2ConnectionMock();
@@ -34,6 +35,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldThrow_WhenParameterMissing()
     {
         Assert.Throws<Db2MockException>(() =>
@@ -45,6 +47,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldParseInList_ToListOfResolvedValues.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldParseInList_ToListOfResolvedValues()
     {
         var v = Db2ValueHelper.Resolve("(1, 2, 3)", DbType.Int32, isNullable: false, pars: null, colDict: null);
@@ -58,6 +61,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_NullOnNonNullable_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_NullOnNonNullable_ShouldThrow()
     {
         Assert.Throws<Db2MockException>(() =>
@@ -69,6 +73,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Json_ShouldReturnJsonDocument_WhenValid.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Json_ShouldReturnJsonDocument_WhenValid()
     {
         var v = Db2ValueHelper.Resolve("{\"a\":1}", DbType.Object, isNullable: false, pars: null, colDict: null);
@@ -82,6 +87,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Like_ShouldMatch_Db2Style.
     /// </summary>
     [Theory]
+    [Trait("Category", "SqlValueHelperTests ")]
     [InlineData("John", "%oh%", true)]
     [InlineData("John", "J_hn", true)]
     [InlineData("John", "J__n", true)]
@@ -97,6 +103,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Enum_ShouldValidateAgainstColumnDef.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Enum_ShouldValidateAgainstColumnDef()
     {
         var tb = new Db2DbMock().AddTable("tb");
@@ -120,6 +127,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Set_ShouldReturnHashSet_AndValidate.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Set_ShouldReturnHashSet_AndValidate()
     {
         var tb = new Db2DbMock().AddTable("tb");
@@ -151,6 +159,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateStringSize.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateStringSize()
     {
         var tb = new Db2DbMock().AddTable("tb");
@@ -176,6 +185,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateDecimalPlaces.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateDecimalPlaces()
     {
         var tb = new Db2DbMock().AddTable("tb");

--- a/src/DbSqlLikeMem.Db2.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/StoredProcedureExecutionTests.cs
@@ -24,6 +24,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs()
     {
         // Arrange
@@ -64,6 +65,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput()
     {
         // Arrange
@@ -102,6 +104,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull()
     {
         // Arrange
@@ -140,6 +143,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue()
     {
         // Arrange
@@ -187,6 +191,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset()
     {
         // Arrange
@@ -221,6 +226,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero()
     {
         using var c = new Db2ConnectionMock();
@@ -252,6 +258,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput()
     {
         using var c = new Db2ConnectionMock();
@@ -281,6 +288,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldWork()
     {
         // Arrange
@@ -314,6 +322,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Db2.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/StoredProcedureSignatureTests.cs
@@ -12,6 +12,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldValidateRequiredInAndOutParams.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldValidateRequiredInAndOutParams()
     {
         using var c = new Db2ConnectionMock();
@@ -43,6 +44,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldThrowWhenMissingRequiredParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldThrowWhenMissingRequiredParam()
     {
         using var c = new Db2ConnectionMock();
@@ -66,6 +68,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de CallStatement_ShouldValidateAgainstRegisteredProcedure.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void CallStatement_ShouldValidateAgainstRegisteredProcedure()
     {
         using var c = new Db2ConnectionMock();

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2DeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2DeleteStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class Db2CommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_1_linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_1_linha()
     {
         var db = new Db2DbMock();
@@ -35,6 +36,7 @@ public sealed class Db2CommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_varias_linhas.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_varias_linhas()
     {
         var db = new Db2DbMock();
@@ -59,6 +61,7 @@ public sealed class Db2CommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0()
     {
         var db = new Db2DbMock();
@@ -80,6 +83,7 @@ public sealed class Db2CommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_tabela_inexistente_dispara.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_tabela_inexistente_dispara()
     {
         var db = new Db2DbMock();
@@ -95,6 +99,7 @@ public sealed class Db2CommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara()
     {
         var db = new Db2DbMock();
@@ -114,6 +119,7 @@ public sealed class Db2CommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia()
     {
         var db = new Db2DbMock();
@@ -140,6 +146,7 @@ public sealed class Db2CommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false(bool threadSafe)
@@ -162,6 +169,7 @@ public sealed class Db2CommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_case_insensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_case_insensitive()
     {
         var db = new Db2DbMock();
@@ -182,6 +190,7 @@ public sealed class Db2CommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_com_parametro_se_suportado.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_com_parametro_se_suportado()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertOnDuplicateTests.cs
@@ -13,6 +13,7 @@ public class Db2InsertOnDuplicateTests(
     /// PT: O dialeto DB2 deve rejeitar sintaxe ON DUPLICATE KEY UPDATE.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataDb2Version]
     public void Insert_OnDuplicate_ShouldThrowNotSupported(int version)
     {

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertStrategyCoverageTests.cs
@@ -12,6 +12,7 @@ public sealed class Db2InsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_MultiRowValues_ShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_MultiRowValues_ShouldInsertAllRows()
     {
         var db = new Db2DbMock();
@@ -40,6 +41,7 @@ public sealed class Db2InsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_WithIdentityColumnOmitted_ShouldAutoIncrement.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_WithIdentityColumnOmitted_ShouldAutoIncrement()
     {
         var db = new Db2DbMock();
@@ -70,6 +72,7 @@ public sealed class Db2InsertStrategyCoverageTests(
     /// PT: Testa o comportamento de InsertSelect_ShouldInsertRowsFromSelect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertSelect_ShouldInsertRowsFromSelect()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertStrategyExtrasTests.cs
@@ -11,6 +11,7 @@ public sealed class Db2InsertStrategyExtrasTests(
     /// PT: Testa o comportamento de MultiRowInsertShouldAddAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void MultiRowInsertShouldAddAllRows()
     {
         // Arrange
@@ -38,6 +39,7 @@ public sealed class Db2InsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertWithDefaultValueAndIdentityShouldApplyDefaults.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertWithDefaultValueAndIdentityShouldApplyDefaults()
     {
         // Arrange
@@ -69,6 +71,7 @@ public sealed class Db2InsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertDuplicatePrimaryKeyShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertDuplicatePrimaryKeyShouldThrow()
     {
         // Arrange
@@ -100,6 +103,7 @@ public class Db2DeleteStrategyForeignKeyTests
     /// PT: Testa o comportamento de DeleteReferencedRowShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void DeleteReferencedRowShouldThrow()
     {
         // Arrange parent
@@ -139,6 +143,7 @@ public class Db2UpdateStrategyExtrasTests
     /// PT: Testa o comportamento de UpdateMultipleConditionsShouldOnlyAffectMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateMultipleConditionsShouldOnlyAffectMatchingRows()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertStrategyTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class Db2InsertStrategyTests(
     /// PT: Testa o comportamento de InsertIntoTableShouldAddNewRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertIntoTableShouldAddNewRow()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2MergeUpsertTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2MergeUpsertTests.cs
@@ -12,6 +12,7 @@ public sealed class Db2MergeUpsertTests(ITestOutputHelper helper) : XUnitTestBas
     /// </summary>
     /// <param name="version">EN: DB2 dialect version under test. PT: Versão do dialeto DB2 em teste.</param>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataDb2Version]
     public void Merge_ShouldFollowDialectVersionSupport(int version)
     {
@@ -38,6 +39,7 @@ public sealed class Db2MergeUpsertTests(ITestOutputHelper helper) : XUnitTestBas
     /// PT: Garante que MERGE atualize uma linha existente quando a condição ON é satisfeita.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Merge_ShouldUpdate_WhenMatched()
     {
         var db = new Db2DbMock(Db2Dialect.MergeMinVersion);

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2TransactionTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2TransactionTests.cs
@@ -11,6 +11,7 @@ public sealed class Db2TransactionTests(
     /// PT: Testa o comportamento de TransactionShouldCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldCommit()
     {
         // Arrange
@@ -45,6 +46,7 @@ public sealed class Db2TransactionTests(
     /// PT: Testa o comportamento de TransactionShouldRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldRollback()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2TriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2TriggerStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class Db2TriggerStrategyTests
     /// PT: Garante que um gatilho AFTER INSERT seja executado para uma tabela não temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
     {
         var db = new Db2DbMock();
@@ -33,6 +34,7 @@ public sealed class Db2TriggerStrategyTests
     /// PT: Garante que um gatilho AFTER INSERT não seja executado para uma tabela temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2UpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2UpdateStrategyCoverageTests.cs
@@ -12,6 +12,7 @@ public sealed class Db2UpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNullableColumnToNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNullableColumnToNull_ShouldWork()
     {
         var db = new Db2DbMock();
@@ -37,6 +38,7 @@ public sealed class Db2UpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNotNullableColumnToNull_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNotNullableColumnToNull_ShouldThrow()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/Strategy/Db2UpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Strategy/Db2UpdateStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de UpdateTableShouldModifyExistingRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateTableShouldModifyExistingRow()
     {
         // Arrange
@@ -40,6 +41,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldReturnZero_WhenNoRowsMatchWhere.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldReturnZero_WhenNoRowsMatchWhere()
     {
         var db = new Db2DbMock();
@@ -65,6 +67,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple()
     {
         var db = new Db2DbMock();
@@ -93,6 +96,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldHandleWhereWithAnd_CaseInsensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldHandleWhereWithAnd_CaseInsensitive()
     {
         var db = new Db2DbMock();
@@ -121,6 +125,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleSetPairs.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleSetPairs()
     {
         var db = new Db2DbMock();
@@ -146,6 +151,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords()
     {
         var db = new Db2DbMock();
@@ -170,6 +176,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldWork_WithThreadSafeTrueOrFalse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void Update_ShouldWork_WithThreadSafeTrueOrFalse(bool threadSafe)
@@ -196,6 +203,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenTableDoesNotExist.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenTableDoesNotExist()
     {
         var db = new Db2DbMock();
@@ -214,6 +222,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken()
     {
         var db = new Db2DbMock();
@@ -235,6 +244,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull()
     {
         var db = new Db2DbMock();
@@ -260,6 +270,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldSupportParameter_IfSqlValueHelperSupports.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldSupportParameter_IfSqlValueHelperSupports()
     {
         var db = new Db2DbMock();
@@ -294,6 +305,7 @@ public sealed class Db2UpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/SubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/SubqueryFromAndJoinsTests.cs
@@ -12,6 +12,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
         using var cnn = new Db2ConnectionMock();
@@ -44,6 +45,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
         using var cnn = new Db2ConnectionMock();
@@ -88,6 +90,7 @@ ORDER BY u.Id, o.Amount";
     /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void NestedSubquery_ShouldWork()
     {
         using var cnn = new Db2ConnectionMock();

--- a/src/DbSqlLikeMem.Db2.Test/TemporaryTable/Db2TemporaryTableEngineTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/TemporaryTable/Db2TemporaryTableEngineTests.cs
@@ -12,6 +12,7 @@ public sealed class Db2TemporaryTableEngineTests
     /// PT: Testa o comportamento de CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "TemporaryTable")]
     public void CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows()
     {
         var db = new Db2DbMock();

--- a/src/DbSqlLikeMem.Db2.Test/TemporaryTable/Db2TemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/TemporaryTable/Db2TemporaryTableParserTests.cs
@@ -10,6 +10,7 @@ public sealed class Db2TemporaryTableParserTests
     /// PT: Testa o comportamento de ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataDb2Version]
     public void ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect(int version)
     {
@@ -56,6 +57,7 @@ SELECT * FROM tmp_users;
     /// PT: Testa o comportamento de Parse_ShouldAccept_CreateTemporaryTable_Variants.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataByDb2Version(nameof(CreateTempTableStatements))]
     public void Parse_ShouldAccept_CreateTemporaryTable_Variants(string sql, int version)
     {
@@ -72,6 +74,7 @@ SELECT * FROM tmp_users;
     /// PT: Testa o comportamento de Parse_ShouldReject_Backticks_ByDb2Spec.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataDb2Version]
     public void Parse_ShouldReject_Backticks_ByDb2Spec(int version)
     {
@@ -87,6 +90,7 @@ WHERE `tenantid` = 10";
     /// Auto-generated summary.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataDb2Version]
     public void Parse_ShouldAccept_GlobalTemporaryTable(int version)
     {

--- a/src/DbSqlLikeMem.Db2.Test/Views/Db2CreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Views/Db2CreateViewEngineTests.cs
@@ -39,6 +39,7 @@ public sealed class Db2CreateViewEngineTests : XUnitTestBase
     /// PT: Testa o comportamento de CreateView_ThenSelectFromView_ShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ThenSelectFromView_ShouldReturnExpectedRows()
     {
         _cnn.ExecNonQuery(@"
@@ -56,6 +57,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_IsNotMaterialized_ShouldReflectBaseTableChanges.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_IsNotMaterialized_ShouldReflectBaseTableChanges()
     {
         _cnn.ExecNonQuery("CREATE VIEW v_all AS SELECT id FROM users ORDER BY id;");
@@ -72,6 +74,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de CreateOrReplaceView_ShouldChangeDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateOrReplaceView_ShouldChangeDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW v AS SELECT id FROM users WHERE tenantid = 10;");
@@ -88,6 +91,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_NameShouldShadowTable_WhenSameName.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_NameShouldShadowTable_WhenSameName()
     {
         // cria uma tabela física chamada vshadow, com dados diferentes
@@ -109,6 +113,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_CanReferenceAnotherView.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_CanReferenceAnotherView()
     {
         _cnn.ExecNonQuery("CREATE VIEW v1 AS SELECT id FROM users WHERE tenantid = 10;");
@@ -123,6 +128,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_WithJoinAndAggregation_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_WithJoinAndAggregation_ShouldWork()
     {
         _cnn.ExecNonQuery(@"
@@ -147,6 +153,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de CreateView_ExistingNameWithoutOrReplace_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ExistingNameWithoutOrReplace_ShouldThrow()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdup AS SELECT 1 AS x FROM DUAL;");
@@ -158,6 +165,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de DropView_ShouldRemoveDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void DropView_ShouldRemoveDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdrop AS SELECT id FROM users;");

--- a/src/DbSqlLikeMem.Db2.Test/Views/Db2CreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Views/Db2CreateViewParserTests.cs
@@ -12,6 +12,7 @@ public sealed class Db2CreateViewParserTests(
     /// PT: Testa o comportamento de ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataDb2Version]
     public void ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements(int version)
     {
@@ -39,6 +40,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateOrReplaceView_ShouldSetFlag.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataDb2Version]
     public void Parse_CreateOrReplaceView_ShouldSetFlag(int version)
     {
@@ -54,6 +56,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataDb2Version]
     public void Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames(int version)
     {
@@ -68,6 +71,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithBackticks_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataDb2Version]
     public void Parse_CreateView_WithBackticks_ShouldFail_ByDb2Spec(int version)
     {
@@ -80,6 +84,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByDb2Spec.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataDb2Version]
     public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByDb2Spec(int version)
     {

--- a/src/DbSqlLikeMem.MySql.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/CsvLoaderAndIndexTests.cs
@@ -12,6 +12,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de CsvLoader_ShouldLoadRows_ByColumnName.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void CsvLoader_ShouldLoadRows_ByColumnName()
     {
         var db = new MySqlDbMock();
@@ -38,6 +39,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de GetColumn_ShouldThrow_UnknownColumn.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void GetColumn_ShouldThrow_UnknownColumn()
     {
         var db = new MySqlDbMock();
@@ -53,6 +55,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de Index_Lookup_ShouldReturnRowPositions.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void Index_Lookup_ShouldReturnRowPositions()
     {
         var db = new MySqlDbMock();
@@ -75,6 +78,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de BackupRestore_ShouldRollbackData.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void BackupRestore_ShouldRollbackData()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/DapperTests.cs
@@ -33,6 +33,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de TestSelectQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void TestSelectQuery()
     {
         var users = _connection.Query<UserObjectTest>("SELECT * FROM Users").ToList();
@@ -44,6 +45,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de QueryShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryShouldReturnCorrectData()
     {
         // Arrange
@@ -81,6 +83,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldInsertData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldInsertData()
     {
         // Arrange
@@ -111,6 +114,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldUpdateData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldUpdateData()
     {
         // Arrange
@@ -154,6 +158,7 @@ UPDATE users
     /// PT: Testa o comportamento de ExecuteShouldDeleteData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldDeleteData()
     {
         // Arrange
@@ -180,6 +185,7 @@ UPDATE users
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryMultipleShouldReturnMultipleResultSets()
     {
         var dt = DateTime.UtcNow;

--- a/src/DbSqlLikeMem.MySql.Test/DapperUserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/DapperUserTests.cs
@@ -43,6 +43,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de InsertUserShouldAddUserToTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void InsertUserShouldAddUserToTable()
     {
         // Arrange
@@ -91,6 +92,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -147,6 +149,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de UpdateUserShouldModifyUserInTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void UpdateUserShouldModifyUserInTable()
     {
         // Arrange
@@ -217,6 +220,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de DeleteUserShouldRemoveUserFromTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void DeleteUserShouldRemoveUserFromTable()
     {
         // Arrange
@@ -268,6 +272,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange

--- a/src/DbSqlLikeMem.MySql.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.MySql.Test/DapperUserTests2.cs
@@ -48,6 +48,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -104,6 +105,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange
@@ -167,6 +169,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryWithJoinShouldReturnJoinedData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryWithJoinShouldReturnJoinedData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.MySql.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/ExistsTests.cs
@@ -12,6 +12,7 @@ public sealed class ExistsTests(
     /// PT: Testa o comportamento de Exists_ShouldFilterUsersWithOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_ShouldFilterUsersWithOrders()
     {
         using var cnn = new MySqlConnectionMock([]);
@@ -55,6 +56,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de NotExists_ShouldFilterUsersWithoutOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void NotExists_ShouldFilterUsersWithoutOrders()
     {
         using var cnn = new MySqlConnectionMock();
@@ -97,6 +99,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de Exists_WithExtraPredicate_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_WithExtraPredicate_ShouldWork()
     {
         using var cnn = new MySqlConnectionMock();

--- a/src/DbSqlLikeMem.MySql.Test/ExtendedMySqlMockTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/ExtendedMySqlMockTests.cs
@@ -12,6 +12,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertAutoIncrementShouldAssignIdentityWhenNotSpecified.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void InsertAutoIncrementShouldAssignIdentityWhenNotSpecified()
     {
         var db = new MySqlDbMock();
@@ -38,6 +39,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertNullIntoNullableColumnShouldSucceed.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void InsertNullIntoNullableColumnShouldSucceed()
     {
         var db = new MySqlDbMock();
@@ -57,6 +59,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertNullIntoNonNullableColumnShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void InsertNullIntoNonNullableColumnShouldThrow()
     {
         var db = new MySqlDbMock();
@@ -77,6 +80,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de CompositeIndexFilterShouldReturnCorrectRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void CompositeIndexFilterShouldReturnCorrectRows()
     {
         var db = new MySqlDbMock();
@@ -102,6 +106,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de LikeFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void LikeFilterShouldReturnMatchingRows()
     {
         var db = new MySqlDbMock();
@@ -122,6 +127,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void InFilterShouldReturnMatchingRows()
     {
         var db = new MySqlDbMock();
@@ -143,6 +149,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de OrderByLimitOffsetDistinctShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void OrderByLimitOffsetDistinctShouldReturnExpectedRows()
     {
         var db = new MySqlDbMock();
@@ -164,6 +171,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de HavingFilterShouldApplyAfterAggregation.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void HavingFilterShouldApplyAfterAggregation()
     {
         var db = new MySqlDbMock();
@@ -188,6 +196,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletion.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletion()
     {
         // Parent
@@ -215,6 +224,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK()
     {
         // Parent
@@ -241,6 +251,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de MultipleParameterSetsInsertShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedMySqlMock")]
     public void MultipleParameterSetsInsertShouldInsertAllRows()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/FluentTest.cs
+++ b/src/DbSqlLikeMem.MySql.Test/FluentTest.cs
@@ -27,6 +27,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de InsertUpdateDeleteFluentScenario.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void InsertUpdateDeleteFluentScenario()
     {
         using var cnn = BuildConnection();
@@ -70,6 +71,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de TestFluent.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void TestFluent()
     {
         using var cnn = new MySqlConnectionMock();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlAdditionalBehaviorCoverageTests.cs
@@ -47,6 +47,7 @@ public sealed class MySqlAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNull_And_IsNotNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdditionalBehaviorCoverage")]
     public void Where_IsNull_And_IsNotNull_ShouldWork()
     {
         var nullIds = _cnn.Query<int>("SELECT id FROM users WHERE email IS NULL ORDER BY id").ToList();
@@ -61,6 +62,7 @@ public sealed class MySqlAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_EqualNull_ShouldReturnNoRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdditionalBehaviorCoverage")]
     public void Where_EqualNull_ShouldReturnNoRows()
     {
         // MySQL: any comparison with NULL yields UNKNOWN (i.e., filtered out in WHERE)
@@ -76,6 +78,7 @@ public sealed class MySqlAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldPreserveLeftRows_WhenNoMatch.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdditionalBehaviorCoverage")]
     public void LeftJoin_ShouldPreserveLeftRows_WhenNoMatch()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -102,6 +105,7 @@ ORDER BY u.id
     /// PT: Testa o comportamento de OrderBy_Desc_ThenAsc_ShouldBeDeterministic.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdditionalBehaviorCoverage")]
     public void OrderBy_Desc_ThenAsc_ShouldBeDeterministic()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -119,6 +123,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdditionalBehaviorCoverage")]
     public void Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls()
     {
         var r = _cnn.QuerySingle<dynamic>("SELECT COUNT(*) c1, COUNT(email) c2 FROM users");
@@ -132,6 +137,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Having_ShouldFilterGroups.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdditionalBehaviorCoverage")]
     public void Having_ShouldFilterGroups()
     {
         var userIds = _cnn.Query<int>(@"
@@ -150,6 +156,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Where_In_WithParameterList_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdditionalBehaviorCoverage")]
     public void Where_In_WithParameterList_ShouldWork()
     {
         var ids = _cnn.Query<int>("SELECT id FROM users WHERE id IN @ids ORDER BY id", new { ids = param }).ToList();
@@ -161,6 +168,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Insert_WithColumnsOutOfOrder_ShouldMapCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdditionalBehaviorCoverage")]
     public void Insert_WithColumnsOutOfOrder_ShouldMapCorrectly()
     {
         _cnn.Execute("INSERT INTO users (name, id, email) VALUES (@name, @id, @email)", new { id = 4, name = "Zed", email = "zed@x.com" });
@@ -176,6 +184,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Delete_WithInParameterList_ShouldDeleteMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdditionalBehaviorCoverage")]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
         var deleted = _cnn.Execute("DELETE users WHERE id IN @ids", new { ids = param });
@@ -190,6 +199,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Update_SetExpression_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdditionalBehaviorCoverage")]
     public void Update_SetExpression_ShouldUpdateRows()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlAdvancedSqlGapTests.cs
@@ -49,6 +49,7 @@ public sealed class MySqlAdvancedSqlGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
     [MemberDataMySqlVersion]
     public void Window_RowNumber_PartitionBy_ShouldRespectVersion(int version)
     {
@@ -80,6 +81,7 @@ ORDER BY tenantid, id").ToList();
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -96,6 +98,7 @@ ORDER BY u.id").ToList();
     /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
     public void DateAdd_IntervalDay_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -115,6 +118,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
     public void Cast_StringToInt_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT CAST('42' AS SIGNED) AS v").ToList();
@@ -127,6 +131,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
     public void Regexp_Operator_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name REGEXP '^J' ORDER BY id").ToList();
@@ -140,6 +145,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
     public void OrderBy_Field_Function_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users ORDER BY FIELD(id, 3, 1, 2)").ToList();
@@ -151,6 +157,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {
         // Example expectation in MySQL: behavior depends on column collation.

--- a/src/DbSqlLikeMem.MySql.Test/MySqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlAggregationTests.cs
@@ -31,6 +31,7 @@ public sealed class MySqlAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAggregation")]
     public void GroupBy_WithCountAndSum_ShouldWork()
     {
         const string sql = """
@@ -57,6 +58,7 @@ public sealed class MySqlAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAggregation")]
     public void Having_ShouldFilterAggregates()
     {
         const string sql = """
@@ -76,6 +78,7 @@ public sealed class MySqlAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlAggregation")]
     public void Distinct_Order_Limit_Offset_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.MySql.Test/MySqlBatchMockTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlBatchMockTests.cs
@@ -11,6 +11,7 @@ public sealed class MySqlBatchMockTests
     /// PT: Garante que o ExecuteNonQuery execute todos os comandos do lote e retorne a quantidade de linhas afetadas.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlBatchMock")]
     public void ExecuteNonQuery_ShouldExecuteAllBatchCommands()
     {
         var db = new MySqlDbMock();
@@ -37,6 +38,7 @@ public sealed class MySqlBatchMockTests
     /// PT: Garante que o ExecuteScalar retorne o resultado escalar do primeiro comando do lote.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlBatchMock")]
     public void ExecuteScalar_ShouldUseFirstBatchCommandResult()
     {
         var db = new MySqlDbMock();
@@ -68,6 +70,7 @@ public sealed class MySqlBatchMockTests
     /// PT: Garante que o ExecuteReader retorne múltiplos conjuntos de resultados produzidos por comandos em lote sequenciais.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlBatchMock")]
     public void ExecuteReader_ShouldReturnResultsFromMultipleBatchCommands()
     {
         var db = new MySqlDbMock();
@@ -103,6 +106,7 @@ public sealed class MySqlBatchMockTests
     /// PT: Garante que o ExecuteReader suporte lotes que executam comandos sem retorno antes de consultas select.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlBatchMock")]
     public void ExecuteReader_ShouldAllowNonQueryBeforeSelect()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlDataParameterCollectionMockTest.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlDataParameterCollectionMockTest.cs
@@ -11,6 +11,7 @@ public sealed class MySqlDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlDataParameterCollectionMockTest")]
     public void ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames()
     {
         Assert.Equal("id", MySqlDataParameterCollectionMock.NormalizeParameterName("@id"));
@@ -25,6 +26,7 @@ public sealed class MySqlDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Add_DuplicateName_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlDataParameterCollectionMockTest")]
     public void ParameterCollection_Add_DuplicateName_ShouldThrow()
     {
         var pars = new MySqlDataParameterCollectionMock();
@@ -38,6 +40,7 @@ public sealed class MySqlDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_RemoveAt_ShouldReindexDictionary.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlDataParameterCollectionMockTest")]
     public void ParameterCollection_RemoveAt_ShouldReindexDictionary()
     {
         var pars = new MySqlDataParameterCollectionMock();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlJoinTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlJoinTests.cs
@@ -39,6 +39,7 @@ public sealed class MySqlJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldKeepAllLeftRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlJoin")]
     public void LeftJoin_ShouldKeepAllLeftRows()
     {
         const string sql = """
@@ -59,6 +60,7 @@ public sealed class MySqlJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de RightJoin_ShouldKeepAllRightRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlJoin")]
     public void RightJoin_ShouldKeepAllRightRows()
     {
         const string sql = """
@@ -93,6 +95,7 @@ public sealed class MySqlJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ON_WithMultipleConditions_AND_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlJoin")]
     public void Join_ON_WithMultipleConditions_AND_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.MySql.Test/MySqlLinqProviderTest.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlLinqProviderTest.cs
@@ -23,6 +23,7 @@ public sealed class MySqlLinqProviderTest
     /// PT: Testa o comportamento de LinqProvider_ShouldQueryWhereAndReturnRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlLinqProviderTest")]
     public void LinqProvider_ShouldQueryWhereAndReturnRows()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs
@@ -36,6 +36,7 @@ public sealed class MySqlMockTests
     /// PT: Testa o comportamento de TestInsert.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlMock")]
     public void TestInsert()
     {
         using var command = new MySqlCommandMock(_connection)
@@ -52,6 +53,7 @@ public sealed class MySqlMockTests
     /// PT: Testa o comportamento de TestUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlMock")]
     public void TestUpdate()
     {
         using var command = new MySqlCommandMock(_connection)
@@ -71,6 +73,7 @@ public sealed class MySqlMockTests
     /// PT: Testa o comportamento de TestDelete.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlMock")]
     public void TestDelete()
     {
         using var command = new MySqlCommandMock(_connection)
@@ -90,6 +93,7 @@ public sealed class MySqlMockTests
     /// PT: Testa o comportamento de TestTransactionCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlMock")]
     public void TestTransactionCommit()
     {
         using (var transaction = _connection.BeginTransaction())
@@ -125,6 +129,7 @@ public sealed class MySqlMockTests
     /// PT: Testa o comportamento de TestTransactionCommitInsertUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlMock")]
     public void TestTransactionCommitInsertUpdate()
     {
         using var cmd = _connection.CreateCommand();
@@ -147,6 +152,7 @@ public sealed class MySqlMockTests
     /// PT: Testa o comportamento de TestTransactionRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlMock")]
     public void TestTransactionRollback()
     {
         using (var transaction = _connection.BeginTransaction())
@@ -183,6 +189,7 @@ public sealed class MySqlMockTests
     /// PT: Garante que SELECT com hints de índice do MySQL execute corretamente.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlMock")]
     public void TestSelect_WithMySqlIndexHint_ShouldExecute()
     {
         using var command = new MySqlCommandMock(_connection)

--- a/src/DbSqlLikeMem.MySql.Test/MySqlSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlSelectAndWhereMoreCoverageTests.cs
@@ -41,6 +41,7 @@ public sealed class MySqlSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Between_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSelectAndWhereMoreCoverage")]
     public void Where_Between_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id BETWEEN 2 AND 3 ORDER BY id").ToList();
@@ -52,6 +53,7 @@ public sealed class MySqlSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NotIn_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSelectAndWhereMoreCoverage")]
     public void Where_NotIn_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id NOT IN (1,3)").ToList();
@@ -64,6 +66,7 @@ public sealed class MySqlSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ExistsSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSelectAndWhereMoreCoverage")]
     public void Where_ExistsSubquery_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -85,6 +88,7 @@ ORDER BY u.id").ToList();
     /// PT: Testa o comportamento de Select_CaseWhen_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSelectAndWhereMoreCoverage")]
     public void Select_CaseWhen_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -104,6 +108,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Select_IfNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSelectAndWhereMoreCoverage")]
     public void Select_IfNull_ShouldWork()
     {
         var row = _cnn.QuerySingle<dynamic>("SELECT IFNULL(email,'(none)') AS em FROM users WHERE id = 2");

--- a/src/DbSqlLikeMem.MySql.Test/MySqlSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlSqlCompatibilityGapTests.cs
@@ -49,6 +49,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Precedence_AND_ShouldBindStrongerThan_OR.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Where_Precedence_AND_ShouldBindStrongerThan_OR()
     {
         // MySQL precedence: AND binds stronger than OR.
@@ -62,6 +63,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_OR_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Where_OR_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id = 1 OR id = 3").ToList();
@@ -73,6 +75,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ParenthesesGrouping_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Where_ParenthesesGrouping_ShouldWork()
     {
         // (id=1 OR id=2) AND email IS NULL => only user 2
@@ -86,6 +89,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_Arithmetic_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Select_Expressions_Arithmetic_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, id + 1 AS nextId FROM users ORDER BY id").ToList();
@@ -97,6 +101,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_CASE_WHEN_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Select_Expressions_CASE_WHEN_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CASE WHEN email IS NULL THEN 0 ELSE 1 END AS hasEmail FROM users ORDER BY id").ToList();
@@ -108,6 +113,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IF_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Select_Expressions_IF_ShouldWork()
     {
         // MySQL: IF(cond, then, else)
@@ -120,6 +126,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IIF_ShouldWork_AsAliasForIF.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Select_Expressions_IIF_ShouldWork_AsAliasForIF()
     {
         // Not native MySQL, but requested as convenience.
@@ -132,6 +139,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_COALESCE_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Functions_COALESCE_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, COALESCE(NULL, email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -143,6 +151,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_IFNULL_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Functions_IFNULL_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, IFNULL(email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -154,6 +163,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_CONCAT_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Functions_CONCAT_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CONCAT(name, '#', id) AS tag FROM users ORDER BY id").ToList();
@@ -165,6 +175,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_ShouldBeConsistent.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Distinct_ShouldBeConsistent()
     {
         // duplicate names
@@ -178,6 +189,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ComplexOn_WithOr_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Join_ComplexOn_WithOr_ShouldWork()
     {
         // include orders joined when (o.userId = u.id OR o.userId = 0)
@@ -198,6 +210,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_Having_ShouldSupportAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void GroupBy_Having_ShouldSupportAggregates()
     {
         var rows = _cnn.Query<dynamic>(
@@ -215,6 +228,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de OrderBy_ShouldSupportAlias_And_Ordinal.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void OrderBy_ShouldSupportAlias_And_Ordinal()
     {
         var rows1 = _cnn.Query<dynamic>("SELECT id, id + 1 AS x FROM users ORDER BY x DESC").ToList();
@@ -230,6 +244,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Union_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -245,6 +260,7 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Union_Inside_SubSelect_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -263,6 +279,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Cte_With_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     [MemberDataMySqlVersion]
     public void Cte_With_ShouldRespectVersion(int version)
     {
@@ -289,6 +306,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
     public void Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault()
     {
         // Many MySQL installations use case-insensitive collations by default.

--- a/src/DbSqlLikeMem.MySql.Test/MySqlTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlTransactionReliabilityTests.cs
@@ -11,6 +11,7 @@ public sealed class MySqlTransactionReliabilityTests
     /// PT: Garante que rollback para savepoint restaure o estado intermediário.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlTransactionReliability")]
     public void SavepointRollbackShouldRestoreIntermediateState()
     {
         var db = new MySqlDbMock();
@@ -38,6 +39,7 @@ public sealed class MySqlTransactionReliabilityTests
     /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlTransactionReliability")]
     public void IsolationLevelShouldBeExposedDeterministically()
     {
         var db = new MySqlDbMock();
@@ -55,6 +57,7 @@ public sealed class MySqlTransactionReliabilityTests
     /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlTransactionReliability")]
     public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
     {
         var db = new MySqlDbMock();
@@ -72,6 +75,7 @@ public sealed class MySqlTransactionReliabilityTests
     /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlTransactionReliability")]
     public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
     {
         var db = new MySqlDbMock { ThreadSafe = true };

--- a/src/DbSqlLikeMem.MySql.Test/MySqlTransactionTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlTransactionTests.cs
@@ -27,6 +27,7 @@ public sealed class MySqlTransactionTests(
     /// PT: Testa o comportamento de TransactionCommitShouldPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlTransaction")]
     public void TransactionCommitShouldPersistData()
     {
         // Arrange
@@ -59,6 +60,7 @@ public sealed class MySqlTransactionTests(
     /// PT: Testa o comportamento de TransactionRollbackShouldNotPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlTransaction")]
     public void TransactionRollbackShouldNotPersistData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs
@@ -37,6 +37,7 @@ public sealed class MySqlUnionLimitAndJsonCompatibilityTests : XUnitTestBase
     /// PT: Testa o comportamento de UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlUnionLimitAndJsonCompatibility")]
     public void UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates()
     {
         // UNION ALL keeps duplicates
@@ -61,6 +62,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de Limit_OffsetCommaSyntax_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlUnionLimitAndJsonCompatibility")]
     public void Limit_OffsetCommaSyntax_ShouldWork()
     {
         // MySQL supports: LIMIT offset, count
@@ -73,6 +75,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de Limit_OffsetKeywordSyntax_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlUnionLimitAndJsonCompatibility")]
     public void Limit_OffsetKeywordSyntax_ShouldWork()
     {
         // MySQL supports: LIMIT count OFFSET offset
@@ -85,6 +88,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonExtract_SimpleObjectPath_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "MySqlUnionLimitAndJsonCompatibility")]
     [MemberDataMySqlVersion]
     public void JsonExtract_SimpleObjectPath_ShouldRespectVersion(int version)
     {
@@ -112,6 +116,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de OrderBy_NullsFirst_ShouldThrow_WhenDialectDoesNotSupportModifier.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlUnionLimitAndJsonCompatibility")]
     public void OrderBy_NullsFirst_ShouldThrow_WhenDialectDoesNotSupportModifier()
     {
         Assert.Throws<NotSupportedException>(() =>
@@ -124,6 +129,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonFunction_ShouldThrow_WhenNotSupportedByDialect.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlUnionLimitAndJsonCompatibility")]
     public void JsonFunction_ShouldThrow_WhenNotSupportedByDialect()
     {
         Assert.Throws<NotSupportedException>(() =>
@@ -135,6 +141,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlUnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -151,6 +158,7 @@ SELECT 1 AS v
     /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlUnionLimitAndJsonCompatibility")]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
         Assert.Throws<InvalidOperationException>(() =>
@@ -168,6 +176,7 @@ SELECT 'x' AS v
     /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlUnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {
         var rows = _cnn.Query<dynamic>(@"

--- a/src/DbSqlLikeMem.MySql.Test/MySqlWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlWhereParserAndExecutorTests.cs
@@ -36,6 +36,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEquality_ShouldUseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_IndexedEquality_ShouldUseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -56,6 +57,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -84,6 +86,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex()
     {
         var table = _cnn.GetTable("users");
@@ -108,6 +111,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow()
     {
         var table = _cnn.GetTable("users");
@@ -129,6 +133,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -147,6 +152,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IN_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_IN_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id IN (1,3)").ToList();
@@ -160,6 +166,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNotNull_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_IsNotNull_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE email IS NOT NULL").ToList();
@@ -171,6 +178,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Operators_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_Operators_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id >= 2 AND id <= 3").ToList();
@@ -185,6 +193,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Like_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_Like_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name LIKE '%oh%'").ToList();
@@ -197,6 +206,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_FindInSet_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_FindInSet_ShouldWork()
     {
         // FIND_IN_SET('b', tags) -> John(a,b) e Jane(b,c)
@@ -209,6 +219,7 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_AND_ShouldBeCaseInsensitive_InRealLife.
     /// </summary>
     [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
     public void Where_AND_ShouldBeCaseInsensitive_InRealLife()
     {
         // esse teste é pra pegar o bug clássico: split só em " AND " / " and "

--- a/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
@@ -12,6 +12,7 @@ public sealed class MySqlDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: MySQL dialect version under test. PT: Versão do dialeto MySQL em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void ParseInsert_OnConflict_ShouldRespectDialectRule(int version)
     {
@@ -26,6 +27,7 @@ public sealed class MySqlDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: MySQL dialect version under test. PT: Versão do dialeto MySQL em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void ParseSelect_WithRecursive_ShouldRespectVersion(int version)
     {
@@ -47,6 +49,7 @@ public sealed class MySqlDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: MySQL dialect version under test. PT: Versão do dialeto MySQL em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void ParseSelect_WithIndexHints_ShouldParse(int version)
     {
@@ -63,6 +66,7 @@ public sealed class MySqlDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void RuntimeDialectRules_ShouldRemainStable(int version)
     {
@@ -86,6 +90,7 @@ public sealed class MySqlDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: MySQL dialect version under test. PT: Versão do dialeto MySQL em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void ParseUnsupportedSql_ShouldUseStandardNotSupportedMessage(int version)
     {

--- a/src/DbSqlLikeMem.MySql.Test/Parser/SqlExprPrinterTest.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/SqlExprPrinterTest.cs
@@ -12,6 +12,7 @@ public sealed class SqlExprPrinterTest(
     /// PT: Testa o comportamento de ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByMySqlVersion(nameof(Expressions))]
     public void ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse(string expr, int version)
     {

--- a/src/DbSqlLikeMem.MySql.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/SqlExpressionParserTests.cs
@@ -15,6 +15,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByMySqlVersion(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
     {
@@ -90,6 +91,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de ParseWhere_ShouldThrow_ForUnsupportedExpressions.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByMySqlVersion(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
     {
@@ -123,6 +125,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Precedence_OR_ShouldBindLooserThan_AND.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
     {
@@ -151,6 +154,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Parentheses_ShouldOverridePrecedence.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void Parentheses_ShouldOverridePrecedence(int version)
     {
@@ -172,6 +176,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Not_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void Not_ShouldWork(int version)
     {
@@ -189,6 +194,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de IsNotNull_ShouldProduce_IsNullExpr_Negated.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
     {
@@ -202,6 +208,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de In_ShouldParse_List.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void In_ShouldParse_List(int version)
     {
@@ -215,6 +222,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Like_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void Like_ShouldParse(int version)
     {
@@ -228,6 +236,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Identifier_WithAliasDotColumn_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
     {
@@ -250,6 +259,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Parameter_Tokens_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void Parameter_Tokens_ShouldParse(int version)
     {
@@ -264,6 +274,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Backtick_Identifier_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void Backtick_Identifier_ShouldParse(int version)
     {
@@ -278,6 +289,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de DoubleQuoted_String_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void DoubleQuoted_String_ShouldParse(int version)
     {
@@ -292,6 +304,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)
     {

--- a/src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -638,6 +638,7 @@ select id
     /// PT: Testa o comportamento de Parse_ShouldHandle_MultiStatementStrings_BySplitting.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataMySqlVersion]
     public void Parse_ShouldHandle_MultiStatementStrings_BySplitting(int version)
     {
@@ -661,6 +662,7 @@ select id
     /// PT: Testa o comportamento de Parse_Corpus.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByMySqlVersion(nameof(Statements))]
     public void Parse_Corpus(string sql, string why, SqlCaseExpectation expectation, int minVersion, int version)
     {

--- a/src/DbSqlLikeMem.MySql.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Query/QueryExecutorExtrasTests.cs
@@ -28,6 +28,7 @@ public sealed class QueryExecutorExtrasTests(
     /// PT: Testa o comportamento de GroupByAndAggregationsShouldComputeCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void GroupByAndAggregationsShouldComputeCorrectly()
     {
         // Arrange
@@ -65,6 +66,7 @@ GROUP BY grp";
     /// PT: Testa o comportamento de OrderByLimitOffsetShouldPageCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void OrderByLimitOffsetShouldPageCorrectly()
     {
         // Arrange
@@ -114,6 +116,7 @@ public class SqlTranslatorTests
     /// PT: Testa o comportamento de TranslateBasicWhereAndOrderBySqlCorrect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void TranslateBasicWhereAndOrderBySqlCorrect()
     {
         // Arrange

--- a/src/DbSqlLikeMem.MySql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -12,6 +12,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de CreateTableAsSelect_ShouldCreateNewTableWithRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void CreateTableAsSelect_ShouldCreateNewTableWithRows()
     {
         var db = new MySqlDbMock();
@@ -44,6 +45,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de InsertIntoSelect_ShouldInsertRowsFromQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void InsertIntoSelect_ShouldInsertRowsFromQuery()
     {
         var db = new MySqlDbMock();
@@ -75,6 +77,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de UpdateJoinDerivedSelect_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void UpdateJoinDerivedSelect_ShouldUpdateRows()
     {
         var db = new MySqlDbMock();
@@ -114,6 +117,7 @@ WHERE u.tenantid = 10";
     /// PT: Testa o comportamento de DeleteJoinDerivedSelect_ShouldDeleteRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void DeleteJoinDerivedSelect_ShouldDeleteRows()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.MySql.Test/SqlValueHelperTests .cs
@@ -14,6 +14,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_ByName.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldReadDapperParameter_ByName()
     {
         using var cnn = new MySqlConnectionMock();
@@ -34,6 +35,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldThrow_WhenParameterMissing()
     {
         Assert.Throws<MySqlMockException>(() =>
@@ -45,6 +47,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldParseInList_ToListOfResolvedValues.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldParseInList_ToListOfResolvedValues()
     {
         var v = MySqlValueHelper.Resolve("(1, 2, 3)", DbType.Int32, isNullable: false, pars: null, colDict: null);
@@ -58,6 +61,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_NullOnNonNullable_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_NullOnNonNullable_ShouldThrow()
     {
         Assert.Throws<MySqlMockException>(() =>
@@ -69,6 +73,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Json_ShouldReturnJsonDocument_WhenValid.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Json_ShouldReturnJsonDocument_WhenValid()
     {
         var v = MySqlValueHelper.Resolve("{\"a\":1}", DbType.Object, isNullable: false, pars: null, colDict: null);
@@ -82,6 +87,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Like_ShouldMatch_MySqlStyle.
     /// </summary>
     [Theory]
+    [Trait("Category", "SqlValueHelperTests ")]
     [InlineData("John", "%oh%", true)]
     [InlineData("John", "J_hn", true)]
     [InlineData("John", "J__n", true)]
@@ -97,6 +103,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Enum_ShouldValidateAgainstColumnDef.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Enum_ShouldValidateAgainstColumnDef()
     {
         var tb = new MySqlDbMock().AddTable("tb");
@@ -119,6 +126,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Set_ShouldReturnHashSet_AndValidate.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Set_ShouldReturnHashSet_AndValidate()
     {
         var tb = new MySqlDbMock().AddTable("tb");
@@ -150,6 +158,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateStringSize.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateStringSize()
     {
         var tb = new MySqlDbMock().AddTable("tb");
@@ -175,6 +184,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateDecimalPlaces.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateDecimalPlaces()
     {
         var tb = new MySqlDbMock().AddTable("tb");

--- a/src/DbSqlLikeMem.MySql.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/StoredProcedureExecutionTests.cs
@@ -24,6 +24,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs()
     {
         // Arrange
@@ -64,6 +65,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput()
     {
         // Arrange
@@ -102,6 +104,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull()
     {
         // Arrange
@@ -140,6 +143,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue()
     {
         // Arrange
@@ -187,6 +191,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset()
     {
         // Arrange
@@ -221,6 +226,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero()
     {
         using var c = new MySqlConnectionMock();
@@ -252,6 +258,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput()
     {
         using var c = new MySqlConnectionMock();
@@ -281,6 +288,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldWork()
     {
         // Arrange
@@ -314,6 +322,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam()
     {
         // Arrange

--- a/src/DbSqlLikeMem.MySql.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/StoredProcedureSignatureTests.cs
@@ -12,6 +12,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldValidateRequiredInAndOutParams.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldValidateRequiredInAndOutParams()
     {
         using var c = new MySqlConnectionMock();
@@ -43,6 +44,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldThrowWhenMissingRequiredParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldThrowWhenMissingRequiredParam()
     {
         using var c = new MySqlConnectionMock();
@@ -66,6 +68,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de CallStatement_ShouldValidateAgainstRegisteredProcedure.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void CallStatement_ShouldValidateAgainstRegisteredProcedure()
     {
         using var c = new MySqlConnectionMock();

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlDeleteStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class MySqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_1_linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_1_linha()
     {
         var db = new MySqlDbMock();
@@ -35,6 +36,7 @@ public sealed class MySqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_varias_linhas.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_varias_linhas()
     {
         var db = new MySqlDbMock();
@@ -59,6 +61,7 @@ public sealed class MySqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0()
     {
         var db = new MySqlDbMock();
@@ -80,6 +83,7 @@ public sealed class MySqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_tabela_inexistente_dispara.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_tabela_inexistente_dispara()
     {
         var db = new MySqlDbMock();
@@ -95,6 +99,7 @@ public sealed class MySqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sem_FROM_remove_1_linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_sem_FROM_remove_1_linha()
     {
         var db = new MySqlDbMock();
@@ -118,6 +123,7 @@ public sealed class MySqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia()
     {
         var db = new MySqlDbMock();
@@ -144,6 +150,7 @@ public sealed class MySqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false(bool threadSafe)
@@ -166,6 +173,7 @@ public sealed class MySqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_case_insensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_case_insensitive()
     {
         var db = new MySqlDbMock();
@@ -186,6 +194,7 @@ public sealed class MySqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_com_parametro_se_suportado.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_com_parametro_se_suportado()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertOnDuplicateTests.cs
@@ -13,6 +13,7 @@ public class MySqlInsertOnDuplicateTests(
     /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldInsertWhenNoConflict.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataMySqlVersion]
     public void Insert_OnDuplicate_ShouldInsertWhenNoConflict(int version)
     {
@@ -38,6 +39,7 @@ public class MySqlInsertOnDuplicateTests(
     /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateExistingRow_ByPrimaryKey_UsingValues.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataMySqlVersion]
     public void Insert_OnDuplicate_ShouldUpdateExistingRow_ByPrimaryKey_UsingValues(int version)
     {
@@ -65,6 +67,7 @@ public class MySqlInsertOnDuplicateTests(
     /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateExistingRow_ByUniqueIndex.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataMySqlVersion]
     public void Insert_OnDuplicate_ShouldUpdateExistingRow_ByUniqueIndex(int version)
     {
@@ -95,6 +98,7 @@ public class MySqlInsertOnDuplicateTests(
     /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateUsingLiteralAndParam.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataMySqlVersion]
     public void Insert_OnDuplicate_ShouldUpdateUsingLiteralAndParam(int version)
     {
@@ -127,6 +131,7 @@ public class MySqlInsertOnDuplicateTests(
     /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateAggragating.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataMySqlVersion]
     public void Insert_OnDuplicate_ShouldUpdateAggragating(int version)
     {

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyCoverageTests.cs
@@ -12,6 +12,7 @@ public sealed class MySqlInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_MultiRowValues_ShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_MultiRowValues_ShouldInsertAllRows()
     {
         var db = new MySqlDbMock();
@@ -40,6 +41,7 @@ public sealed class MySqlInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_WithIdentityColumnOmitted_ShouldAutoIncrement.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_WithIdentityColumnOmitted_ShouldAutoIncrement()
     {
         var db = new MySqlDbMock();
@@ -70,6 +72,7 @@ public sealed class MySqlInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de InsertSelect_ShouldInsertRowsFromSelect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertSelect_ShouldInsertRowsFromSelect()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyExtrasTests.cs
@@ -11,6 +11,7 @@ public sealed class MySqlInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de MultiRowInsertShouldAddAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void MultiRowInsertShouldAddAllRows()
     {
         // Arrange
@@ -38,6 +39,7 @@ public sealed class MySqlInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertWithDefaultValueAndIdentityShouldApplyDefaults.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertWithDefaultValueAndIdentityShouldApplyDefaults()
     {
         // Arrange
@@ -69,6 +71,7 @@ public sealed class MySqlInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertDuplicatePrimaryKeyShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertDuplicatePrimaryKeyShouldThrow()
     {
         // Arrange
@@ -100,6 +103,7 @@ public class MySqlDeleteStrategyForeignKeyTests
     /// PT: Testa o comportamento de DeleteReferencedRowShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void DeleteReferencedRowShouldThrow()
     {
         // Arrange parent
@@ -139,6 +143,7 @@ public class MySqlUpdateStrategyExtrasTests
     /// PT: Testa o comportamento de UpdateMultipleConditionsShouldOnlyAffectMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateMultipleConditionsShouldOnlyAffectMatchingRows()
     {
         // Arrange

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class MySqlInsertStrategyTests(
     /// PT: Testa o comportamento de InsertIntoTableShouldAddNewRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertIntoTableShouldAddNewRow()
     {
         // Arrange

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTransactionTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTransactionTests.cs
@@ -11,6 +11,7 @@ public sealed class MySqlTransactionTests(
     /// PT: Testa o comportamento de TransactionShouldCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldCommit()
     {
         // Arrange
@@ -45,6 +46,7 @@ public sealed class MySqlTransactionTests(
     /// PT: Testa o comportamento de TransactionShouldRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldRollback()
     {
         // Arrange

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTriggerStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class MySqlTriggerStrategyTests
     /// PT: Garante que um gatilho AFTER INSERT seja executado para uma tabela não temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
     {
         var db = new MySqlDbMock();
@@ -33,6 +34,7 @@ public sealed class MySqlTriggerStrategyTests
     /// PT: Garante que um gatilho AFTER INSERT não seja executado para uma tabela temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyCoverageTests.cs
@@ -12,6 +12,7 @@ public sealed class MySqlUpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNullableColumnToNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNullableColumnToNull_ShouldWork()
     {
         var db = new MySqlDbMock();
@@ -37,6 +38,7 @@ public sealed class MySqlUpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNotNullableColumnToNull_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNotNullableColumnToNull_ShouldThrow()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de UpdateTableShouldModifyExistingRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateTableShouldModifyExistingRow()
     {
         // Arrange
@@ -40,6 +41,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldReturnZero_WhenNoRowsMatchWhere.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldReturnZero_WhenNoRowsMatchWhere()
     {
         var db = new MySqlDbMock();
@@ -65,6 +67,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple()
     {
         var db = new MySqlDbMock();
@@ -93,6 +96,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldHandleWhereWithAnd_CaseInsensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldHandleWhereWithAnd_CaseInsensitive()
     {
         var db = new MySqlDbMock();
@@ -121,6 +125,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleSetPairs.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleSetPairs()
     {
         var db = new MySqlDbMock();
@@ -146,6 +151,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords()
     {
         var db = new MySqlDbMock();
@@ -170,6 +176,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldWork_WithThreadSafeTrueOrFalse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void Update_ShouldWork_WithThreadSafeTrueOrFalse(bool threadSafe)
@@ -196,6 +203,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenTableDoesNotExist.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenTableDoesNotExist()
     {
         var db = new MySqlDbMock();
@@ -214,6 +222,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken()
     {
         var db = new MySqlDbMock();
@@ -235,6 +244,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull()
     {
         var db = new MySqlDbMock();
@@ -260,6 +270,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldSupportParameter_IfSqlValueHelperSupports.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldSupportParameter_IfSqlValueHelperSupports()
     {
         var db = new MySqlDbMock();
@@ -294,6 +305,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides()
     {
         var db = new MySqlDbMock();
@@ -321,6 +333,7 @@ public sealed class MySqlUpdateStrategyTests(
     /// PT: Recalcula colunas geradas persistidas durante update e preserva a consistência de índices únicos.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldRecomputePersistedGeneratedColumn_AndAllowUniqueIndex()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/SubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/SubqueryFromAndJoinsTests.cs
@@ -12,6 +12,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
         using var cnn = new MySqlConnectionMock();
@@ -44,6 +45,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
         using var cnn = new MySqlConnectionMock();
@@ -88,6 +90,7 @@ ORDER BY u.Id, o.Amount";
     /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void NestedSubquery_ShouldWork()
     {
         using var cnn = new MySqlConnectionMock();

--- a/src/DbSqlLikeMem.MySql.Test/TemporaryTable/MySqlTemporaryTableEngineTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/TemporaryTable/MySqlTemporaryTableEngineTests.cs
@@ -12,6 +12,7 @@ public sealed class MySqlTemporaryTableEngineTests
     /// PT: Testa o comportamento de CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "TemporaryTable")]
     public void CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows()
     {
         var db = new MySqlDbMock();

--- a/src/DbSqlLikeMem.MySql.Test/TemporaryTable/MySqlTemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/TemporaryTable/MySqlTemporaryTableParserTests.cs
@@ -10,6 +10,7 @@ public sealed class MySqlTemporaryTableParserTests
     /// PT: Testa o comportamento de ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataMySqlVersion]
     public void ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect(int version)
     {
@@ -64,6 +65,7 @@ WHERE `tenantid` = 10",
     /// PT: Testa o comportamento de Parse_ShouldAccept_CreateTemporaryTable_Variants.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataByMySqlVersion(nameof(CreateTempTableStatements))]
     public void Parse_ShouldAccept_CreateTemporaryTable_Variants(string sql, int version)
     {
@@ -78,6 +80,7 @@ WHERE `tenantid` = 10",
     /// Auto-generated summary.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataMySqlVersion]
     public void Parse_ShouldAccept_GlobalTemporaryTable(int version)
     {

--- a/src/DbSqlLikeMem.MySql.Test/Views/MySqlCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Views/MySqlCreateViewEngineTests.cs
@@ -39,6 +39,7 @@ public sealed class MySqlCreateViewEngineTests : XUnitTestBase
     /// PT: Testa o comportamento de CreateView_ThenSelectFromView_ShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ThenSelectFromView_ShouldReturnExpectedRows()
     {
         _cnn.ExecNonQuery(@"
@@ -56,6 +57,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_IsNotMaterialized_ShouldReflectBaseTableChanges.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_IsNotMaterialized_ShouldReflectBaseTableChanges()
     {
         _cnn.ExecNonQuery("CREATE VIEW v_all AS SELECT id FROM users ORDER BY id;");
@@ -72,6 +74,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de CreateOrReplaceView_ShouldChangeDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateOrReplaceView_ShouldChangeDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW v AS SELECT id FROM users WHERE tenantid = 10;");
@@ -88,6 +91,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_NameShouldShadowTable_WhenSameName.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_NameShouldShadowTable_WhenSameName()
     {
         // cria uma tabela física chamada vshadow, com dados diferentes
@@ -109,6 +113,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_CanReferenceAnotherView.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_CanReferenceAnotherView()
     {
         _cnn.ExecNonQuery("CREATE VIEW v1 AS SELECT id FROM users WHERE tenantid = 10;");
@@ -123,6 +128,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_WithJoinAndAggregation_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_WithJoinAndAggregation_ShouldWork()
     {
         _cnn.ExecNonQuery(@"
@@ -147,6 +153,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de CreateView_ExistingNameWithoutOrReplace_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ExistingNameWithoutOrReplace_ShouldThrow()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdup AS SELECT 1 AS x FROM DUAL;");
@@ -158,6 +165,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de DropView_ShouldRemoveDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void DropView_ShouldRemoveDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdrop AS SELECT id FROM users;");

--- a/src/DbSqlLikeMem.MySql.Test/Views/MySqlCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Views/MySqlCreateViewParserTests.cs
@@ -12,6 +12,7 @@ public sealed class MySqlCreateViewParserTests(
     /// PT: Testa o comportamento de ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataMySqlVersion]
     public void ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements(int version)
     {
@@ -39,6 +40,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateOrReplaceView_ShouldSetFlag.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataMySqlVersion]
     public void Parse_CreateOrReplaceView_ShouldSetFlag(int version)
     {
@@ -54,6 +56,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataMySqlVersion]
     public void Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames(int version)
     {
@@ -68,6 +71,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithBackticks_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataMySqlVersion]
     public void Parse_CreateView_WithBackticks_ShouldWork(int version)
     {
@@ -82,6 +86,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataMySqlVersion]
     public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec(int version)
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/CsvLoaderAndIndexTests.cs
@@ -12,6 +12,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de CsvLoader_ShouldLoadRows_ByColumnName.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void CsvLoader_ShouldLoadRows_ByColumnName()
     {
         var db = new NpgsqlDbMock();
@@ -38,6 +39,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de GetColumn_ShouldThrow_UnknownColumn.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void GetColumn_ShouldThrow_UnknownColumn()
     {
         var db = new NpgsqlDbMock();
@@ -53,6 +55,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de Index_Lookup_ShouldReturnRowPositions.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void Index_Lookup_ShouldReturnRowPositions()
     {
         var db = new NpgsqlDbMock();
@@ -75,6 +78,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de BackupRestore_ShouldRollbackData.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void BackupRestore_ShouldRollbackData()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/DapperTests.cs
@@ -32,6 +32,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de TestSelectQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void TestSelectQuery()
     {
         var users = _connection.Query<UserObjectTest>("SELECT * FROM Users").ToList();
@@ -43,6 +44,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de QueryShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryShouldReturnCorrectData()
     {
         // Arrange
@@ -80,6 +82,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldInsertData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldInsertData()
     {
         // Arrange
@@ -110,6 +113,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldUpdateData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldUpdateData()
     {
         // Arrange
@@ -153,6 +157,7 @@ UPDATE users
     /// PT: Testa o comportamento de ExecuteShouldDeleteData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldDeleteData()
     {
         // Arrange
@@ -179,6 +184,7 @@ UPDATE users
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryMultipleShouldReturnMultipleResultSets()
     {
         var dt = DateTime.UtcNow;

--- a/src/DbSqlLikeMem.Npgsql.Test/DapperUserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/DapperUserTests.cs
@@ -43,6 +43,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de InsertUserShouldAddUserToTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void InsertUserShouldAddUserToTable()
     {
         // Arrange
@@ -91,6 +92,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -147,6 +149,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de UpdateUserShouldModifyUserInTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void UpdateUserShouldModifyUserInTable()
     {
         // Arrange
@@ -217,6 +220,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de DeleteUserShouldRemoveUserFromTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void DeleteUserShouldRemoveUserFromTable()
     {
         // Arrange
@@ -268,6 +272,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Npgsql.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/DapperUserTests2.cs
@@ -48,6 +48,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -104,6 +105,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange
@@ -167,6 +169,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryWithJoinShouldReturnJoinedData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryWithJoinShouldReturnJoinedData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Npgsql.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/ExistsTests.cs
@@ -12,6 +12,7 @@ public sealed class ExistsTests(
     /// PT: Testa o comportamento de Exists_ShouldFilterUsersWithOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_ShouldFilterUsersWithOrders()
     {
         using var cnn = new NpgsqlConnectionMock();
@@ -55,6 +56,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de NotExists_ShouldFilterUsersWithoutOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void NotExists_ShouldFilterUsersWithoutOrders()
     {
         using var cnn = new NpgsqlConnectionMock();
@@ -97,6 +99,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de Exists_WithExtraPredicate_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_WithExtraPredicate_ShouldWork()
     {
         using var cnn = new NpgsqlConnectionMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/ExtendedPostgreSqlMockTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/ExtendedPostgreSqlMockTests.cs
@@ -12,6 +12,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertAutoIncrementShouldAssignIdentityWhenNotSpecified.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void InsertAutoIncrementShouldAssignIdentityWhenNotSpecified()
     {
         var db = new NpgsqlDbMock();
@@ -38,6 +39,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertNullIntoNullableColumnShouldSucceed.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void InsertNullIntoNullableColumnShouldSucceed()
     {
         var db = new NpgsqlDbMock();
@@ -57,6 +59,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertNullIntoNonNullableColumnShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void InsertNullIntoNonNullableColumnShouldThrow()
     {
         var db = new NpgsqlDbMock();
@@ -77,6 +80,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de CompositeIndexFilterShouldReturnCorrectRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void CompositeIndexFilterShouldReturnCorrectRows()
     {
         var db = new NpgsqlDbMock();
@@ -102,6 +106,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de LikeFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void LikeFilterShouldReturnMatchingRows()
     {
         var db = new NpgsqlDbMock();
@@ -122,6 +127,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void InFilterShouldReturnMatchingRows()
     {
         var db = new NpgsqlDbMock();
@@ -143,6 +149,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de OrderByLimitOffsetDistinctShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void OrderByLimitOffsetDistinctShouldReturnExpectedRows()
     {
         var db = new NpgsqlDbMock();
@@ -164,6 +171,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de HavingFilterShouldApplyAfterAggregation.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void HavingFilterShouldApplyAfterAggregation()
     {
         var db = new NpgsqlDbMock();
@@ -188,6 +196,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletion.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletion()
     {
         // Parent
@@ -215,6 +224,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK()
     {
         // Parent
@@ -241,6 +251,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de MultipleParameterSetsInsertShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedPostgreSqlMock")]
     public void MultipleParameterSetsInsertShouldInsertAllRows()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/FluentTest.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/FluentTest.cs
@@ -30,6 +30,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de InsertUpdateDeleteFluentScenario.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void InsertUpdateDeleteFluentScenario()
     {
         using var cnn = BuildConnection();
@@ -73,6 +74,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de TestFluent.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void TestFluent()
     {
         using var cnn = new NpgsqlConnectionMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
@@ -12,6 +12,7 @@ public sealed class NpgsqlDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Npgsql dialect version under test. PT: Versão do dialeto Npgsql em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void ParseInsert_OnConflict_DoNothing_ShouldParse(int version)
     {
@@ -30,6 +31,7 @@ public sealed class NpgsqlDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Npgsql dialect version under test. PT: Versão do dialeto Npgsql em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void ParseWithCte_AsMaterialized_ShouldParse(int version)
     {
@@ -46,6 +48,7 @@ public sealed class NpgsqlDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Npgsql dialect version under test. PT: Versão do dialeto Npgsql em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void ParseInsert_OnConflict_OnConstraint_DoUpdate_ShouldParse(int version)
     {
@@ -68,6 +71,7 @@ DO UPDATE SET name = EXCLUDED.name";
     /// </summary>
     /// <param name="version">EN: Npgsql dialect version under test. PT: Versão do dialeto Npgsql em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void ParseInsert_OnConflict_TargetWhere_UpdateWhere_Returning_ShouldParse(int version)
     {
@@ -91,6 +95,7 @@ RETURNING id";
     /// </summary>
     /// <param name="version">EN: Npgsql dialect version under test. PT: Versão do dialeto Npgsql em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void ParseSelect_WithSqlServerTableHints_ShouldBeRejected(int version)
     {
@@ -105,6 +110,7 @@ RETURNING id";
     /// </summary>
     /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void RuntimeDialectRules_ShouldRemainStable(int version)
     {
@@ -128,6 +134,7 @@ RETURNING id";
     /// </summary>
     /// <param name="version">EN: Npgsql dialect version under test. PT: Versão do dialeto Npgsql em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void ParseUnsupportedSql_ShouldUseStandardNotSupportedMessage(int version)
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlExprPrinterTest.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlExprPrinterTest.cs
@@ -11,6 +11,7 @@ public sealed class SqlExprPrinterTest(
     /// PT: Testa o comportamento de ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByNpgsqlVersion(nameof(Expressions))]
     public void ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse(string expr, int version)
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlExpressionParserTests.cs
@@ -15,6 +15,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByNpgsqlVersion(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
     {
@@ -89,6 +90,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de ParseWhere_ShouldThrow_ForUnsupportedExpressions.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByNpgsqlVersion(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
     {
@@ -122,6 +124,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Precedence_OR_ShouldBindLooserThan_AND.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
     {
@@ -150,6 +153,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Parentheses_ShouldOverridePrecedence.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void Parentheses_ShouldOverridePrecedence(int version)
     {
@@ -171,6 +175,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Not_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void Not_ShouldWork(int version)
     {
@@ -188,6 +193,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de IsNotNull_ShouldProduce_IsNullExpr_Negated.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
     {
@@ -201,6 +207,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de In_ShouldParse_List.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void In_ShouldParse_List(int version)
     {
@@ -214,6 +221,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Like_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void Like_ShouldParse(int version)
     {
@@ -227,6 +235,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Identifier_WithAliasDotColumn_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
     {
@@ -249,6 +258,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Parameter_Tokens_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void Parameter_Tokens_ShouldParse(int version)
     {
@@ -263,6 +273,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de DoubleQuoted_Identifier_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void DoubleQuoted_Identifier_ShouldParse(int version)
     {
@@ -277,6 +288,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de SingleQuoted_String_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void SingleQuoted_String_ShouldParse(int version)
     {
@@ -291,6 +303,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -616,6 +616,7 @@ select id
     /// PT: Testa o comportamento de Parse_ShouldHandle_MultiStatementStrings_BySplitting.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
     public void Parse_ShouldHandle_MultiStatementStrings_BySplitting(int version)
     {
@@ -639,6 +640,7 @@ select id
     /// PT: Testa o comportamento de Parse_Corpus.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByNpgsqlVersion(nameof(Statements))]
     public void Parse_Corpus(string sql, string why, SqlCaseExpectation expectation, int minVersion, int version)
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdditionalBehaviorCoverageTests.cs
@@ -47,6 +47,7 @@ public sealed class PostgreSqlAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNull_And_IsNotNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdditionalBehaviorCoverage")]
     public void Where_IsNull_And_IsNotNull_ShouldWork()
     {
         var nullIds = _cnn.Query<int>("SELECT id FROM users WHERE email IS NULL ORDER BY id").ToList();
@@ -61,6 +62,7 @@ public sealed class PostgreSqlAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_EqualNull_ShouldReturnNoRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdditionalBehaviorCoverage")]
     public void Where_EqualNull_ShouldReturnNoRows()
     {
         // MySQL: any comparison with NULL yields UNKNOWN (i.e., filtered out in WHERE)
@@ -76,6 +78,7 @@ public sealed class PostgreSqlAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldPreserveLeftRows_WhenNoMatch.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdditionalBehaviorCoverage")]
     public void LeftJoin_ShouldPreserveLeftRows_WhenNoMatch()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -102,6 +105,7 @@ ORDER BY u.id
     /// PT: Testa o comportamento de OrderBy_Desc_ThenAsc_ShouldBeDeterministic.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdditionalBehaviorCoverage")]
     public void OrderBy_Desc_ThenAsc_ShouldBeDeterministic()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -119,6 +123,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdditionalBehaviorCoverage")]
     public void Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls()
     {
         var r = _cnn.QuerySingle<dynamic>("SELECT COUNT(*) c1, COUNT(email) c2 FROM users");
@@ -132,6 +137,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Having_ShouldFilterGroups.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdditionalBehaviorCoverage")]
     public void Having_ShouldFilterGroups()
     {
         var userIds = _cnn.Query<int>(@"
@@ -150,6 +156,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Where_In_WithParameterList_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdditionalBehaviorCoverage")]
     public void Where_In_WithParameterList_ShouldWork()
     {
         var ids = _cnn.Query<int>("SELECT id FROM users WHERE id IN @ids ORDER BY id", new { ids = param }).ToList();
@@ -161,6 +168,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Insert_WithColumnsOutOfOrder_ShouldMapCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdditionalBehaviorCoverage")]
     public void Insert_WithColumnsOutOfOrder_ShouldMapCorrectly()
     {
         _cnn.Execute("INSERT INTO users (name, id, email) VALUES (@name, @id, @email)", new { id = 4, name = "Zed", email = "zed@x.com" });
@@ -176,6 +184,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Delete_WithInParameterList_ShouldDeleteMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdditionalBehaviorCoverage")]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
         var deleted = _cnn.Execute("DELETE FROM users WHERE id IN @ids", new { ids = param });
@@ -190,6 +199,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Update_SetExpression_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdditionalBehaviorCoverage")]
     public void Update_SetExpression_ShouldUpdateRows()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdvancedSqlGapTests.cs
@@ -43,6 +43,7 @@ public sealed class PostgreSqlAdvancedSqlGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -59,6 +60,7 @@ ORDER BY tenantid, id").ToList();
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -75,6 +77,7 @@ ORDER BY u.id").ToList();
     /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
     public void DateAdd_IntervalDay_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -94,6 +97,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
     public void Cast_StringToInt_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT CAST('42' AS INT) AS v").ToList();
@@ -106,6 +110,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
     public void Regexp_Operator_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name REGEXP '^J' ORDER BY id").ToList();
@@ -119,6 +124,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
     public void OrderBy_Field_Function_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users ORDER BY CASE id WHEN 3 THEN 1 WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END").ToList();
@@ -130,6 +136,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {
         // Example expectation in MySQL: behavior depends on column collation.

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAggregationTests.cs
@@ -31,6 +31,7 @@ public sealed class PostgreSqlAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
     public void GroupBy_WithCountAndSum_ShouldWork()
     {
         const string sql = """
@@ -57,6 +58,7 @@ public sealed class PostgreSqlAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
     public void Having_ShouldFilterAggregates()
     {
         const string sql = """
@@ -76,6 +78,7 @@ public sealed class PostgreSqlAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
     public void Distinct_Order_Limit_Offset_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlDataParameterCollectionMockTest.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlDataParameterCollectionMockTest.cs
@@ -11,6 +11,7 @@ public sealed class NpgsqlDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlDataParameterCollectionMockTest")]
     public void ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames()
     {
         Assert.Equal("id", NpgsqlDataParameterCollectionMock.NormalizeParameterName("@id"));
@@ -25,6 +26,7 @@ public sealed class NpgsqlDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Add_DuplicateName_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlDataParameterCollectionMockTest")]
     public void ParameterCollection_Add_DuplicateName_ShouldThrow()
     {
         var pars = new NpgsqlDataParameterCollectionMock();
@@ -38,6 +40,7 @@ public sealed class NpgsqlDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_RemoveAt_ShouldReindexDictionary.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlDataParameterCollectionMockTest")]
     public void ParameterCollection_RemoveAt_ShouldReindexDictionary()
     {
         var pars = new NpgsqlDataParameterCollectionMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlJoinTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlJoinTests.cs
@@ -39,6 +39,7 @@ public sealed class PostgreSqlJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldKeepAllLeftRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlJoin")]
     public void LeftJoin_ShouldKeepAllLeftRows()
     {
         const string sql = """
@@ -59,6 +60,7 @@ public sealed class PostgreSqlJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de RightJoin_ShouldKeepAllRightRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlJoin")]
     public void RightJoin_ShouldKeepAllRightRows()
     {
         const string sql = """
@@ -93,6 +95,7 @@ public sealed class PostgreSqlJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ON_WithMultipleConditions_AND_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlJoin")]
     public void Join_ON_WithMultipleConditions_AND_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlLinqProviderTest.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlLinqProviderTest.cs
@@ -23,6 +23,7 @@ public sealed class PostgreSqlLinqProviderTest
     /// PT: Testa o comportamento de LinqProvider_ShouldQueryWhereAndReturnRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlLinqProviderTest")]
     public void LinqProvider_ShouldQueryWhereAndReturnRows()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlMockTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlMockTests.cs
@@ -35,6 +35,7 @@ public sealed class PostgreSqlMockTests
     /// PT: Testa o comportamento de TestInsert.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlMock")]
     public void TestInsert()
     {
         using var command = new NpgsqlCommandMock(_connection)
@@ -51,6 +52,7 @@ public sealed class PostgreSqlMockTests
     /// PT: Testa o comportamento de TestUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlMock")]
     public void TestUpdate()
     {
         using var command = new NpgsqlCommandMock(_connection)
@@ -70,6 +72,7 @@ public sealed class PostgreSqlMockTests
     /// PT: Testa o comportamento de TestDelete.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlMock")]
     public void TestDelete()
     {
         using var command = new NpgsqlCommandMock(_connection)
@@ -89,6 +92,7 @@ public sealed class PostgreSqlMockTests
     /// PT: Testa o comportamento de TestTransactionCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlMock")]
     public void TestTransactionCommit()
     {
         using (var transaction = _connection.BeginTransaction())
@@ -124,6 +128,7 @@ public sealed class PostgreSqlMockTests
     /// PT: Testa o comportamento de TestTransactionCommitInsertUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlMock")]
     public void TestTransactionCommitInsertUpdate()
     {
         using var cmd = _connection.CreateCommand();
@@ -146,6 +151,7 @@ public sealed class PostgreSqlMockTests
     /// PT: Testa o comportamento de TestTransactionRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlMock")]
     public void TestTransactionRollback()
     {
         using (var transaction = _connection.BeginTransaction())

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSelectAndWhereMoreCoverageTests.cs
@@ -41,6 +41,7 @@ public sealed class PostgreSqlSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Between_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSelectAndWhereMoreCoverage")]
     public void Where_Between_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id BETWEEN 2 AND 3 ORDER BY id").ToList();
@@ -52,6 +53,7 @@ public sealed class PostgreSqlSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NotIn_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSelectAndWhereMoreCoverage")]
     public void Where_NotIn_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id NOT IN (1,3)").ToList();
@@ -64,6 +66,7 @@ public sealed class PostgreSqlSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ExistsSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSelectAndWhereMoreCoverage")]
     public void Where_ExistsSubquery_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -85,6 +88,7 @@ ORDER BY u.id").ToList();
     /// PT: Testa o comportamento de Select_CaseWhen_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSelectAndWhereMoreCoverage")]
     public void Select_CaseWhen_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -104,6 +108,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Select_IfNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSelectAndWhereMoreCoverage")]
     public void Select_IfNull_ShouldWork()
     {
         var row = _cnn.QuerySingle<dynamic>("SELECT COALESCE(email,'(none)') AS em FROM users WHERE id = 2");

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSqlCompatibilityGapTests.cs
@@ -44,6 +44,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Precedence_AND_ShouldBindStrongerThan_OR.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Where_Precedence_AND_ShouldBindStrongerThan_OR()
     {
         // MySQL precedence: AND binds stronger than OR.
@@ -57,6 +58,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_OR_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Where_OR_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id = 1 OR id = 3").ToList();
@@ -68,6 +70,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ParenthesesGrouping_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Where_ParenthesesGrouping_ShouldWork()
     {
         // (id=1 OR id=2) AND email IS NULL => only user 2
@@ -81,6 +84,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_Arithmetic_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Select_Expressions_Arithmetic_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, id + 1 AS nextId FROM users ORDER BY id").ToList();
@@ -92,6 +96,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_CASE_WHEN_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Select_Expressions_CASE_WHEN_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CASE WHEN email IS NULL THEN 0 ELSE 1 END AS hasEmail FROM users ORDER BY id").ToList();
@@ -103,6 +108,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IF_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Select_Expressions_IF_ShouldWork()
     {
         // MySQL: IF(cond, then, else)
@@ -115,6 +121,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IIF_ShouldWork_AsAliasForIF.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Select_Expressions_IIF_ShouldWork_AsAliasForIF()
     {
         // Not native MySQL, but requested as convenience.
@@ -127,6 +134,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_COALESCE_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Functions_COALESCE_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, COALESCE(NULL, email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -138,6 +146,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_IFNULL_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Functions_IFNULL_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, COALESCE(NULL, email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -149,6 +158,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_CONCAT_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Functions_CONCAT_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CONCAT(name, '#', id) AS tag FROM users ORDER BY id").ToList();
@@ -160,6 +170,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_ShouldBeConsistent.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Distinct_ShouldBeConsistent()
     {
         // duplicate names
@@ -173,6 +184,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ComplexOn_WithOr_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Join_ComplexOn_WithOr_ShouldWork()
     {
         // include orders joined when (o.userId = u.id OR o.userId = 0)
@@ -193,6 +205,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_Having_ShouldSupportAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void GroupBy_Having_ShouldSupportAggregates()
     {
         var rows = _cnn.Query<dynamic>(
@@ -210,6 +223,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de OrderBy_ShouldSupportAlias_And_Ordinal.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void OrderBy_ShouldSupportAlias_And_Ordinal()
     {
         var rows1 = _cnn.Query<dynamic>("SELECT id, id + 1 AS x FROM users ORDER BY x DESC").ToList();
@@ -225,6 +239,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Union_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -240,6 +255,7 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Union_Inside_SubSelect_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -258,6 +274,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Cte_With_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Cte_With_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -271,6 +288,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
     public void Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault()
     {
         // Many MySQL installations use case-insensitive collations by default.

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlTransactionReliabilityTests.cs
@@ -11,6 +11,7 @@ public sealed class PostgreSqlTransactionReliabilityTests
     /// PT: Garante que rollback para savepoint restaure o estado intermediário.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlTransactionReliability")]
     public void SavepointRollbackShouldRestoreIntermediateState()
     {
         var db = new NpgsqlDbMock();
@@ -38,6 +39,7 @@ public sealed class PostgreSqlTransactionReliabilityTests
     /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlTransactionReliability")]
     public void IsolationLevelShouldBeExposedDeterministically()
     {
         var db = new NpgsqlDbMock();
@@ -55,6 +57,7 @@ public sealed class PostgreSqlTransactionReliabilityTests
     /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlTransactionReliability")]
     public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
     {
         var db = new NpgsqlDbMock();
@@ -72,6 +75,7 @@ public sealed class PostgreSqlTransactionReliabilityTests
     /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlTransactionReliability")]
     public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
     {
         var db = new NpgsqlDbMock { ThreadSafe = true };

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlTransactionTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlTransactionTests.cs
@@ -27,6 +27,7 @@ public sealed class PostgreSqlTransactionTests(
     /// PT: Testa o comportamento de TransactionCommitShouldPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlTransaction")]
     public void TransactionCommitShouldPersistData()
     {
         // Arrange
@@ -59,6 +60,7 @@ public sealed class PostgreSqlTransactionTests(
     /// PT: Testa o comportamento de TransactionRollbackShouldNotPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlTransaction")]
     public void TransactionRollbackShouldNotPersistData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs
@@ -36,6 +36,7 @@ public sealed class PostgreSqlUnionLimitAndJsonCompatibilityTests : XUnitTestBas
     /// PT: Testa o comportamento de UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlUnionLimitAndJsonCompatibility")]
     public void UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates()
     {
         // UNION ALL keeps duplicates
@@ -60,6 +61,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de LimitOffset_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlUnionLimitAndJsonCompatibility")]
     public void LimitOffset_ShouldWork()
     {
         // MySQL supports: LIMIT offset, count
@@ -72,6 +74,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonPathExtract_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "PostgreSqlUnionLimitAndJsonCompatibility")]
     [MemberDataNpgsqlVersion]
     public void JsonPathExtract_ShouldRespectVersion(int version)
     {
@@ -99,6 +102,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de OrderBy_NullsFirst_ShouldApplyExplicitNullOrdering.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlUnionLimitAndJsonCompatibility")]
     public void OrderBy_NullsFirst_ShouldApplyExplicitNullOrdering()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM t ORDER BY payload NULLS FIRST, id").ToList();
@@ -111,6 +115,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonFunction_ShouldThrow_WhenNotSupportedByDialect.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlUnionLimitAndJsonCompatibility")]
     public void JsonFunction_ShouldThrow_WhenNotSupportedByDialect()
     {
         Assert.Throws<NotSupportedException>(() =>
@@ -122,6 +127,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlUnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -138,6 +144,7 @@ SELECT 1 AS v
     /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlUnionLimitAndJsonCompatibility")]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
         Assert.Throws<InvalidOperationException>(() =>
@@ -155,6 +162,7 @@ SELECT 'x' AS v
     /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlUnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {
         var rows = _cnn.Query<dynamic>(@"

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlWhereParserAndExecutorTests.cs
@@ -36,6 +36,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEquality_ShouldUseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_IndexedEquality_ShouldUseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -56,6 +57,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -83,6 +85,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex()
     {
         var table = _cnn.GetTable("users");
@@ -107,6 +110,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow()
     {
         var table = _cnn.GetTable("users");
@@ -128,6 +132,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -146,6 +151,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IN_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_IN_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id IN (1,3)").ToList();
@@ -159,6 +165,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNotNull_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_IsNotNull_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE email IS NOT NULL").ToList();
@@ -170,6 +177,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Operators_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_Operators_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id >= 2 AND id <= 3").ToList();
@@ -184,6 +192,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Like_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_Like_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name LIKE '%oh%'").ToList();
@@ -196,6 +205,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_FindInSet_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_FindInSet_ShouldWork()
     {
         // FIND_IN_SET('b', tags) -> John(a,b) e Jane(b,c)
@@ -208,6 +218,7 @@ public sealed class PostgreSqlWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_AND_ShouldBeCaseInsensitive_InRealLife.
     /// </summary>
     [Fact]
+    [Trait("Category", "PostgreSqlWhereParserAndExecutor")]
     public void Where_AND_ShouldBeCaseInsensitive_InRealLife()
     {
         // esse teste é pra pegar o bug clássico: split só em " AND " / " and "

--- a/src/DbSqlLikeMem.Npgsql.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Query/QueryExecutorExtrasTests.cs
@@ -28,6 +28,7 @@ public sealed class QueryExecutorExtrasTests(
     /// PT: Testa o comportamento de GroupByAndAggregationsShouldComputeCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void GroupByAndAggregationsShouldComputeCorrectly()
     {
         // Arrange
@@ -65,6 +66,7 @@ GROUP BY grp";
     /// PT: Testa o comportamento de OrderByLimitOffsetShouldPageCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void OrderByLimitOffsetShouldPageCorrectly()
     {
         // Arrange
@@ -114,6 +116,7 @@ public class SqlTranslatorTests
     /// PT: Testa o comportamento de TranslateBasicWhereAndOrderBySqlCorrect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void TranslateBasicWhereAndOrderBySqlCorrect()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Npgsql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -12,6 +12,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de CreateTableAsSelect_ShouldCreateNewTableWithRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void CreateTableAsSelect_ShouldCreateNewTableWithRows()
     {
         var db = new NpgsqlDbMock();
@@ -44,6 +45,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de InsertIntoSelect_ShouldInsertRowsFromQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void InsertIntoSelect_ShouldInsertRowsFromQuery()
     {
         var db = new NpgsqlDbMock();
@@ -75,6 +77,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de UpdateJoinDerivedSelect_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void UpdateJoinDerivedSelect_ShouldUpdateRows()
     {
         var db = new NpgsqlDbMock();
@@ -114,6 +117,7 @@ WHERE u.tenantid = 10";
     /// PT: Testa o comportamento de DeleteJoinDerivedSelect_ShouldDeleteRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void DeleteJoinDerivedSelect_ShouldDeleteRows()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/SqlValueHelperTests .cs
@@ -14,6 +14,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_ByName.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldReadDapperParameter_ByName()
     {
         using var cnn = new NpgsqlConnectionMock();
@@ -34,6 +35,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldThrow_WhenParameterMissing()
     {
         Assert.Throws<NpgsqlMockException>(() =>
@@ -45,6 +47,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldParseInList_ToListOfResolvedValues.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldParseInList_ToListOfResolvedValues()
     {
         var v = NpgsqlValueHelper.Resolve("(1, 2, 3)", DbType.Int32, isNullable: false, pars: null, colDict: null);
@@ -58,6 +61,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_NullOnNonNullable_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_NullOnNonNullable_ShouldThrow()
     {
         Assert.Throws<NpgsqlMockException>(() =>
@@ -69,6 +73,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Json_ShouldReturnJsonDocument_WhenValid.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Json_ShouldReturnJsonDocument_WhenValid()
     {
         var v = NpgsqlValueHelper.Resolve("{\"a\":1}", DbType.Object, isNullable: false, pars: null, colDict: null);
@@ -82,6 +87,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Like_ShouldMatch_MySqlStyle.
     /// </summary>
     [Theory]
+    [Trait("Category", "SqlValueHelperTests ")]
     [InlineData("John", "%oh%", true)]
     [InlineData("John", "J_hn", true)]
     [InlineData("John", "J__n", true)]
@@ -97,6 +103,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Enum_ShouldValidateAgainstColumnDef.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Enum_ShouldValidateAgainstColumnDef()
     {
         var tb = new NpgsqlDbMock().AddTable("tb");
@@ -119,6 +126,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Set_ShouldReturnHashSet_AndValidate.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Set_ShouldReturnHashSet_AndValidate()
     {
         var tb = new NpgsqlDbMock().AddTable("tb");
@@ -150,6 +158,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateStringSize.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateStringSize()
     {
         var tb = new NpgsqlDbMock().AddTable("tb");
@@ -175,6 +184,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateDecimalPlaces.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateDecimalPlaces()
     {
         var tb = new NpgsqlDbMock().AddTable("tb");

--- a/src/DbSqlLikeMem.Npgsql.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/StoredProcedureExecutionTests.cs
@@ -24,6 +24,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs()
     {
         // Arrange
@@ -64,6 +65,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput()
     {
         // Arrange
@@ -102,6 +104,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull()
     {
         // Arrange
@@ -140,6 +143,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue()
     {
         // Arrange
@@ -187,6 +191,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset()
     {
         // Arrange
@@ -221,6 +226,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero()
     {
         using var c = new NpgsqlConnectionMock();
@@ -252,6 +258,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput()
     {
         using var c = new NpgsqlConnectionMock();
@@ -281,6 +288,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldWork()
     {
         // Arrange
@@ -314,6 +322,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Npgsql.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/StoredProcedureSignatureTests.cs
@@ -12,6 +12,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldValidateRequiredInAndOutParams.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldValidateRequiredInAndOutParams()
     {
         using var c = new NpgsqlConnectionMock();
@@ -43,6 +44,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldThrowWhenMissingRequiredParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldThrowWhenMissingRequiredParam()
     {
         using var c = new NpgsqlConnectionMock();
@@ -66,6 +68,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de CallStatement_ShouldValidateAgainstRegisteredProcedure.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void CallStatement_ShouldValidateAgainstRegisteredProcedure()
     {
         using var c = new NpgsqlConnectionMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class PostgreSqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_1_linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_1_linha()
     {
         var db = new NpgsqlDbMock();
@@ -35,6 +36,7 @@ public sealed class PostgreSqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_varias_linhas.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_varias_linhas()
     {
         var db = new NpgsqlDbMock();
@@ -59,6 +61,7 @@ public sealed class PostgreSqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0()
     {
         var db = new NpgsqlDbMock();
@@ -80,6 +83,7 @@ public sealed class PostgreSqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_tabela_inexistente_dispara.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_tabela_inexistente_dispara()
     {
         var db = new NpgsqlDbMock();
@@ -95,6 +99,7 @@ public sealed class PostgreSqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara()
     {
         var db = new NpgsqlDbMock();
@@ -114,6 +119,7 @@ public sealed class PostgreSqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia()
     {
         var db = new NpgsqlDbMock();
@@ -140,6 +146,7 @@ public sealed class PostgreSqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false(bool threadSafe)
@@ -162,6 +169,7 @@ public sealed class PostgreSqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_case_insensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_case_insensitive()
     {
         var db = new NpgsqlDbMock();
@@ -182,6 +190,7 @@ public sealed class PostgreSqlCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_com_parametro_se_suportado.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_com_parametro_se_suportado()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertOnDuplicateTests.cs
@@ -10,6 +10,7 @@ public sealed class PostgreSqlOnConflictUpsertTests(ITestOutputHelper helper) : 
     /// PT: Testa o comportamento de Insert_OnConflict_ShouldInsert_WhenNoConflict.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_OnConflict_ShouldInsert_WhenNoConflict()
     {
         var db = new NpgsqlDbMock();
@@ -34,6 +35,7 @@ public sealed class PostgreSqlOnConflictUpsertTests(ITestOutputHelper helper) : 
     /// PT: Testa o comportamento de Insert_OnConflict_ShouldUpdate_WhenConflict.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_OnConflict_ShouldUpdate_WhenConflict()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyCoverageTests.cs
@@ -12,6 +12,7 @@ public sealed class PostgreSqlInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_MultiRowValues_ShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_MultiRowValues_ShouldInsertAllRows()
     {
         var db = new NpgsqlDbMock();
@@ -40,6 +41,7 @@ public sealed class PostgreSqlInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_WithIdentityColumnOmitted_ShouldAutoIncrement.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_WithIdentityColumnOmitted_ShouldAutoIncrement()
     {
         var db = new NpgsqlDbMock();
@@ -70,6 +72,7 @@ public sealed class PostgreSqlInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de InsertSelect_ShouldInsertRowsFromSelect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertSelect_ShouldInsertRowsFromSelect()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyExtrasTests.cs
@@ -11,6 +11,7 @@ public sealed class PostgreSqlInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de MultiRowInsertShouldAddAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void MultiRowInsertShouldAddAllRows()
     {
         // Arrange
@@ -38,6 +39,7 @@ public sealed class PostgreSqlInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertWithDefaultValueAndIdentityShouldApplyDefaults.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertWithDefaultValueAndIdentityShouldApplyDefaults()
     {
         // Arrange
@@ -69,6 +71,7 @@ public sealed class PostgreSqlInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertDuplicatePrimaryKeyShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertDuplicatePrimaryKeyShouldThrow()
     {
         // Arrange
@@ -100,6 +103,7 @@ public class PostgreSqlDeleteStrategyForeignKeyTests
     /// PT: Testa o comportamento de DeleteReferencedRowShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void DeleteReferencedRowShouldThrow()
     {
         // Arrange parent
@@ -139,6 +143,7 @@ public class PostgreSqlUpdateStrategyExtrasTests
     /// PT: Testa o comportamento de UpdateMultipleConditionsShouldOnlyAffectMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateMultipleConditionsShouldOnlyAffectMatchingRows()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class PostgreSqlInsertStrategyTests(
     /// PT: Testa o comportamento de InsertIntoTableShouldAddNewRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertIntoTableShouldAddNewRow()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlMergeUpsertTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlMergeUpsertTests.cs
@@ -12,6 +12,7 @@ public sealed class PostgreSqlMergeUpsertTests(ITestOutputHelper helper) : XUnit
     /// </summary>
     /// <param name="version">EN: Npgsql dialect version under test. PT: Versão do dialeto Npgsql em teste.</param>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataNpgsqlVersion]
     public void Merge_ShouldFollowDialectVersionSupport(int version)
     {
@@ -38,6 +39,7 @@ public sealed class PostgreSqlMergeUpsertTests(ITestOutputHelper helper) : XUnit
     /// PT: Garante que MERGE atualize uma linha existente quando a condição ON é satisfeita.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Merge_ShouldUpdate_WhenMatched()
     {
         var db = new NpgsqlDbMock(NpgsqlDialect.MergeMinVersion);

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTransactionTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTransactionTests.cs
@@ -11,6 +11,7 @@ public sealed class PostgreSqlTransactionTests(
     /// PT: Testa o comportamento de TransactionShouldCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldCommit()
     {
         // Arrange
@@ -45,6 +46,7 @@ public sealed class PostgreSqlTransactionTests(
     /// PT: Testa o comportamento de TransactionShouldRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldRollback()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTriggerStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class PostgreSqlTriggerStrategyTests
     /// PT: Garante que um gatilho AFTER INSERT seja executado para uma tabela não temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
     {
         var db = new NpgsqlDbMock();
@@ -33,6 +34,7 @@ public sealed class PostgreSqlTriggerStrategyTests
     /// PT: Garante que os gatilhos não sejam executados para uma tabela temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyCoverageTests.cs
@@ -12,6 +12,7 @@ public sealed class PostgreSqlUpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNullableColumnToNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNullableColumnToNull_ShouldWork()
     {
         var db = new NpgsqlDbMock();
@@ -37,6 +38,7 @@ public sealed class PostgreSqlUpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNotNullableColumnToNull_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNotNullableColumnToNull_ShouldThrow()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de UpdateTableShouldModifyExistingRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateTableShouldModifyExistingRow()
     {
         // Arrange
@@ -40,6 +41,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldReturnZero_WhenNoRowsMatchWhere.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldReturnZero_WhenNoRowsMatchWhere()
     {
         var db = new NpgsqlDbMock();
@@ -65,6 +67,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple()
     {
         var db = new NpgsqlDbMock();
@@ -93,6 +96,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldHandleWhereWithAnd_CaseInsensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldHandleWhereWithAnd_CaseInsensitive()
     {
         var db = new NpgsqlDbMock();
@@ -121,6 +125,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleSetPairs.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleSetPairs()
     {
         var db = new NpgsqlDbMock();
@@ -146,6 +151,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords()
     {
         var db = new NpgsqlDbMock();
@@ -170,6 +176,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldWork_WithThreadSafeTrueOrFalse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void Update_ShouldWork_WithThreadSafeTrueOrFalse(bool threadSafe)
@@ -196,6 +203,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenTableDoesNotExist.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenTableDoesNotExist()
     {
         var db = new NpgsqlDbMock();
@@ -214,6 +222,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken()
     {
         var db = new NpgsqlDbMock();
@@ -235,6 +244,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull()
     {
         var db = new NpgsqlDbMock();
@@ -260,6 +270,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldSupportParameter_IfSqlValueHelperSupports.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldSupportParameter_IfSqlValueHelperSupports()
     {
         var db = new NpgsqlDbMock();
@@ -294,6 +305,7 @@ public sealed class PostgreSqlUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/SubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/SubqueryFromAndJoinsTests.cs
@@ -12,6 +12,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
         using var cnn = new NpgsqlConnectionMock();
@@ -44,6 +45,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
         using var cnn = new NpgsqlConnectionMock();
@@ -88,6 +90,7 @@ ORDER BY u.Id, o.Amount";
     /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void NestedSubquery_ShouldWork()
     {
         using var cnn = new NpgsqlConnectionMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/TemporaryTable/PostgreSqlTemporaryTableEngineTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/TemporaryTable/PostgreSqlTemporaryTableEngineTests.cs
@@ -12,6 +12,7 @@ public sealed class PostgreSqlTemporaryTableEngineTests
     /// PT: Testa o comportamento de CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "TemporaryTable")]
     public void CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows()
     {
         var db = new NpgsqlDbMock();
@@ -48,6 +49,7 @@ SELECT id FROM tmp_users ORDER BY id;";
     /// Auto-generated summary.
     /// </summary>
     [Fact]
+    [Trait("Category", "TemporaryTable")]
     public void CreateTemporaryTable_InPgTempSchema_ShouldReturnProjectedRows()
     {
         var db = new NpgsqlDbMock();

--- a/src/DbSqlLikeMem.Npgsql.Test/TemporaryTable/PostgreSqlTemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/TemporaryTable/PostgreSqlTemporaryTableParserTests.cs
@@ -10,6 +10,7 @@ public sealed class PostgreSqlTemporaryTableParserTests
     /// PT: Testa o comportamento de ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataNpgsqlVersion]
     public void ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect(int version)
     {
@@ -64,6 +65,7 @@ WHERE tenantid = 10",
     /// PT: Testa o comportamento de Parse_ShouldAccept_CreateTemporaryTable_Variants.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataByNpgsqlVersion(nameof(CreateTempTableStatements))]
     public void Parse_ShouldAccept_CreateTemporaryTable_Variants(string sql, int version)
     {
@@ -78,6 +80,7 @@ WHERE tenantid = 10",
     /// Auto-generated summary.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataNpgsqlVersion]
     public void Parse_ShouldTreat_PgTempSchema_AsTemporary(int version)
     {

--- a/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewEngineTests.cs
@@ -39,6 +39,7 @@ public sealed class PostgreSqlCreateViewEngineTests : XUnitTestBase
     /// PT: Testa o comportamento de CreateView_ThenSelectFromView_ShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ThenSelectFromView_ShouldReturnExpectedRows()
     {
         _cnn.ExecNonQuery(@"
@@ -56,6 +57,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_IsNotMaterialized_ShouldReflectBaseTableChanges.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_IsNotMaterialized_ShouldReflectBaseTableChanges()
     {
         _cnn.ExecNonQuery("CREATE VIEW v_all AS SELECT id FROM users ORDER BY id;");
@@ -72,6 +74,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de CreateOrReplaceView_ShouldChangeDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateOrReplaceView_ShouldChangeDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW v AS SELECT id FROM users WHERE tenantid = 10;");
@@ -88,6 +91,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_NameShouldShadowTable_WhenSameName.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_NameShouldShadowTable_WhenSameName()
     {
         var db = new NpgsqlDbMock();
@@ -109,6 +113,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_CanReferenceAnotherView.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_CanReferenceAnotherView()
     {
         _cnn.ExecNonQuery("CREATE VIEW v1 AS SELECT id FROM users WHERE tenantid = 10;");
@@ -123,6 +128,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_WithJoinAndAggregation_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_WithJoinAndAggregation_ShouldWork()
     {
         _cnn.ExecNonQuery(@"
@@ -147,6 +153,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de CreateView_ExistingNameWithoutOrReplace_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ExistingNameWithoutOrReplace_ShouldThrow()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdup AS SELECT 1 AS x ;");
@@ -158,6 +165,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de DropView_ShouldRemoveDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void DropView_ShouldRemoveDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdrop AS SELECT id FROM users;");

--- a/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Views/PostgreSqlCreateViewParserTests.cs
@@ -12,6 +12,7 @@ public sealed class PostgreSqlCreateViewParserTests(
     /// PT: Testa o comportamento de ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataNpgsqlVersion]
     public void ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements(int version)
     {
@@ -39,6 +40,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateOrReplaceView_ShouldSetFlag.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataNpgsqlVersion]
     public void Parse_CreateOrReplaceView_ShouldSetFlag(int version)
     {
@@ -54,6 +56,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataNpgsqlVersion]
     public void Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames(int version)
     {
@@ -68,6 +71,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithBackticks_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataNpgsqlVersion]
     public void Parse_CreateView_WithBackticks_ShouldWork(int version)
     {
@@ -82,6 +86,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataNpgsqlVersion]
     public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec(int version)
     {

--- a/src/DbSqlLikeMem.Oracle.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/CsvLoaderAndIndexTests.cs
@@ -13,6 +13,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de CsvLoader_ShouldLoadRows_ByColumnName.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void CsvLoader_ShouldLoadRows_ByColumnName()
     {
         var db = new OracleDbMock();
@@ -39,6 +40,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de GetColumn_ShouldThrow_UnknownColumn.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void GetColumn_ShouldThrow_UnknownColumn()
     {
         var db = new OracleDbMock();
@@ -54,6 +56,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de Index_Lookup_ShouldReturnRowPositions.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void Index_Lookup_ShouldReturnRowPositions()
     {
         var db = new OracleDbMock();
@@ -76,6 +79,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de BackupRestore_ShouldRollbackData.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void BackupRestore_ShouldRollbackData()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/DapperTests.cs
@@ -34,6 +34,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de TestSelectQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void TestSelectQuery()
     {
         var users = _connection.Query<UserObjectTest>("SELECT * FROM Users").ToList();
@@ -45,6 +46,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de QueryShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryShouldReturnCorrectData()
     {
         // Arrange
@@ -82,6 +84,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldInsertData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldInsertData()
     {
         // Arrange
@@ -112,6 +115,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldUpdateData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldUpdateData()
     {
         // Arrange
@@ -155,6 +159,7 @@ UPDATE users
     /// PT: Testa o comportamento de ExecuteShouldDeleteData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldDeleteData()
     {
         // Arrange
@@ -181,6 +186,7 @@ UPDATE users
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryMultipleShouldReturnMultipleResultSets()
     {
         var dt = DateTime.UtcNow;

--- a/src/DbSqlLikeMem.Oracle.Test/DapperUserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/DapperUserTests.cs
@@ -51,6 +51,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de InsertUserShouldAddUserToTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void InsertUserShouldAddUserToTable()
     {
         // Arrange
@@ -99,6 +100,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -155,6 +157,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de UpdateUserShouldModifyUserInTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void UpdateUserShouldModifyUserInTable()
     {
         // Arrange
@@ -225,6 +228,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de DeleteUserShouldRemoveUserFromTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void DeleteUserShouldRemoveUserFromTable()
     {
         // Arrange
@@ -276,6 +280,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Oracle.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/DapperUserTests2.cs
@@ -57,6 +57,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -113,6 +114,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange
@@ -176,6 +178,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryWithJoinShouldReturnJoinedData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryWithJoinShouldReturnJoinedData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Oracle.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/ExistsTests.cs
@@ -13,6 +13,7 @@ public sealed class ExistsTests(
     /// PT: Testa o comportamento de Exists_ShouldFilterUsersWithOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_ShouldFilterUsersWithOrders()
     {
         using var cnn = new OracleConnectionMock();
@@ -56,6 +57,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de NotExists_ShouldFilterUsersWithoutOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void NotExists_ShouldFilterUsersWithoutOrders()
     {
         using var cnn = new OracleConnectionMock();
@@ -98,6 +100,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de Exists_WithExtraPredicate_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_WithExtraPredicate_ShouldWork()
     {
         using var cnn = new OracleConnectionMock();

--- a/src/DbSqlLikeMem.Oracle.Test/ExtendedOracleMockTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/ExtendedOracleMockTests.cs
@@ -13,6 +13,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertAutoIncrementShouldAssignIdentityWhenNotSpecified.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void InsertAutoIncrementShouldAssignIdentityWhenNotSpecified()
     {
         var db = new OracleDbMock();
@@ -39,6 +40,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertNullIntoNullableColumnShouldSucceed.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void InsertNullIntoNullableColumnShouldSucceed()
     {
         var db = new OracleDbMock();
@@ -58,6 +60,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertNullIntoNonNullableColumnShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void InsertNullIntoNonNullableColumnShouldThrow()
     {
         var db = new OracleDbMock();
@@ -78,6 +81,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de CompositeIndexFilterShouldReturnCorrectRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void CompositeIndexFilterShouldReturnCorrectRows()
     {
         var db = new OracleDbMock();
@@ -103,6 +107,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de LikeFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void LikeFilterShouldReturnMatchingRows()
     {
         var db = new OracleDbMock();
@@ -123,6 +128,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void InFilterShouldReturnMatchingRows()
     {
         var db = new OracleDbMock();
@@ -144,6 +150,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de OrderByLimitOffsetDistinctShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void OrderByLimitOffsetDistinctShouldReturnExpectedRows()
     {
         var db = new OracleDbMock();
@@ -165,6 +172,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de HavingFilterShouldApplyAfterAggregation.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void HavingFilterShouldApplyAfterAggregation()
     {
         var db = new OracleDbMock();
@@ -189,6 +197,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletion.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletion()
     {
         // Parent
@@ -216,6 +225,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK()
     {
         // Parent
@@ -242,6 +252,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de MultipleParameterSetsInsertShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedOracleMock")]
     public void MultipleParameterSetsInsertShouldInsertAllRows()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/FluentTest.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/FluentTest.cs
@@ -31,6 +31,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de InsertUpdateDeleteFluentScenario.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void InsertUpdateDeleteFluentScenario()
     {
         using var cnn = BuildConnection();
@@ -74,6 +75,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de TestFluent.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void TestFluent()
     {
         using var cnn = new OracleConnectionMock();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAdditionalBehaviorCoverageTests.cs
@@ -49,6 +49,7 @@ public sealed class OracleAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNull_And_IsNotNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdditionalBehaviorCoverage")]
     public void Where_IsNull_And_IsNotNull_ShouldWork()
     {
         var nullIds = _cnn.Query<int>("SELECT id FROM users WHERE email IS NULL ORDER BY id").ToList();
@@ -63,6 +64,7 @@ public sealed class OracleAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_EqualNull_ShouldReturnNoRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdditionalBehaviorCoverage")]
     public void Where_EqualNull_ShouldReturnNoRows()
     {
         // MySQL: any comparison with NULL yields UNKNOWN (i.e., filtered out in WHERE)
@@ -78,6 +80,7 @@ public sealed class OracleAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldPreserveLeftRows_WhenNoMatch.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdditionalBehaviorCoverage")]
     public void LeftJoin_ShouldPreserveLeftRows_WhenNoMatch()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -104,6 +107,7 @@ ORDER BY u.id
     /// PT: Testa o comportamento de OrderBy_Desc_ThenAsc_ShouldBeDeterministic.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdditionalBehaviorCoverage")]
     public void OrderBy_Desc_ThenAsc_ShouldBeDeterministic()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -121,6 +125,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdditionalBehaviorCoverage")]
     public void Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls()
     {
         var r = _cnn.QuerySingle<dynamic>("SELECT COUNT(*) c1, COUNT(email) c2 FROM users");
@@ -134,6 +139,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Having_ShouldFilterGroups.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdditionalBehaviorCoverage")]
     public void Having_ShouldFilterGroups()
     {
         var userIds = _cnn.Query<int>(@"
@@ -152,6 +158,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Where_In_WithParameterList_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdditionalBehaviorCoverage")]
     public void Where_In_WithParameterList_ShouldWork()
     {
         var ids = _cnn.Query<int>("SELECT id FROM users WHERE id IN @ids ORDER BY id", new { ids = param }).ToList();
@@ -163,6 +170,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Insert_WithColumnsOutOfOrder_ShouldMapCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdditionalBehaviorCoverage")]
     public void Insert_WithColumnsOutOfOrder_ShouldMapCorrectly()
     {
         _cnn.Execute("INSERT INTO users (name, id, email) VALUES (@name, @id, @email)", new { id = 4, name = "Zed", email = "zed@x.com" });
@@ -178,6 +186,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Delete_WithInParameterList_ShouldDeleteMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdditionalBehaviorCoverage")]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
         var deleted = _cnn.Execute("DELETE FROM users WHERE id IN @ids", new { ids = param });
@@ -192,6 +201,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Update_SetExpression_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdditionalBehaviorCoverage")]
     public void Update_SetExpression_ShouldUpdateRows()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAdvancedSqlGapTests.cs
@@ -44,6 +44,7 @@ public sealed class OracleAdvancedSqlGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -60,6 +61,7 @@ ORDER BY tenantid, id").ToList();
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -76,6 +78,7 @@ ORDER BY u.id").ToList();
     /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
     public void DateAdd_IntervalDay_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -95,6 +98,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
     public void Cast_StringToInt_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT TO_NUMBER('42') AS v").ToList();
@@ -109,6 +113,7 @@ ORDER BY id").ToList();
     /// PT: Garante que o alvo de cast NUMBER seja tratado como compatível com inteiro no comportamento Oracle.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
     public void Cast_StringToInt_NumberType_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT CAST('42' AS NUMBER) AS v").ToList();
@@ -121,6 +126,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
     public void Regexp_Operator_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name REGEXP '^J' ORDER BY id").ToList();
@@ -134,6 +140,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
     public void OrderBy_Field_Function_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users ORDER BY CASE id WHEN 3 THEN 1 WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END").ToList();
@@ -145,6 +152,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {
         // Example expectation in MySQL: behavior depends on column collation.

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAggregationTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAggregationTests.cs
@@ -33,6 +33,7 @@ public sealed class OracleAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAggregation")]
     public void GroupBy_WithCountAndSum_ShouldWork()
     {
         const string sql = """
@@ -59,6 +60,7 @@ public sealed class OracleAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAggregation")]
     public void Having_ShouldFilterAggregates()
     {
         const string sql = """
@@ -78,6 +80,7 @@ public sealed class OracleAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleAggregation")]
     public void Distinct_Order_Limit_Offset_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.Oracle.Test/OracleDataParameterCollectionMockTest.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleDataParameterCollectionMockTest.cs
@@ -12,6 +12,7 @@ public sealed class OracleDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleDataParameterCollectionMockTest")]
     public void ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames()
     {
         Assert.Equal("id", OracleDataParameterCollectionMock.NormalizeParameterName("@id"));
@@ -26,6 +27,7 @@ public sealed class OracleDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Add_DuplicateName_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleDataParameterCollectionMockTest")]
     public void ParameterCollection_Add_DuplicateName_ShouldThrow()
     {
         var pars = new OracleDataParameterCollectionMock();
@@ -39,6 +41,7 @@ public sealed class OracleDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_RemoveAt_ShouldReindexDictionary.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleDataParameterCollectionMockTest")]
     public void ParameterCollection_RemoveAt_ShouldReindexDictionary()
     {
         var pars = new OracleDataParameterCollectionMock();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleJoinTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleJoinTests.cs
@@ -41,6 +41,7 @@ public sealed class OracleJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldKeepAllLeftRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleJoin")]
     public void LeftJoin_ShouldKeepAllLeftRows()
     {
         const string sql = """
@@ -61,6 +62,7 @@ public sealed class OracleJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de RightJoin_ShouldKeepAllRightRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleJoin")]
     public void RightJoin_ShouldKeepAllRightRows()
     {
         const string sql = """
@@ -95,6 +97,7 @@ public sealed class OracleJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ON_WithMultipleConditions_AND_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleJoin")]
     public void Join_ON_WithMultipleConditions_AND_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.Oracle.Test/OracleLinqProviderTest.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleLinqProviderTest.cs
@@ -26,6 +26,7 @@ public sealed class OracleLinqProviderTest
     /// PT: Testa o comportamento de LinqProvider_ShouldQueryWhereAndReturnRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleLinqProviderTest")]
     public void LinqProvider_ShouldQueryWhereAndReturnRows()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/OracleMockTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleMockTests.cs
@@ -38,6 +38,7 @@ public sealed class OracleMockTests
     /// PT: Testa o comportamento de TestInsert.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleMock")]
     public void TestInsert()
     {
         using var command = new OracleCommandMock(_connection)
@@ -54,6 +55,7 @@ public sealed class OracleMockTests
     /// PT: Testa o comportamento de TestUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleMock")]
     public void TestUpdate()
     {
         using var command = new OracleCommandMock(_connection)
@@ -73,6 +75,7 @@ public sealed class OracleMockTests
     /// PT: Testa o comportamento de TestDelete.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleMock")]
     public void TestDelete()
     {
         using var command = new OracleCommandMock(_connection)
@@ -92,6 +95,7 @@ public sealed class OracleMockTests
     /// PT: Testa o comportamento de TestTransactionCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleMock")]
     public void TestTransactionCommit()
     {
         using (var transaction = _connection.BeginTransaction())
@@ -127,6 +131,7 @@ public sealed class OracleMockTests
     /// PT: Testa o comportamento de TestTransactionCommitInsertUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleMock")]
     public void TestTransactionCommitInsertUpdate()
     {
         using var cmd = _connection.CreateCommand();
@@ -149,6 +154,7 @@ public sealed class OracleMockTests
     /// PT: Testa o comportamento de TestTransactionRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleMock")]
     public void TestTransactionRollback()
     {
         using (var transaction = _connection.BeginTransaction())

--- a/src/DbSqlLikeMem.Oracle.Test/OracleSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleSelectAndWhereMoreCoverageTests.cs
@@ -43,6 +43,7 @@ public sealed class OracleSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Between_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSelectAndWhereMoreCoverage")]
     public void Where_Between_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id BETWEEN 2 AND 3 ORDER BY id").ToList();
@@ -54,6 +55,7 @@ public sealed class OracleSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NotIn_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSelectAndWhereMoreCoverage")]
     public void Where_NotIn_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id NOT IN (1,3)").ToList();
@@ -66,6 +68,7 @@ public sealed class OracleSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ExistsSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSelectAndWhereMoreCoverage")]
     public void Where_ExistsSubquery_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -87,6 +90,7 @@ ORDER BY u.id").ToList();
     /// PT: Testa o comportamento de Select_CaseWhen_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSelectAndWhereMoreCoverage")]
     public void Select_CaseWhen_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -106,6 +110,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Select_IfNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSelectAndWhereMoreCoverage")]
     public void Select_IfNull_ShouldWork()
     {
         var row = _cnn.QuerySingle<dynamic>("SELECT COALESCE(email,'(none)') AS em FROM users WHERE id = 2");

--- a/src/DbSqlLikeMem.Oracle.Test/OracleSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleSqlCompatibilityGapTests.cs
@@ -45,6 +45,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Precedence_AND_ShouldBindStrongerThan_OR.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Where_Precedence_AND_ShouldBindStrongerThan_OR()
     {
         // MySQL precedence: AND binds stronger than OR.
@@ -58,6 +59,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_OR_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Where_OR_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id = 1 OR id = 3").ToList();
@@ -69,6 +71,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ParenthesesGrouping_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Where_ParenthesesGrouping_ShouldWork()
     {
         // (id=1 OR id=2) AND email IS NULL => only user 2
@@ -82,6 +85,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_Arithmetic_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Select_Expressions_Arithmetic_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, id + 1 AS nextId FROM users ORDER BY id").ToList();
@@ -93,6 +97,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_CASE_WHEN_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Select_Expressions_CASE_WHEN_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CASE WHEN email IS NULL THEN 0 ELSE 1 END AS hasEmail FROM users ORDER BY id").ToList();
@@ -104,6 +109,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IF_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Select_Expressions_IF_ShouldWork()
     {
         // MySQL: IF(cond, then, else)
@@ -116,6 +122,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IIF_ShouldWork_AsAliasForIF.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Select_Expressions_IIF_ShouldWork_AsAliasForIF()
     {
         // Not native MySQL, but requested as convenience.
@@ -128,6 +135,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_COALESCE_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Functions_COALESCE_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, COALESCE(NULL, email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -139,6 +147,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_IFNULL_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Functions_IFNULL_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, NVL(email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -150,6 +159,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_CONCAT_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Functions_CONCAT_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CONCAT(name, '#', id) AS tag FROM users ORDER BY id").ToList();
@@ -161,6 +171,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_ShouldBeConsistent.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Distinct_ShouldBeConsistent()
     {
         // duplicate names
@@ -174,6 +185,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ComplexOn_WithOr_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Join_ComplexOn_WithOr_ShouldWork()
     {
         // include orders joined when (o.userId = u.id OR o.userId = 0)
@@ -194,6 +206,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_Having_ShouldSupportAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void GroupBy_Having_ShouldSupportAggregates()
     {
         var rows = _cnn.Query<dynamic>(
@@ -211,6 +224,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de OrderBy_ShouldSupportAlias_And_Ordinal.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void OrderBy_ShouldSupportAlias_And_Ordinal()
     {
         var rows1 = _cnn.Query<dynamic>("SELECT id, id + 1 AS x FROM users ORDER BY x DESC").ToList();
@@ -226,6 +240,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Union_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -241,6 +256,7 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Union_Inside_SubSelect_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -259,6 +275,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Cte_With_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Cte_With_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -272,6 +289,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
     public void Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault()
     {
         // Many MySQL installations use case-insensitive collations by default.

--- a/src/DbSqlLikeMem.Oracle.Test/OracleTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleTransactionReliabilityTests.cs
@@ -11,6 +11,7 @@ public sealed class OracleTransactionReliabilityTests
     /// PT: Garante que rollback para savepoint restaure o estado intermediário.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleTransactionReliability")]
     public void SavepointRollbackShouldRestoreIntermediateState()
     {
         var db = new OracleDbMock();
@@ -38,6 +39,7 @@ public sealed class OracleTransactionReliabilityTests
     /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleTransactionReliability")]
     public void IsolationLevelShouldBeExposedDeterministically()
     {
         var db = new OracleDbMock();
@@ -55,6 +57,7 @@ public sealed class OracleTransactionReliabilityTests
     /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleTransactionReliability")]
     public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
     {
         var db = new OracleDbMock();
@@ -72,6 +75,7 @@ public sealed class OracleTransactionReliabilityTests
     /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleTransactionReliability")]
     public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
     {
         var db = new OracleDbMock { ThreadSafe = true };

--- a/src/DbSqlLikeMem.Oracle.Test/OracleTransactionTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleTransactionTests.cs
@@ -31,6 +31,7 @@ public sealed class OracleTransactionTests(
     /// PT: Testa o comportamento de TransactionCommitShouldPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleTransaction")]
     public void TransactionCommitShouldPersistData()
     {
         // Arrange
@@ -63,6 +64,7 @@ public sealed class OracleTransactionTests(
     /// PT: Testa o comportamento de TransactionRollbackShouldNotPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleTransaction")]
     public void TransactionRollbackShouldNotPersistData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs
@@ -31,6 +31,7 @@ public sealed class OracleUnionLimitAndJsonCompatibilityTests : XUnitTestBase
     /// PT: Testa o comportamento de UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleUnionLimitAndJsonCompatibility")]
     public void UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates()
     {
         // UNION ALL keeps duplicates
@@ -55,6 +56,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de OffsetFetch_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleUnionLimitAndJsonCompatibility")]
     public void OffsetFetch_ShouldWork()
     {
         // MySQL supports: LIMIT offset, count
@@ -67,6 +69,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonValue_SimpleObjectPath_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleUnionLimitAndJsonCompatibility")]
     public void JsonValue_SimpleObjectPath_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, JSON_VALUE(payload, '$.a.b' RETURNING NUMBER) AS v FROM t ORDER BY id").ToList();
@@ -83,6 +86,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de OrderBy_NullsFirst_ShouldApplyExplicitNullOrdering.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleUnionLimitAndJsonCompatibility")]
     public void OrderBy_NullsFirst_ShouldApplyExplicitNullOrdering()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM t ORDER BY payload NULLS FIRST, id").ToList();
@@ -95,6 +99,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonFunction_ShouldThrow_WhenNotSupportedByDialect.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleUnionLimitAndJsonCompatibility")]
     public void JsonFunction_ShouldThrow_WhenNotSupportedByDialect()
     {
         Assert.Throws<NotSupportedException>(() =>
@@ -106,6 +111,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleUnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -122,6 +128,7 @@ SELECT 1 AS v
     /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleUnionLimitAndJsonCompatibility")]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
         Assert.Throws<InvalidOperationException>(() =>
@@ -139,6 +146,7 @@ SELECT 'x' AS v
     /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleUnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {
         var rows = _cnn.Query<dynamic>(@"

--- a/src/DbSqlLikeMem.Oracle.Test/OracleWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleWhereParserAndExecutorTests.cs
@@ -38,6 +38,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEquality_ShouldUseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_IndexedEquality_ShouldUseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -58,6 +59,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -85,6 +87,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex()
     {
         var table = _cnn.GetTable("users");
@@ -109,6 +112,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow()
     {
         var table = _cnn.GetTable("users");
@@ -130,6 +134,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -148,6 +153,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IN_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_IN_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id IN (1,3)").ToList();
@@ -161,6 +167,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNotNull_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_IsNotNull_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE email IS NOT NULL").ToList();
@@ -172,6 +179,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Operators_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_Operators_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id >= 2 AND id <= 3").ToList();
@@ -186,6 +194,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Like_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_Like_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name LIKE '%oh%'").ToList();
@@ -198,6 +207,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_FindInSet_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_FindInSet_ShouldWork()
     {
         // FIND_IN_SET('b', tags) -> John(a,b) e Jane(b,c)
@@ -210,6 +220,7 @@ public sealed class OracleWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_AND_ShouldBeCaseInsensitive_InRealLife.
     /// </summary>
     [Fact]
+    [Trait("Category", "OracleWhereParserAndExecutor")]
     public void Where_AND_ShouldBeCaseInsensitive_InRealLife()
     {
         // esse teste é pra pegar o bug clássico: split só em " AND " / " and "

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
@@ -12,6 +12,7 @@ public sealed class OracleDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Oracle dialect version under test. PT: Versão do dialeto Oracle em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void ParseSelect_WithRecursive_ShouldBeRejected(int version)
     {
@@ -32,6 +33,7 @@ public sealed class OracleDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Oracle dialect version under test. PT: Versão do dialeto Oracle em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void ParseInsert_OnConflict_ShouldBeRejected(int version)
     {
@@ -46,6 +48,7 @@ public sealed class OracleDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Oracle dialect version under test. PT: Versão do dialeto Oracle em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void ParseSelect_WithSqlServerTableHints_ShouldBeRejected(int version)
     {
@@ -61,6 +64,7 @@ public sealed class OracleDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void RuntimeDialectRules_ShouldRemainStable(int version)
     {
@@ -84,6 +88,7 @@ public sealed class OracleDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Oracle dialect version under test. PT: Versão do dialeto Oracle em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void ParseUnsupportedSql_ShouldUseStandardNotSupportedMessage(int version)
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/SqlExprPrinterTest.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/SqlExprPrinterTest.cs
@@ -12,6 +12,7 @@ public sealed class SqlExprPrinterTest(
     /// PT: Testa o comportamento de ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByOracleVersion(nameof(Expressions))]
     public void ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse(string expr, int version)
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/SqlExpressionParserTests.cs
@@ -16,6 +16,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByOracleVersion(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
     {
@@ -91,6 +92,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de ParseWhere_ShouldThrow_ForUnsupportedExpressions.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByOracleVersion(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
     {
@@ -125,6 +127,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Precedence_OR_ShouldBindLooserThan_AND.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
     {
@@ -153,6 +156,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Parentheses_ShouldOverridePrecedence.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void Parentheses_ShouldOverridePrecedence(int version)
     {
@@ -174,6 +178,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Not_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void Not_ShouldWork(int version)
     {
@@ -191,6 +196,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de IsNotNull_ShouldProduce_IsNullExpr_Negated.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
     {
@@ -204,6 +210,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de In_ShouldParse_List.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void In_ShouldParse_List(int version)
     {
@@ -217,6 +224,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Like_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void Like_ShouldParse(int version)
     {
@@ -230,6 +238,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Identifier_WithAliasDotColumn_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
     {
@@ -252,6 +261,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Parameter_Tokens_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void Parameter_Tokens_ShouldParse(int version)
     {
@@ -266,6 +276,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de DoubleQuoted_Identifier_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void DoubleQuoted_Identifier_ShouldParse(int version)
     {
@@ -280,6 +291,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de SingleQuoted_String_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void SingleQuoted_String_ShouldParse(int version)
     {
@@ -294,6 +306,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de DoubleQuoted_Token_IsIdentifier_NotString.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void DoubleQuoted_Token_IsIdentifier_NotString(int version)
     {
@@ -307,6 +320,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -631,6 +631,7 @@ select id
     /// PT: Testa o comportamento de Parse_ShouldHandle_MultiStatementStrings_BySplitting.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
     public void Parse_ShouldHandle_MultiStatementStrings_BySplitting(int version)
     {
@@ -654,6 +655,7 @@ select id
     /// PT: Testa o comportamento de Parse_Corpus.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataByOracleVersion(nameof(Statements))]
     public void Parse_Corpus(string sql, string why, SqlCaseExpectation expectation, int minVersion, int version)
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Query/QueryExecutorExtrasTests.cs
@@ -29,6 +29,7 @@ public sealed class QueryExecutorExtrasTests(
     /// PT: Testa o comportamento de GroupByAndAggregationsShouldComputeCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void GroupByAndAggregationsShouldComputeCorrectly()
     {
         // Arrange
@@ -66,6 +67,7 @@ GROUP BY grp";
     /// PT: Testa o comportamento de OrderByLimitOffsetShouldPageCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void OrderByLimitOffsetShouldPageCorrectly()
     {
         // Arrange
@@ -115,6 +117,7 @@ public class SqlTranslatorTests
     /// PT: Testa o comportamento de TranslateBasicWhereAndOrderBySqlCorrect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void TranslateBasicWhereAndOrderBySqlCorrect()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Oracle.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -13,6 +13,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de CreateTableAsSelect_ShouldCreateNewTableWithRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void CreateTableAsSelect_ShouldCreateNewTableWithRows()
     {
         var db = new OracleDbMock();
@@ -45,6 +46,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de InsertIntoSelect_ShouldInsertRowsFromQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void InsertIntoSelect_ShouldInsertRowsFromQuery()
     {
         var db = new OracleDbMock();
@@ -76,6 +78,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de UpdateJoinDerivedSelect_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void UpdateJoinDerivedSelect_ShouldUpdateRows()
     {
         var db = new OracleDbMock();
@@ -115,6 +118,7 @@ WHERE u.tenantid = 10";
     /// PT: Testa o comportamento de DeleteJoinDerivedSelect_ShouldDeleteRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void DeleteJoinDerivedSelect_ShouldDeleteRows()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.Oracle.Test/SqlValueHelperTests .cs
@@ -15,6 +15,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_ByName.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldReadDapperParameter_ByName()
     {
         using var cnn = new OracleConnectionMock();
@@ -35,6 +36,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldThrow_WhenParameterMissing()
     {
         Assert.Throws<OracleMockException>(() =>
@@ -46,6 +48,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldParseInList_ToListOfResolvedValues.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldParseInList_ToListOfResolvedValues()
     {
         var v = OracleValueHelper.Resolve("(1, 2, 3)", DbType.Int32, isNullable: false, pars: null, colDict: null);
@@ -59,6 +62,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_NullOnNonNullable_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_NullOnNonNullable_ShouldThrow()
     {
         Assert.Throws<OracleMockException>(() =>
@@ -70,6 +74,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Json_ShouldReturnJsonDocument_WhenValid.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Json_ShouldReturnJsonDocument_WhenValid()
     {
         var v = OracleValueHelper.Resolve("{\"a\":1}", DbType.Object, isNullable: false, pars: null, colDict: null);
@@ -87,6 +92,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Descreve o comportamento validado por Like_ShouldMatch_MySqlStyle.
     /// </summary>
     [Theory]
+    [Trait("Category", "SqlValueHelperTests ")]
     [InlineData("John", "%oh%", true)]
     [InlineData("John", "J_hn", true)]
     [InlineData("John", "J__n", true)]
@@ -102,6 +108,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Enum_ShouldValidateAgainstColumnDef.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Enum_ShouldValidateAgainstColumnDef()
     {
         var tb = new OracleDbMock().AddTable("tb");
@@ -124,6 +131,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Set_ShouldReturnHashSet_AndValidate.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Set_ShouldReturnHashSet_AndValidate()
     {
         var tb = new OracleDbMock().AddTable("tb");
@@ -155,6 +163,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateStringSize.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateStringSize()
     {
         var tb = new OracleDbMock().AddTable("tb");
@@ -180,6 +189,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateDecimalPlaces.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateDecimalPlaces()
     {
         var tb = new OracleDbMock().AddTable("tb");

--- a/src/DbSqlLikeMem.Oracle.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/StoredProcedureExecutionTests.cs
@@ -25,6 +25,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs()
     {
         // Arrange
@@ -65,6 +66,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput()
     {
         // Arrange
@@ -103,6 +105,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull()
     {
         // Arrange
@@ -141,6 +144,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue()
     {
         // Arrange
@@ -188,6 +192,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset()
     {
         // Arrange
@@ -222,6 +227,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero()
     {
         using var c = new OracleConnectionMock();
@@ -253,6 +259,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput()
     {
         using var c = new OracleConnectionMock();
@@ -282,6 +289,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldWork()
     {
         // Arrange
@@ -315,6 +323,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Oracle.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/StoredProcedureSignatureTests.cs
@@ -13,6 +13,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldValidateRequiredInAndOutParams.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldValidateRequiredInAndOutParams()
     {
         using var c = new OracleConnectionMock();
@@ -44,6 +45,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldThrowWhenMissingRequiredParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldThrowWhenMissingRequiredParam()
     {
         using var c = new OracleConnectionMock();
@@ -67,6 +69,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de CallStatement_ShouldValidateAgainstRegisteredProcedure.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void CallStatement_ShouldValidateAgainstRegisteredProcedure()
     {
         using var c = new OracleConnectionMock();

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleDeleteStrategyTests.cs
@@ -13,6 +13,7 @@ public sealed class OracleCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_1_linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_1_linha()
     {
         var db = new OracleDbMock();
@@ -36,6 +37,7 @@ public sealed class OracleCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_varias_linhas.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_varias_linhas()
     {
         var db = new OracleDbMock();
@@ -60,6 +62,7 @@ public sealed class OracleCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0()
     {
         var db = new OracleDbMock();
@@ -81,6 +84,7 @@ public sealed class OracleCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_tabela_inexistente_dispara.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_tabela_inexistente_dispara()
     {
         var db = new OracleDbMock();
@@ -96,6 +100,7 @@ public sealed class OracleCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara()
     {
         var db = new OracleDbMock();
@@ -115,6 +120,7 @@ public sealed class OracleCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia()
     {
         var db = new OracleDbMock();
@@ -141,6 +147,7 @@ public sealed class OracleCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false(bool threadSafe)
@@ -163,6 +170,7 @@ public sealed class OracleCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_case_insensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_case_insensitive()
     {
         var db = new OracleDbMock();
@@ -183,6 +191,7 @@ public sealed class OracleCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_com_parametro_se_suportado.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_com_parametro_se_suportado()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertOnDuplicateTests.cs
@@ -11,6 +11,7 @@ public sealed class OracleMergeUpsertTests(ITestOutputHelper helper) : XUnitTest
     /// PT: Testa o comportamento de Merge_ShouldInsert_WhenNotMatched.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Merge_ShouldInsert_WhenNotMatched()
     {
         var db = new OracleDbMock();
@@ -41,6 +42,7 @@ WHEN NOT MATCHED THEN
     /// PT: Testa o comportamento de Merge_ShouldUpdate_WhenMatched.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Merge_ShouldUpdate_WhenMatched()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyCoverageTests.cs
@@ -13,6 +13,7 @@ public sealed class OracleInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_MultiRowValues_ShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_MultiRowValues_ShouldInsertAllRows()
     {
         var db = new OracleDbMock();
@@ -41,6 +42,7 @@ public sealed class OracleInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_WithIdentityColumnOmitted_ShouldAutoIncrement.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_WithIdentityColumnOmitted_ShouldAutoIncrement()
     {
         var db = new OracleDbMock();
@@ -71,6 +73,7 @@ public sealed class OracleInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de InsertSelect_ShouldInsertRowsFromSelect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertSelect_ShouldInsertRowsFromSelect()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyExtrasTests.cs
@@ -12,6 +12,7 @@ public sealed class OracleInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de MultiRowInsertShouldAddAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void MultiRowInsertShouldAddAllRows()
     {
         // Arrange
@@ -39,6 +40,7 @@ public sealed class OracleInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertWithDefaultValueAndIdentityShouldApplyDefaults.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertWithDefaultValueAndIdentityShouldApplyDefaults()
     {
         // Arrange
@@ -70,6 +72,7 @@ public sealed class OracleInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertDuplicatePrimaryKeyShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertDuplicatePrimaryKeyShouldThrow()
     {
         // Arrange
@@ -101,6 +104,7 @@ public class OracleDeleteStrategyForeignKeyTests
     /// PT: Testa o comportamento de DeleteReferencedRowShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void DeleteReferencedRowShouldThrow()
     {
         // Arrange parent
@@ -140,6 +144,7 @@ public class OracleUpdateStrategyExtrasTests
     /// PT: Testa o comportamento de UpdateMultipleConditionsShouldOnlyAffectMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateMultipleConditionsShouldOnlyAffectMatchingRows()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class OracleInsertStrategyTests(
     /// PT: Testa o comportamento de InsertIntoTableShouldAddNewRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertIntoTableShouldAddNewRow()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTransactionTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTransactionTests.cs
@@ -12,6 +12,7 @@ public sealed class OracleTransactionTests(
     /// PT: Testa o comportamento de TransactionShouldCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldCommit()
     {
         // Arrange
@@ -46,6 +47,7 @@ public sealed class OracleTransactionTests(
     /// PT: Testa o comportamento de TransactionShouldRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldRollback()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTriggerStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class OracleTriggerStrategyTests
     /// PT: Garante que um gatilho AFTER INSERT seja executado para uma tabela não temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
     {
         var db = new OracleDbMock();
@@ -33,6 +34,7 @@ public sealed class OracleTriggerStrategyTests
     /// PT: Garante que os gatilhos não sejam executados para uma tabela temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyCoverageTests.cs
@@ -13,6 +13,7 @@ public sealed class OracleUpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNullableColumnToNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNullableColumnToNull_ShouldWork()
     {
         var db = new OracleDbMock();
@@ -38,6 +39,7 @@ public sealed class OracleUpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNotNullableColumnToNull_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNotNullableColumnToNull_ShouldThrow()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyTests.cs
@@ -13,6 +13,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de UpdateTableShouldModifyExistingRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateTableShouldModifyExistingRow()
     {
         // Arrange
@@ -41,6 +42,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldReturnZero_WhenNoRowsMatchWhere.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldReturnZero_WhenNoRowsMatchWhere()
     {
         var db = new OracleDbMock();
@@ -66,6 +68,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple()
     {
         var db = new OracleDbMock();
@@ -94,6 +97,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldHandleWhereWithAnd_CaseInsensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldHandleWhereWithAnd_CaseInsensitive()
     {
         var db = new OracleDbMock();
@@ -122,6 +126,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleSetPairs.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleSetPairs()
     {
         var db = new OracleDbMock();
@@ -147,6 +152,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords()
     {
         var db = new OracleDbMock();
@@ -171,6 +177,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldWork_WithThreadSafeTrueOrFalse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void Update_ShouldWork_WithThreadSafeTrueOrFalse(bool threadSafe)
@@ -197,6 +204,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenTableDoesNotExist.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenTableDoesNotExist()
     {
         var db = new OracleDbMock();
@@ -215,6 +223,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken()
     {
         var db = new OracleDbMock();
@@ -236,6 +245,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull()
     {
         var db = new OracleDbMock();
@@ -261,6 +271,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldSupportParameter_IfSqlValueHelperSupports.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldSupportParameter_IfSqlValueHelperSupports()
     {
         var db = new OracleDbMock();
@@ -295,6 +306,7 @@ public sealed class OracleUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/SubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/SubqueryFromAndJoinsTests.cs
@@ -13,6 +13,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
         using var cnn = new OracleConnectionMock();
@@ -45,6 +46,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
         using var cnn = new OracleConnectionMock();
@@ -89,6 +91,7 @@ ORDER BY u.Id, o.Amount";
     /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void NestedSubquery_ShouldWork()
     {
         using var cnn = new OracleConnectionMock();

--- a/src/DbSqlLikeMem.Oracle.Test/TemporaryTable/OracleTemporaryTableEngineTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/TemporaryTable/OracleTemporaryTableEngineTests.cs
@@ -13,6 +13,7 @@ public sealed class OracleTemporaryTableEngineTests
     /// PT: Testa o comportamento de CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "TemporaryTable")]
     public void CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle.Test/TemporaryTable/OracleTemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/TemporaryTable/OracleTemporaryTableParserTests.cs
@@ -11,6 +11,7 @@ public sealed class OracleTemporaryTableParserTests
     /// PT: Testa o comportamento de ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataOracleVersion]
     public void ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect(int version)
     {
@@ -66,6 +67,7 @@ WHERE tenantid = 10",
     /// PT: Testa o comportamento de Parse_ShouldAccept_CreateTemporaryTable_Variants.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataByOracleVersion(nameof(CreateTempTableStatements))]
     public void Parse_ShouldAccept_CreateTemporaryTable_Variants(string sql, int version)
     {
@@ -81,6 +83,7 @@ WHERE tenantid = 10",
     /// PT: Descreve o comportamento validado por Parse_ShouldAccept_GlobalTemporaryTable.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataOracleVersion]
     public void Parse_ShouldAccept_GlobalTemporaryTable(int version)
     {

--- a/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewEngineTests.cs
@@ -41,6 +41,7 @@ public sealed class OracleCreateViewEngineTests : XUnitTestBase
     /// PT: Testa o comportamento de CreateView_ThenSelectFromView_ShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ThenSelectFromView_ShouldReturnExpectedRows()
     {
         _cnn.ExecNonQuery(@"
@@ -58,6 +59,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_IsNotMaterialized_ShouldReflectBaseTableChanges.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_IsNotMaterialized_ShouldReflectBaseTableChanges()
     {
         _cnn.ExecNonQuery("CREATE VIEW v_all AS SELECT id FROM users ORDER BY id;");
@@ -74,6 +76,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de CreateOrReplaceView_ShouldChangeDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateOrReplaceView_ShouldChangeDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW v AS SELECT id FROM users WHERE tenantid = 10;");
@@ -90,6 +93,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_NameShouldShadowTable_WhenSameName.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_NameShouldShadowTable_WhenSameName()
     {
         // cria uma tabela física chamada vshadow, com dados diferentes
@@ -110,6 +114,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_CanReferenceAnotherView.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_CanReferenceAnotherView()
     {
         _cnn.ExecNonQuery("CREATE VIEW v1 AS SELECT id FROM users WHERE tenantid = 10;");
@@ -124,6 +129,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_WithJoinAndAggregation_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_WithJoinAndAggregation_ShouldWork()
     {
         _cnn.ExecNonQuery(@"
@@ -148,6 +154,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de CreateView_ExistingNameWithoutOrReplace_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ExistingNameWithoutOrReplace_ShouldThrow()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdup AS SELECT 1 AS x FROM DUAL;");
@@ -159,6 +166,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de DropView_ShouldRemoveDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void DropView_ShouldRemoveDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdrop AS SELECT id FROM users;");

--- a/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Views/OracleCreateViewParserTests.cs
@@ -13,6 +13,7 @@ public sealed class OracleCreateViewParserTests(
     /// PT: Testa o comportamento de ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataOracleVersion]
     public void ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements(int version)
     {
@@ -40,6 +41,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateOrReplaceView_ShouldSetFlag.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataOracleVersion]
     public void Parse_CreateOrReplaceView_ShouldSetFlag(int version)
     {
@@ -55,6 +57,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataOracleVersion]
     public void Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames(int version)
     {
@@ -69,6 +72,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithBackticks_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataOracleVersion]
     public void Parse_CreateView_WithBackticks_ShouldWork(int version)
     {
@@ -83,6 +87,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataOracleVersion]
     public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec(int version)
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/CsvLoaderAndIndexTests.cs
@@ -12,6 +12,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de CsvLoader_ShouldLoadRows_ByColumnName.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void CsvLoader_ShouldLoadRows_ByColumnName()
     {
         var db = new SqlServerDbMock();
@@ -38,6 +39,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de GetColumn_ShouldThrow_UnknownColumn.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void GetColumn_ShouldThrow_UnknownColumn()
     {
         var db = new SqlServerDbMock();
@@ -53,6 +55,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de Index_Lookup_ShouldReturnRowPositions.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void Index_Lookup_ShouldReturnRowPositions()
     {
         var db = new SqlServerDbMock();
@@ -75,6 +78,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de BackupRestore_ShouldRollbackData.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void BackupRestore_ShouldRollbackData()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/DapperTests.cs
@@ -32,6 +32,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de TestSelectQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void TestSelectQuery()
     {
         var users = _connection.Query<UserObjectTest>("SELECT * FROM Users").ToList();
@@ -43,6 +44,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de QueryShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryShouldReturnCorrectData()
     {
         // Arrange
@@ -80,6 +82,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldInsertData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldInsertData()
     {
         // Arrange
@@ -110,6 +113,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldUpdateData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldUpdateData()
     {
         // Arrange
@@ -153,6 +157,7 @@ UPDATE users
     /// PT: Testa o comportamento de ExecuteShouldDeleteData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldDeleteData()
     {
         // Arrange
@@ -179,6 +184,7 @@ UPDATE users
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryMultipleShouldReturnMultipleResultSets()
     {
         var dt = DateTime.UtcNow;

--- a/src/DbSqlLikeMem.SqlServer.Test/DapperUserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/DapperUserTests.cs
@@ -43,6 +43,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de InsertUserShouldAddUserToTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void InsertUserShouldAddUserToTable()
     {
         // Arrange
@@ -91,6 +92,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -147,6 +149,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de UpdateUserShouldModifyUserInTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void UpdateUserShouldModifyUserInTable()
     {
         // Arrange
@@ -217,6 +220,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de DeleteUserShouldRemoveUserFromTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void DeleteUserShouldRemoveUserFromTable()
     {
         // Arrange
@@ -268,6 +272,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange

--- a/src/DbSqlLikeMem.SqlServer.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/DapperUserTests2.cs
@@ -48,6 +48,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -104,6 +105,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange
@@ -167,6 +169,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryWithJoinShouldReturnJoinedData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryWithJoinShouldReturnJoinedData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.SqlServer.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/ExistsTests.cs
@@ -12,6 +12,7 @@ public sealed class ExistsTests(
     /// PT: Testa o comportamento de Exists_ShouldFilterUsersWithOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_ShouldFilterUsersWithOrders()
     {
         using var cnn = new SqlServerConnectionMock();
@@ -55,6 +56,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de NotExists_ShouldFilterUsersWithoutOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void NotExists_ShouldFilterUsersWithoutOrders()
     {
         using var cnn = new SqlServerConnectionMock();
@@ -97,6 +99,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de Exists_WithExtraPredicate_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_WithExtraPredicate_ShouldWork()
     {
         using var cnn = new SqlServerConnectionMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/ExtendedSqlServerMockTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/ExtendedSqlServerMockTests.cs
@@ -12,6 +12,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertAutoIncrementShouldAssignIdentityWhenNotSpecified.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void InsertAutoIncrementShouldAssignIdentityWhenNotSpecified()
     {
         var db = new SqlServerDbMock();
@@ -38,6 +39,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertNullIntoNullableColumnShouldSucceed.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void InsertNullIntoNullableColumnShouldSucceed()
     {
         var db = new SqlServerDbMock();
@@ -57,6 +59,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InsertNullIntoNonNullableColumnShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void InsertNullIntoNonNullableColumnShouldThrow()
     {
         var db = new SqlServerDbMock();
@@ -77,6 +80,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de CompositeIndexFilterShouldReturnCorrectRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void CompositeIndexFilterShouldReturnCorrectRows()
     {
         var db = new SqlServerDbMock();
@@ -102,6 +106,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de LikeFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void LikeFilterShouldReturnMatchingRows()
     {
         var db = new SqlServerDbMock();
@@ -122,6 +127,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de InFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void InFilterShouldReturnMatchingRows()
     {
         var db = new SqlServerDbMock();
@@ -143,6 +149,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de OrderByLimitOffsetDistinctShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void OrderByLimitOffsetDistinctShouldReturnExpectedRows()
     {
         var db = new SqlServerDbMock();
@@ -164,6 +171,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de HavingFilterShouldApplyAfterAggregation.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void HavingFilterShouldApplyAfterAggregation()
     {
         var db = new SqlServerDbMock();
@@ -188,6 +196,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletion.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletion()
     {
         // Parent
@@ -215,6 +224,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK()
     {
         // Parent
@@ -241,6 +251,7 @@ public sealed class ExtendedMySqlMockTests(
     /// PT: Testa o comportamento de MultipleParameterSetsInsertShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqlServerMock")]
     public void MultipleParameterSetsInsertShouldInsertAllRows()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/FluentTest.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/FluentTest.cs
@@ -30,6 +30,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de InsertUpdateDeleteFluentScenario.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void InsertUpdateDeleteFluentScenario()
     {
         using var cnn = BuildConnection();
@@ -73,6 +74,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de TestFluent.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void TestFluent()
     {
         using var cnn = new SqlServerConnectionMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlExprPrinterTest.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlExprPrinterTest.cs
@@ -11,6 +11,7 @@ public sealed class SqlExprPrinterTest(
     /// PT: Testa o comportamento de ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataBySqlServerVersion(nameof(Expressions))]
     public void ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse(string expr, int version)
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlExpressionParserTests.cs
@@ -15,6 +15,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataBySqlServerVersion(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
     {
@@ -89,6 +90,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de ParseWhere_ShouldThrow_ForUnsupportedExpressions.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataBySqlServerVersion(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
     {
@@ -122,6 +124,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Precedence_OR_ShouldBindLooserThan_AND.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
     {
@@ -150,6 +153,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Parentheses_ShouldOverridePrecedence.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void Parentheses_ShouldOverridePrecedence(int version)
     {
@@ -171,6 +175,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Not_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void Not_ShouldWork(int version)
     {
@@ -188,6 +193,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de IsNotNull_ShouldProduce_IsNullExpr_Negated.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
     {
@@ -201,6 +207,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de In_ShouldParse_List.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void In_ShouldParse_List(int version)
     {
@@ -214,6 +221,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Like_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void Like_ShouldParse(int version)
     {
@@ -227,6 +235,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Identifier_WithAliasDotColumn_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
     {
@@ -249,6 +258,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Parameter_Tokens_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void Parameter_Tokens_ShouldParse(int version)
     {
@@ -263,6 +273,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Backtick_Identifier_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void Backtick_Identifier_ShouldParse(int version)
     {
@@ -277,6 +288,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de DoubleQuoted_String_ShouldParse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void DoubleQuoted_String_ShouldParse(int version)
     {
@@ -291,6 +303,7 @@ public sealed class SqlExpressionParserTests(
     /// PT: Testa o comportamento de Printer_ShouldBeStable_ForSimpleExpression.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -621,6 +621,7 @@ select id
     /// PT: Testa o comportamento de Parse_ShouldHandle_MultiStatementStrings_BySplitting.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void Parse_ShouldHandle_MultiStatementStrings_BySplitting(int version)
     {
@@ -644,6 +645,7 @@ select id
     /// PT: Testa o comportamento de Parse_Corpus.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataBySqlServerVersion(nameof(Statements))]
     public void Parse_Corpus(string sql, string why, SqlCaseExpectation expectation, int minVersion, int version)
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
@@ -12,6 +12,7 @@ public sealed class SqlServerDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: SQL Server dialect version under test. PT: Versão do dialeto SQL Server em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void ParseSelect_OffsetWithoutOrderBy_ShouldRespectDialectRule(int version)
     {
@@ -32,6 +33,7 @@ public sealed class SqlServerDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: SQL Server dialect version under test. PT: Versão do dialeto SQL Server em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void ParseSelect_WithRecursive_ShouldBeRejected(int version)
     {
@@ -52,6 +54,7 @@ public sealed class SqlServerDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: SQL Server dialect version under test. PT: Versão do dialeto SQL Server em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void ParseSelect_WithSqlServerTableHints_ShouldParse(int version)
     {
@@ -67,6 +70,7 @@ public sealed class SqlServerDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: SQL Server dialect version under test. PT: Versão do dialeto SQL Server em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void ParseSelect_WithLegacySqlServerTableHint_ShouldParse(int version)
     {
@@ -82,6 +86,7 @@ public sealed class SqlServerDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void RuntimeDialectRules_ShouldRemainStable(int version)
     {
@@ -105,6 +110,7 @@ public sealed class SqlServerDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: SQL Server dialect version under test. PT: Versão do dialeto SQL Server em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqlServerVersion]
     public void ParseUnsupportedSql_ShouldUseStandardNotSupportedMessage(int version)
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Query/QueryExecutorExtrasTests.cs
@@ -28,6 +28,7 @@ public sealed class QueryExecutorExtrasTests(
     /// PT: Testa o comportamento de GroupByAndAggregationsShouldComputeCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void GroupByAndAggregationsShouldComputeCorrectly()
     {
         // Arrange
@@ -65,6 +66,7 @@ GROUP BY grp";
     /// PT: Testa o comportamento de OrderByLimitOffsetShouldPageCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void OrderByLimitOffsetShouldPageCorrectly()
     {
         // Arrange
@@ -114,6 +116,7 @@ public class SqlTranslatorTests
     /// PT: Testa o comportamento de TranslateBasicWhereAndOrderBySqlCorrect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void TranslateBasicWhereAndOrderBySqlCorrect()
     {
         // Arrange

--- a/src/DbSqlLikeMem.SqlServer.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -12,6 +12,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de CreateTableAsSelect_ShouldCreateNewTableWithRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void CreateTableAsSelect_ShouldCreateNewTableWithRows()
     {
         var db = new SqlServerDbMock();
@@ -44,6 +45,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de InsertIntoSelect_ShouldInsertRowsFromQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void InsertIntoSelect_ShouldInsertRowsFromQuery()
     {
         var db = new SqlServerDbMock();
@@ -75,6 +77,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de UpdateJoinDerivedSelect_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void UpdateJoinDerivedSelect_ShouldUpdateRows()
     {
         var db = new SqlServerDbMock();
@@ -114,6 +117,7 @@ WHERE u.tenantid = 10";
     /// PT: Testa o comportamento de DeleteJoinDerivedSelect_ShouldDeleteRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void DeleteJoinDerivedSelect_ShouldDeleteRows()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdditionalBehaviorCoverageTests.cs
@@ -47,6 +47,7 @@ public sealed class SqlServerAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNull_And_IsNotNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdditionalBehaviorCoverage")]
     public void Where_IsNull_And_IsNotNull_ShouldWork()
     {
         var nullIds = _cnn.Query<int>("SELECT id FROM users WHERE email IS NULL ORDER BY id").ToList();
@@ -61,6 +62,7 @@ public sealed class SqlServerAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_EqualNull_ShouldReturnNoRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdditionalBehaviorCoverage")]
     public void Where_EqualNull_ShouldReturnNoRows()
     {
         // MySQL: any comparison with NULL yields UNKNOWN (i.e., filtered out in WHERE)
@@ -76,6 +78,7 @@ public sealed class SqlServerAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldPreserveLeftRows_WhenNoMatch.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdditionalBehaviorCoverage")]
     public void LeftJoin_ShouldPreserveLeftRows_WhenNoMatch()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -102,6 +105,7 @@ ORDER BY u.id
     /// PT: Testa o comportamento de OrderBy_Desc_ThenAsc_ShouldBeDeterministic.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdditionalBehaviorCoverage")]
     public void OrderBy_Desc_ThenAsc_ShouldBeDeterministic()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -119,6 +123,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdditionalBehaviorCoverage")]
     public void Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls()
     {
         var r = _cnn.QuerySingle<dynamic>("SELECT COUNT(*) c1, COUNT(email) c2 FROM users");
@@ -132,6 +137,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Having_ShouldFilterGroups.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdditionalBehaviorCoverage")]
     public void Having_ShouldFilterGroups()
     {
         var userIds = _cnn.Query<int>(@"
@@ -150,6 +156,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Where_In_WithParameterList_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdditionalBehaviorCoverage")]
     public void Where_In_WithParameterList_ShouldWork()
     {
         var ids = _cnn.Query<int>("SELECT id FROM users WHERE id IN @ids ORDER BY id", new { ids = param }).ToList();
@@ -161,6 +168,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Insert_WithColumnsOutOfOrder_ShouldMapCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdditionalBehaviorCoverage")]
     public void Insert_WithColumnsOutOfOrder_ShouldMapCorrectly()
     {
         _cnn.Execute("INSERT INTO users (name, id, email) VALUES (@name, @id, @email)", new { id = 4, name = "Zed", email = "zed@x.com" });
@@ -176,6 +184,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Delete_WithInParameterList_ShouldDeleteMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdditionalBehaviorCoverage")]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
         var deleted = _cnn.Execute("DELETE FROM users WHERE id IN @ids", new { ids = param });
@@ -190,6 +199,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Update_SetExpression_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdditionalBehaviorCoverage")]
     public void Update_SetExpression_ShouldUpdateRows()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdvancedSqlGapTests.cs
@@ -43,6 +43,7 @@ public sealed class SqlServerAdvancedSqlGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -59,6 +60,7 @@ ORDER BY tenantid, id").ToList();
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -75,6 +77,7 @@ ORDER BY u.id").ToList();
     /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
     public void DateAdd_IntervalDay_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -94,6 +97,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
     public void Cast_StringToInt_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT CAST('42' AS INT) AS v").ToList();
@@ -106,6 +110,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
     public void Regexp_Operator_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name REGEXP '^J' ORDER BY id").ToList();
@@ -119,6 +124,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
     public void OrderBy_Field_Function_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users ORDER BY CASE id WHEN 3 THEN 1 WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END").ToList();
@@ -130,6 +136,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {
         // Example expectation in MySQL: behavior depends on column collation.

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerAggregationTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerAggregationTests.cs
@@ -31,6 +31,7 @@ public sealed class SqlServerAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAggregation")]
     public void GroupBy_WithCountAndSum_ShouldWork()
     {
         const string sql = """
@@ -57,6 +58,7 @@ public sealed class SqlServerAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAggregation")]
     public void Having_ShouldFilterAggregates()
     {
         const string sql = """
@@ -76,6 +78,7 @@ public sealed class SqlServerAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerAggregation")]
     public void Distinct_Order_Limit_Offset_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerDataParameterCollectionMockTest.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerDataParameterCollectionMockTest.cs
@@ -11,6 +11,7 @@ public sealed class SqlServerDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerDataParameterCollectionMockTest")]
     public void ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames()
     {
         Assert.Equal("id", SqlServerDataParameterCollectionMock.NormalizeParameterName("@id"));
@@ -25,6 +26,7 @@ public sealed class SqlServerDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Add_DuplicateName_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerDataParameterCollectionMockTest")]
     public void ParameterCollection_Add_DuplicateName_ShouldThrow()
     {
         var pars = new SqlServerDataParameterCollectionMock();
@@ -38,6 +40,7 @@ public sealed class SqlServerDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_RemoveAt_ShouldReindexDictionary.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerDataParameterCollectionMockTest")]
     public void ParameterCollection_RemoveAt_ShouldReindexDictionary()
     {
         var pars = new SqlServerDataParameterCollectionMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerJoinTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerJoinTests.cs
@@ -39,6 +39,7 @@ public sealed class SqlServerJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldKeepAllLeftRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerJoin")]
     public void LeftJoin_ShouldKeepAllLeftRows()
     {
         const string sql = """
@@ -59,6 +60,7 @@ public sealed class SqlServerJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de RightJoin_ShouldKeepAllRightRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerJoin")]
     public void RightJoin_ShouldKeepAllRightRows()
     {
         const string sql = """
@@ -93,6 +95,7 @@ public sealed class SqlServerJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ON_WithMultipleConditions_AND_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerJoin")]
     public void Join_ON_WithMultipleConditions_AND_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerLinqProviderTest.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerLinqProviderTest.cs
@@ -23,6 +23,7 @@ public sealed class SqlServerLinqProviderTest
     /// PT: Testa o comportamento de LinqProvider_ShouldQueryWhereAndReturnRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerLinqProviderTest")]
     public void LinqProvider_ShouldQueryWhereAndReturnRows()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerMockTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerMockTests.cs
@@ -35,6 +35,7 @@ public sealed class SqlServerMockTests
     /// PT: Testa o comportamento de TestInsert.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerMock")]
     public void TestInsert()
     {
         using var command = new SqlServerCommandMock(_connection)
@@ -51,6 +52,7 @@ public sealed class SqlServerMockTests
     /// PT: Testa o comportamento de TestUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerMock")]
     public void TestUpdate()
     {
         using var command = new SqlServerCommandMock(_connection)
@@ -70,6 +72,7 @@ public sealed class SqlServerMockTests
     /// PT: Testa o comportamento de TestDelete.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerMock")]
     public void TestDelete()
     {
         using var command = new SqlServerCommandMock(_connection)
@@ -89,6 +92,7 @@ public sealed class SqlServerMockTests
     /// PT: Testa o comportamento de TestTransactionCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerMock")]
     public void TestTransactionCommit()
     {
         using (var transaction = _connection.BeginTransaction())
@@ -124,6 +128,7 @@ public sealed class SqlServerMockTests
     /// PT: Testa o comportamento de TestTransactionCommitInsertUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerMock")]
     public void TestTransactionCommitInsertUpdate()
     {
         using var cmd = _connection.CreateCommand();
@@ -146,6 +151,7 @@ public sealed class SqlServerMockTests
     /// PT: Testa o comportamento de TestTransactionRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerMock")]
     public void TestTransactionRollback()
     {
         using (var transaction = _connection.BeginTransaction())
@@ -182,6 +188,7 @@ public sealed class SqlServerMockTests
     /// PT: Garante que SELECT com hints de tabela do SQL Server execute corretamente.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerMock")]
     public void TestSelect_WithSqlServerTableHints_ShouldExecute()
     {
         using var command = new SqlServerCommandMock(_connection)

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerSelectAndWhereMoreCoverageTests.cs
@@ -41,6 +41,7 @@ public sealed class SqlServerSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Between_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSelectAndWhereMoreCoverage")]
     public void Where_Between_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id BETWEEN 2 AND 3 ORDER BY id").ToList();
@@ -52,6 +53,7 @@ public sealed class SqlServerSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NotIn_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSelectAndWhereMoreCoverage")]
     public void Where_NotIn_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id NOT IN (1,3)").ToList();
@@ -64,6 +66,7 @@ public sealed class SqlServerSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ExistsSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSelectAndWhereMoreCoverage")]
     public void Where_ExistsSubquery_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -85,6 +88,7 @@ ORDER BY u.id").ToList();
     /// PT: Testa o comportamento de Select_CaseWhen_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSelectAndWhereMoreCoverage")]
     public void Select_CaseWhen_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -104,6 +108,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Select_IfNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSelectAndWhereMoreCoverage")]
     public void Select_IfNull_ShouldWork()
     {
         var row = _cnn.QuerySingle<dynamic>("SELECT ISNULL(email,'(none)') AS em FROM users WHERE id = 2");

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerSqlCompatibilityGapTests.cs
@@ -44,6 +44,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Precedence_AND_ShouldBindStrongerThan_OR.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Where_Precedence_AND_ShouldBindStrongerThan_OR()
     {
         // MySQL precedence: AND binds stronger than OR.
@@ -57,6 +58,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_OR_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Where_OR_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id = 1 OR id = 3").ToList();
@@ -68,6 +70,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ParenthesesGrouping_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Where_ParenthesesGrouping_ShouldWork()
     {
         // (id=1 OR id=2) AND email IS NULL => only user 2
@@ -81,6 +84,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_Arithmetic_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Select_Expressions_Arithmetic_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, id + 1 AS nextId FROM users ORDER BY id").ToList();
@@ -92,6 +96,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_CASE_WHEN_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Select_Expressions_CASE_WHEN_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CASE WHEN email IS NULL THEN 0 ELSE 1 END AS hasEmail FROM users ORDER BY id").ToList();
@@ -103,6 +108,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IF_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Select_Expressions_IF_ShouldWork()
     {
         // MySQL: IF(cond, then, else)
@@ -115,6 +121,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IIF_ShouldWork_AsAliasForIF.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Select_Expressions_IIF_ShouldWork_AsAliasForIF()
     {
         // Not native MySQL, but requested as convenience.
@@ -127,6 +134,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_COALESCE_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Functions_COALESCE_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, COALESCE(NULL, email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -138,6 +146,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_IFNULL_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Functions_IFNULL_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, ISNULL(email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -149,6 +158,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_CONCAT_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Functions_CONCAT_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CONCAT(name, '#', id) AS tag FROM users ORDER BY id").ToList();
@@ -160,6 +170,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_ShouldBeConsistent.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Distinct_ShouldBeConsistent()
     {
         // duplicate names
@@ -173,6 +184,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ComplexOn_WithOr_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Join_ComplexOn_WithOr_ShouldWork()
     {
         // include orders joined when (o.userId = u.id OR o.userId = 0)
@@ -193,6 +205,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_Having_ShouldSupportAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void GroupBy_Having_ShouldSupportAggregates()
     {
         var rows = _cnn.Query<dynamic>(
@@ -210,6 +223,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de OrderBy_ShouldSupportAlias_And_Ordinal.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void OrderBy_ShouldSupportAlias_And_Ordinal()
     {
         var rows1 = _cnn.Query<dynamic>("SELECT id, id + 1 AS x FROM users ORDER BY x DESC").ToList();
@@ -225,6 +239,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Union_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -240,6 +255,7 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Union_Inside_SubSelect_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -258,6 +274,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Cte_With_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Cte_With_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -271,6 +288,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
     public void Typing_ImplicitCasts_And_Collation_ShouldMatchMySqlDefault()
     {
         // Many MySQL installations use case-insensitive collations by default.

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerSubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerSubqueryFromAndJoinsTests.cs
@@ -12,6 +12,7 @@ public sealed class SqlServerSubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSubqueryFromAndJoins")]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
         using var cnn = new SqlServerConnectionMock();
@@ -44,6 +45,7 @@ public sealed class SqlServerSubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSubqueryFromAndJoins")]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
         using var cnn = new SqlServerConnectionMock();
@@ -88,6 +90,7 @@ ORDER BY u.Id, o.Amount";
     /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerSubqueryFromAndJoins")]
     public void NestedSubquery_ShouldWork()
     {
         using var cnn = new SqlServerConnectionMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerTransactionReliabilityTests.cs
@@ -11,6 +11,7 @@ public sealed class SqlServerTransactionReliabilityTests
     /// PT: Garante que rollback para savepoint restaure o estado intermediário.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerTransactionReliability")]
     public void SavepointRollbackShouldRestoreIntermediateState()
     {
         var db = new SqlServerDbMock();
@@ -38,6 +39,7 @@ public sealed class SqlServerTransactionReliabilityTests
     /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerTransactionReliability")]
     public void IsolationLevelShouldBeExposedDeterministically()
     {
         var db = new SqlServerDbMock();
@@ -55,6 +57,7 @@ public sealed class SqlServerTransactionReliabilityTests
     /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerTransactionReliability")]
     public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
     {
         var db = new SqlServerDbMock();
@@ -72,6 +75,7 @@ public sealed class SqlServerTransactionReliabilityTests
     /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerTransactionReliability")]
     public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
     {
         var db = new SqlServerDbMock { ThreadSafe = true };

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerTransactionTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerTransactionTests.cs
@@ -27,6 +27,7 @@ public sealed class SqlServerTransactionTests(
     /// PT: Testa o comportamento de TransactionCommitShouldPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerTransaction")]
     public void TransactionCommitShouldPersistData()
     {
         // Arrange
@@ -59,6 +60,7 @@ public sealed class SqlServerTransactionTests(
     /// PT: Testa o comportamento de TransactionRollbackShouldNotPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerTransaction")]
     public void TransactionRollbackShouldNotPersistData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs
@@ -37,6 +37,7 @@ public sealed class SqlServerUnionLimitAndJsonCompatibilityTests : XUnitTestBase
     /// PT: Testa o comportamento de UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerUnionLimitAndJsonCompatibility")]
     public void UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates()
     {
         // UNION ALL keeps duplicates
@@ -61,6 +62,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de OffsetFetch_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "SqlServerUnionLimitAndJsonCompatibility")]
     [MemberDataSqlServerVersion]
     public void OffsetFetch_ShouldRespectVersion(int version)
     {
@@ -84,6 +86,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonValue_SimpleObjectPath_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "SqlServerUnionLimitAndJsonCompatibility")]
     [MemberDataSqlServerVersion]
     public void JsonValue_SimpleObjectPath_ShouldRespectVersion(int version)
     {
@@ -111,6 +114,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de OrderBy_NullsFirst_ShouldThrow_WhenDialectDoesNotSupportModifier.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerUnionLimitAndJsonCompatibility")]
     public void OrderBy_NullsFirst_ShouldThrow_WhenDialectDoesNotSupportModifier()
     {
         Assert.Throws<NotSupportedException>(() =>
@@ -123,6 +127,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonFunction_ShouldThrow_WhenNotSupportedByDialect.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerUnionLimitAndJsonCompatibility")]
     public void JsonFunction_ShouldThrow_WhenNotSupportedByDialect()
     {
         Assert.Throws<NotSupportedException>(() =>
@@ -134,6 +139,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerUnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -150,6 +156,7 @@ SELECT 1 AS v
     /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerUnionLimitAndJsonCompatibility")]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
         Assert.Throws<InvalidOperationException>(() =>
@@ -167,6 +174,7 @@ SELECT 'x' AS v
     /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerUnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {
         var rows = _cnn.Query<dynamic>(@"

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerWhereParserAndExecutorTests.cs
@@ -36,6 +36,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEquality_ShouldUseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_IndexedEquality_ShouldUseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -56,6 +57,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -83,6 +85,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex()
     {
         var table = _cnn.GetTable("users");
@@ -107,6 +110,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow()
     {
         var table = _cnn.GetTable("users");
@@ -128,6 +132,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -146,6 +151,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IN_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_IN_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id IN (1,3)").ToList();
@@ -159,6 +165,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNotNull_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_IsNotNull_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE email IS NOT NULL").ToList();
@@ -170,6 +177,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Operators_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_Operators_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id >= 2 AND id <= 3").ToList();
@@ -184,6 +192,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Like_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_Like_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name LIKE '%oh%'").ToList();
@@ -196,6 +205,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_FindInSet_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_FindInSet_ShouldWork()
     {
         // FIND_IN_SET('b', tags) -> John(a,b) e Jane(b,c)
@@ -208,6 +218,7 @@ public sealed class SqlServerWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_AND_ShouldBeCaseInsensitive_InRealLife.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlServerWhereParserAndExecutor")]
     public void Where_AND_ShouldBeCaseInsensitive_InRealLife()
     {
         // esse teste é pra pegar o bug clássico: split só em " AND " / " and "

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlValueHelperTests .cs
@@ -14,6 +14,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_ByName.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldReadDapperParameter_ByName()
     {
         using var cnn = new SqlServerConnectionMock();
@@ -34,6 +35,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldThrow_WhenParameterMissing()
     {
         Assert.Throws<SqlServerMockException>(() =>
@@ -45,6 +47,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldParseInList_ToListOfResolvedValues.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldParseInList_ToListOfResolvedValues()
     {
         var v = SqlServerValueHelper.Resolve("(1, 2, 3)", DbType.Int32, isNullable: false, pars: null, colDict: null);
@@ -58,6 +61,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_NullOnNonNullable_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_NullOnNonNullable_ShouldThrow()
     {
         Assert.Throws<SqlServerMockException>(() =>
@@ -69,6 +73,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Json_ShouldReturnJsonDocument_WhenValid.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Json_ShouldReturnJsonDocument_WhenValid()
     {
         var v = SqlServerValueHelper.Resolve("{\"a\":1}", DbType.Object, isNullable: false, pars: null, colDict: null);
@@ -82,6 +87,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Like_ShouldMatch_MySqlStyle.
     /// </summary>
     [Theory]
+    [Trait("Category", "SqlValueHelperTests ")]
     [InlineData("John", "%oh%", true)]
     [InlineData("John", "J_hn", true)]
     [InlineData("John", "J__n", true)]
@@ -97,6 +103,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Enum_ShouldValidateAgainstColumnDef.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Enum_ShouldValidateAgainstColumnDef()
     {
         var tb = new SqlServerDbMock().AddTable("tb");
@@ -119,6 +126,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Set_ShouldReturnHashSet_AndValidate.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Set_ShouldReturnHashSet_AndValidate()
     {
         var tb = new SqlServerDbMock().AddTable("tb");
@@ -150,6 +158,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateStringSize.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateStringSize()
     {
         var tb = new SqlServerDbMock().AddTable("tb");
@@ -175,6 +184,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateDecimalPlaces.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateDecimalPlaces()
     {
         var tb = new SqlServerDbMock().AddTable("tb");

--- a/src/DbSqlLikeMem.SqlServer.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/StoredProcedureExecutionTests.cs
@@ -24,6 +24,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs()
     {
         // Arrange
@@ -64,6 +65,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput()
     {
         // Arrange
@@ -102,6 +104,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull()
     {
         // Arrange
@@ -140,6 +143,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue()
     {
         // Arrange
@@ -187,6 +191,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset()
     {
         // Arrange
@@ -221,6 +226,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero()
     {
         using var c = new SqlServerConnectionMock();
@@ -252,6 +258,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput()
     {
         using var c = new SqlServerConnectionMock();
@@ -281,6 +288,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldWork()
     {
         // Arrange
@@ -314,6 +322,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam()
     {
         // Arrange

--- a/src/DbSqlLikeMem.SqlServer.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/StoredProcedureSignatureTests.cs
@@ -12,6 +12,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldValidateRequiredInAndOutParams.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldValidateRequiredInAndOutParams()
     {
         using var c = new SqlServerConnectionMock();
@@ -43,6 +44,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldThrowWhenMissingRequiredParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldThrowWhenMissingRequiredParam()
     {
         using var c = new SqlServerConnectionMock();
@@ -66,6 +68,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de CallStatement_ShouldValidateAgainstRegisteredProcedure.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void CallStatement_ShouldValidateAgainstRegisteredProcedure()
     {
         using var c = new SqlServerConnectionMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class SqlServerCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_1_linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_1_linha()
     {
         var db = new SqlServerDbMock();
@@ -35,6 +36,7 @@ public sealed class SqlServerCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_varias_linhas.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_varias_linhas()
     {
         var db = new SqlServerDbMock();
@@ -59,6 +61,7 @@ public sealed class SqlServerCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0()
     {
         var db = new SqlServerDbMock();
@@ -80,6 +83,7 @@ public sealed class SqlServerCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_tabela_inexistente_dispara.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_tabela_inexistente_dispara()
     {
         var db = new SqlServerDbMock();
@@ -95,6 +99,7 @@ public sealed class SqlServerCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sem_FROM_remove_1_linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_sem_FROM_remove_1_linha()
     {
         var db = new SqlServerDbMock();
@@ -118,6 +123,7 @@ public sealed class SqlServerCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia()
     {
         var db = new SqlServerDbMock();
@@ -144,6 +150,7 @@ public sealed class SqlServerCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false(bool threadSafe)
@@ -166,6 +173,7 @@ public sealed class SqlServerCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_case_insensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_case_insensitive()
     {
         var db = new SqlServerDbMock();
@@ -186,6 +194,7 @@ public sealed class SqlServerCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_com_parametro_se_suportado.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_com_parametro_se_suportado()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertOnDuplicateTests.cs
@@ -10,6 +10,7 @@ public sealed class SqlServerMergeUpsertTests(ITestOutputHelper helper) : XUnitT
     /// PT: Testa o comportamento de Merge_ShouldInsert_WhenNotMatched.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Merge_ShouldInsert_WhenNotMatched()
     {
         var db = new SqlServerDbMock();
@@ -41,6 +42,7 @@ WHEN NOT MATCHED THEN
     /// PT: Testa o comportamento de Merge_ShouldUpdate_WhenMatched.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Merge_ShouldUpdate_WhenMatched()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyCoverageTests.cs
@@ -12,6 +12,7 @@ public sealed class SqlServerInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_MultiRowValues_ShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_MultiRowValues_ShouldInsertAllRows()
     {
         var db = new SqlServerDbMock();
@@ -40,6 +41,7 @@ public sealed class SqlServerInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_WithIdentityColumnOmitted_ShouldAutoIncrement.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_WithIdentityColumnOmitted_ShouldAutoIncrement()
     {
         var db = new SqlServerDbMock();
@@ -70,6 +72,7 @@ public sealed class SqlServerInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de InsertSelect_ShouldInsertRowsFromSelect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertSelect_ShouldInsertRowsFromSelect()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyExtrasTests.cs
@@ -11,6 +11,7 @@ public sealed class SqlServerInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de MultiRowInsertShouldAddAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void MultiRowInsertShouldAddAllRows()
     {
         // Arrange
@@ -38,6 +39,7 @@ public sealed class SqlServerInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertWithDefaultValueAndIdentityShouldApplyDefaults.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertWithDefaultValueAndIdentityShouldApplyDefaults()
     {
         // Arrange
@@ -69,6 +71,7 @@ public sealed class SqlServerInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertDuplicatePrimaryKeyShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertDuplicatePrimaryKeyShouldThrow()
     {
         // Arrange
@@ -100,6 +103,7 @@ public class SqlServerDeleteStrategyForeignKeyTests
     /// PT: Testa o comportamento de DeleteReferencedRowShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void DeleteReferencedRowShouldThrow()
     {
         // Arrange parent
@@ -139,6 +143,7 @@ public class SqlServerUpdateStrategyExtrasTests
     /// PT: Testa o comportamento de UpdateMultipleConditionsShouldOnlyAffectMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateMultipleConditionsShouldOnlyAffectMatchingRows()
     {
         // Arrange

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class SqlServerInsertStrategyTests(
     /// PT: Testa o comportamento de InsertIntoTableShouldAddNewRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertIntoTableShouldAddNewRow()
     {
         // Arrange

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTransactionTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTransactionTests.cs
@@ -11,6 +11,7 @@ public sealed class SqlServerTransactionTests(
     /// PT: Testa o comportamento de TransactionShouldCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldCommit()
     {
         // Arrange
@@ -45,6 +46,7 @@ public sealed class SqlServerTransactionTests(
     /// PT: Testa o comportamento de TransactionShouldRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldRollback()
     {
         // Arrange

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTriggerStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class SqlServerTriggerStrategyTests
     /// PT: Garante que os gatilhos de insert, update e delete sejam executados para uma tabela não temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void NonTemporaryTable_ShouldExecuteInsertUpdateDeleteTriggers()
     {
         var db = new SqlServerDbMock();
@@ -54,6 +55,7 @@ public sealed class SqlServerTriggerStrategyTests
     /// PT: Garante que os gatilhos não sejam executados para uma tabela temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TemporaryTable_ShouldNotExecuteTriggers()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyCoverageTests.cs
@@ -12,6 +12,7 @@ public sealed class SqlServerUpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNullableColumnToNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNullableColumnToNull_ShouldWork()
     {
         var db = new SqlServerDbMock();
@@ -37,6 +38,7 @@ public sealed class SqlServerUpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNotNullableColumnToNull_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNotNullableColumnToNull_ShouldThrow()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de UpdateTableShouldModifyExistingRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateTableShouldModifyExistingRow()
     {
         // Arrange
@@ -40,6 +41,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldReturnZero_WhenNoRowsMatchWhere.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldReturnZero_WhenNoRowsMatchWhere()
     {
         var db = new SqlServerDbMock();
@@ -65,6 +67,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple()
     {
         var db = new SqlServerDbMock();
@@ -93,6 +96,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldHandleWhereWithAnd_CaseInsensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldHandleWhereWithAnd_CaseInsensitive()
     {
         var db = new SqlServerDbMock();
@@ -121,6 +125,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleSetPairs.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleSetPairs()
     {
         var db = new SqlServerDbMock();
@@ -146,6 +151,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords()
     {
         var db = new SqlServerDbMock();
@@ -170,6 +176,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldWork_WithThreadSafeTrueOrFalse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void Update_ShouldWork_WithThreadSafeTrueOrFalse(bool threadSafe)
@@ -196,6 +203,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenTableDoesNotExist.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenTableDoesNotExist()
     {
         var db = new SqlServerDbMock();
@@ -214,6 +222,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken()
     {
         var db = new SqlServerDbMock();
@@ -235,6 +244,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull()
     {
         var db = new SqlServerDbMock();
@@ -260,6 +270,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldSupportParameter_IfSqlValueHelperSupports.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldSupportParameter_IfSqlValueHelperSupports()
     {
         var db = new SqlServerDbMock();
@@ -294,6 +305,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides()
     {
         var db = new SqlServerDbMock();
@@ -321,6 +333,7 @@ public sealed class SqlServerUpdateStrategyTests(
     /// PT: Recalcula colunas geradas persistidas durante update e preserva a consistência de índices únicos.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldRecomputePersistedGeneratedColumn_AndAllowUniqueIndex()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/SubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SubqueryFromAndJoinsTests.cs
@@ -12,6 +12,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
         using var cnn = new SqlServerConnectionMock();
@@ -44,6 +45,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
         using var cnn = new SqlServerConnectionMock();
@@ -88,6 +90,7 @@ ORDER BY u.Id, o.Amount";
     /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void NestedSubquery_ShouldWork()
     {
         using var cnn = new SqlServerConnectionMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/TemporaryTable/SqlServerTemporaryTableEngineTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/TemporaryTable/SqlServerTemporaryTableEngineTests.cs
@@ -12,6 +12,7 @@ public sealed class SqlServerTemporaryTableEngineTests
     /// PT: Testa o comportamento de CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "TemporaryTable")]
     public void CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows()
     {
         var db = new SqlServerDbMock();
@@ -48,6 +49,7 @@ SELECT id FROM tmp_users ORDER BY id;";
     /// Auto-generated summary.
     /// </summary>
     [Fact]
+    [Trait("Category", "TemporaryTable")]
     public void CreateGlobalTemporaryTable_AsSelect_ShouldBeVisibleAcrossConnections()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer.Test/TemporaryTable/SqlServerTemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/TemporaryTable/SqlServerTemporaryTableParserTests.cs
@@ -10,6 +10,7 @@ public sealed class SqlServerTemporaryTableParserTests
     /// PT: Testa o comportamento de ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataSqlServerVersion]
     public void ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect(int version)
     {
@@ -64,6 +65,7 @@ WHERE tenantid = 10",
     /// PT: Testa o comportamento de Parse_ShouldAccept_CreateTemporaryTable_Variants.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataBySqlServerVersion(nameof(CreateTempTableStatements))]
     public void Parse_ShouldAccept_CreateTemporaryTable_Variants(string sql, int version)
     {
@@ -78,6 +80,7 @@ WHERE tenantid = 10",
     /// Auto-generated summary.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataSqlServerVersion]
     public void Parse_ShouldRecognize_HashTempTableScopes(int version)
     {

--- a/src/DbSqlLikeMem.SqlServer.Test/Views/SqlServerCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Views/SqlServerCreateViewEngineTests.cs
@@ -39,6 +39,7 @@ public sealed class SqlServerCreateViewEngineTests : XUnitTestBase
     /// PT: Testa o comportamento de CreateView_ThenSelectFromView_ShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ThenSelectFromView_ShouldReturnExpectedRows()
     {
         _cnn.ExecNonQuery(@"
@@ -56,6 +57,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_IsNotMaterialized_ShouldReflectBaseTableChanges.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_IsNotMaterialized_ShouldReflectBaseTableChanges()
     {
         _cnn.ExecNonQuery("CREATE VIEW v_all AS SELECT id FROM users ORDER BY id;");
@@ -72,6 +74,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de CreateOrReplaceView_ShouldChangeDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateOrReplaceView_ShouldChangeDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW v AS SELECT id FROM users WHERE tenantid = 10;");
@@ -88,6 +91,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_NameShouldShadowTable_WhenSameName.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_NameShouldShadowTable_WhenSameName()
     {
         var db = new SqlServerDbMock();
@@ -109,6 +113,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_CanReferenceAnotherView.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_CanReferenceAnotherView()
     {
         _cnn.ExecNonQuery("CREATE VIEW v1 AS SELECT id FROM users WHERE tenantid = 10;");
@@ -123,6 +128,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_WithJoinAndAggregation_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_WithJoinAndAggregation_ShouldWork()
     {
         _cnn.ExecNonQuery(@"
@@ -147,6 +153,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de CreateView_ExistingNameWithoutOrReplace_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ExistingNameWithoutOrReplace_ShouldThrow()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdup AS SELECT 1 AS x ;");
@@ -158,6 +165,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de DropView_ShouldRemoveDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void DropView_ShouldRemoveDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdrop AS SELECT id FROM users;");

--- a/src/DbSqlLikeMem.SqlServer.Test/Views/SqlServerCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Views/SqlServerCreateViewParserTests.cs
@@ -12,6 +12,7 @@ public sealed class SqlServerCreateViewParserTests(
     /// PT: Testa o comportamento de ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataSqlServerVersion]
     public void ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements(int version)
     {
@@ -39,6 +40,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateOrReplaceView_ShouldSetFlag.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataSqlServerVersion]
     public void Parse_CreateOrReplaceView_ShouldSetFlag(int version)
     {
@@ -54,6 +56,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataSqlServerVersion]
     public void Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames(int version)
     {
@@ -68,6 +71,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithBackticks_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataSqlServerVersion]
     public void Parse_CreateView_WithBackticks_ShouldWork(int version)
     {
@@ -82,6 +86,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataSqlServerVersion]
     public void Parse_CreateView_IfNotExists_ShouldBeRejected_ByMySqlSpec(int version)
     {

--- a/src/DbSqlLikeMem.Sqlite.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/CsvLoaderAndIndexTests.cs
@@ -12,6 +12,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de CsvLoader_ShouldLoadRows_ByColumnName.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void CsvLoader_ShouldLoadRows_ByColumnName()
     {
         var db = new SqliteDbMock();
@@ -38,6 +39,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de GetColumn_ShouldThrow_UnknownColumn.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void GetColumn_ShouldThrow_UnknownColumn()
     {
         var db = new SqliteDbMock();
@@ -53,6 +55,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de Index_Lookup_ShouldReturnRowPositions.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void Index_Lookup_ShouldReturnRowPositions()
     {
         var db = new SqliteDbMock();
@@ -75,6 +78,7 @@ public sealed class CsvLoaderAndIndexTests(
     /// PT: Testa o comportamento de BackupRestore_ShouldRollbackData.
     /// </summary>
     [Fact]
+    [Trait("Category", "CsvLoaderAndIndex")]
     public void BackupRestore_ShouldRollbackData()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/DapperTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/DapperTests.cs
@@ -32,6 +32,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de TestSelectQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void TestSelectQuery()
     {
         var users = _connection.Query<UserObjectTest>("SELECT * FROM Users").ToList();
@@ -43,6 +44,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de QueryShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryShouldReturnCorrectData()
     {
         // Arrange
@@ -80,6 +82,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldInsertData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldInsertData()
     {
         // Arrange
@@ -110,6 +113,7 @@ public sealed class DapperTests : XUnitTestBase
     /// PT: Testa o comportamento de ExecuteShouldUpdateData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldUpdateData()
     {
         // Arrange
@@ -153,6 +157,7 @@ UPDATE users
     /// PT: Testa o comportamento de ExecuteShouldDeleteData.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void ExecuteShouldDeleteData()
     {
         // Arrange
@@ -179,6 +184,7 @@ UPDATE users
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "Dapper")]
     public void QueryMultipleShouldReturnMultipleResultSets()
     {
         var dt = DateTime.UtcNow;

--- a/src/DbSqlLikeMem.Sqlite.Test/DapperUserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/DapperUserTests.cs
@@ -43,6 +43,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de InsertUserShouldAddUserToTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void InsertUserShouldAddUserToTable()
     {
         // Arrange
@@ -91,6 +92,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -147,6 +149,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de UpdateUserShouldModifyUserInTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void UpdateUserShouldModifyUserInTable()
     {
         // Arrange
@@ -217,6 +220,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de DeleteUserShouldRemoveUserFromTable.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void DeleteUserShouldRemoveUserFromTable()
     {
         // Arrange
@@ -268,6 +272,7 @@ public sealed class DapperUserTests(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUser")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Sqlite.Test/DapperUserTests2.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/DapperUserTests2.cs
@@ -48,6 +48,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryUserShouldReturnCorrectData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryUserShouldReturnCorrectData()
     {
         // Arrange
@@ -104,6 +105,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryMultipleShouldReturnMultipleUserResultSets.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryMultipleShouldReturnMultipleUserResultSets()
     {
         // Arrange
@@ -167,6 +169,7 @@ public sealed class DapperUserTests2(
     /// PT: Testa o comportamento de QueryWithJoinShouldReturnJoinedData.
     /// </summary>
     [Fact]
+    [Trait("Category", "DapperUserTests2")]
     public void QueryWithJoinShouldReturnJoinedData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Sqlite.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/ExistsTests.cs
@@ -12,6 +12,7 @@ public sealed class ExistsTests(
     /// PT: Testa o comportamento de Exists_ShouldFilterUsersWithOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_ShouldFilterUsersWithOrders()
     {
         using var cnn = new SqliteConnectionMock([]);
@@ -55,6 +56,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de NotExists_ShouldFilterUsersWithoutOrders.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void NotExists_ShouldFilterUsersWithoutOrders()
     {
         using var cnn = new SqliteConnectionMock();
@@ -97,6 +99,7 @@ ORDER BY u.Id";
     /// PT: Testa o comportamento de Exists_WithExtraPredicate_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Exists")]
     public void Exists_WithExtraPredicate_ShouldWork()
     {
         using var cnn = new SqliteConnectionMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/ExtendedSqliteMockTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/ExtendedSqliteMockTests.cs
@@ -12,6 +12,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de InsertAutoIncrementShouldAssignIdentityWhenNotSpecified.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void InsertAutoIncrementShouldAssignIdentityWhenNotSpecified()
     {
         var db = new SqliteDbMock();
@@ -38,6 +39,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de InsertNullIntoNullableColumnShouldSucceed.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void InsertNullIntoNullableColumnShouldSucceed()
     {
         var db = new SqliteDbMock();
@@ -57,6 +59,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de InsertNullIntoNonNullableColumnShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void InsertNullIntoNonNullableColumnShouldThrow()
     {
         var db = new SqliteDbMock();
@@ -77,6 +80,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de CompositeIndexFilterShouldReturnCorrectRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void CompositeIndexFilterShouldReturnCorrectRows()
     {
         var db = new SqliteDbMock();
@@ -102,6 +106,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de LikeFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void LikeFilterShouldReturnMatchingRows()
     {
         var db = new SqliteDbMock();
@@ -122,6 +127,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de InFilterShouldReturnMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void InFilterShouldReturnMatchingRows()
     {
         var db = new SqliteDbMock();
@@ -143,6 +149,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de OrderByLimitOffsetDistinctShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void OrderByLimitOffsetDistinctShouldReturnExpectedRows()
     {
         var db = new SqliteDbMock();
@@ -164,6 +171,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de HavingFilterShouldApplyAfterAggregation.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void HavingFilterShouldApplyAfterAggregation()
     {
         var db = new SqliteDbMock();
@@ -188,6 +196,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletion.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletion()
     {
         // Parent
@@ -215,6 +224,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void ForeignKeyDeleteShouldThrowOnReferencedParentDeletionWithouPK()
     {
         // Parent
@@ -241,6 +251,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de MultipleParameterSetsInsertShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void MultipleParameterSetsInsertShouldInsertAllRows()
     {
         var db = new SqliteDbMock();
@@ -268,6 +279,7 @@ public sealed class ExtendedSqliteMockTests(
     /// PT: Testa o comportamento de UniqueCompositeIndexShouldNotCollideWhenValuesContainSeparator.
     /// </summary>
     [Fact]
+    [Trait("Category", "ExtendedSqliteMock")]
     public void UniqueCompositeIndexShouldNotCollideWhenValuesContainSeparator()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/FluentTest.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/FluentTest.cs
@@ -27,6 +27,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de InsertUpdateDeleteFluentScenario.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void InsertUpdateDeleteFluentScenario()
     {
         using var cnn = BuildConnection();
@@ -70,6 +71,7 @@ public sealed class FluentTest(
     /// PT: Testa o comportamento de TestFluent.
     /// </summary>
     [Fact]
+    [Trait("Category", "FluentTest")]
     public void TestFluent()
     {
         using var cnn = new SqliteConnectionMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlExprPrinterTest.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlExprPrinterTest.cs
@@ -12,6 +12,7 @@ public sealed class SqlExprPrinterTest(
     /// PT: Testa o comportamento de ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataBySqliteVersion(nameof(Expressions))]
     public void ExprPrinter_ShouldAllow_Roundtrip_Parse_Print_Parse(string expr, int version)
     {

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlExpressionParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlExpressionParserTests.cs
@@ -19,6 +19,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataBySqliteVersion(nameof(WhereExpressions_Supported))]
     public void ParseWhere_ShouldNotThrow_ForSupportedRealWorldExpressions(string whereExpr, int version)
     {
@@ -98,6 +99,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataBySqliteVersion(nameof(WhereExpressions_Unsupported))]
     public void ParseWhere_ShouldThrow_ForUnsupportedExpressions(string whereExpr, int version)
     {
@@ -135,6 +137,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void Precedence_OR_ShouldBindLooserThan_AND(int version)
     {
@@ -167,6 +170,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void Parentheses_ShouldOverridePrecedence(int version)
     {
@@ -192,6 +196,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void Not_ShouldWork(int version)
     {
@@ -213,6 +218,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void IsNotNull_ShouldProduce_IsNullExpr_Negated(int version)
     {
@@ -230,6 +236,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void In_ShouldParse_List(int version)
     {
@@ -247,6 +254,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void Like_ShouldParse(int version)
     {
@@ -264,6 +272,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void Identifier_WithAliasDotColumn_ShouldParse(int version)
     {
@@ -290,6 +299,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void Parameter_Tokens_ShouldParse(int version)
     {
@@ -308,6 +318,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void Backtick_Identifier_ShouldParse(int version)
     {
@@ -326,6 +337,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void DoubleQuoted_String_ShouldParse(int version)
     {
@@ -340,6 +352,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void NullSafe_Operator_ShouldParse(int version)
     {
@@ -357,6 +370,7 @@ public sealed class SqlExpressionParserTests(
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void Printer_ShouldBeStable_ForSimpleExpression(int version)
     {

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -638,6 +638,7 @@ select id
     /// PT: Testa o comportamento de Parse_ShouldHandle_MultiStatementStrings_BySplitting.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void Parse_ShouldHandle_MultiStatementStrings_BySplitting(int version)
     {
@@ -661,6 +662,7 @@ select id
     /// PT: Testa o comportamento de Parse_Corpus.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataBySqliteVersion(nameof(Statements))]
     public void Parse_Corpus(string sql, string why, SqlCaseExpectation expectation, int minVersion, int version)
     {

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
@@ -11,6 +11,7 @@ public sealed class SqliteDialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void ParseInsert_OnConflict_DoUpdate_ShouldParse(int version)
     {
@@ -28,6 +29,7 @@ public sealed class SqliteDialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void ParseWithCte_AsNotMaterialized_ShouldParse(int version)
     {
@@ -42,6 +44,7 @@ public sealed class SqliteDialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void ParseSelect_WithMySqlIndexHints_ShouldBeRejected(int version)
     {
@@ -56,6 +59,7 @@ public sealed class SqliteDialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void ParseUnsupportedSql_ShouldUseStandardNotSupportedMessage(int version)
     {
@@ -71,6 +75,7 @@ public sealed class SqliteDialectFeatureParserTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void ParseSelect_UnionOrderBy_ShouldParseAsUnion(int version)
     {
@@ -92,6 +97,7 @@ public sealed class SqliteDialectFeatureParserTests
     /// </summary>
     /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
+    [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
     public void RuntimeDialectRules_ShouldRemainStable(int version)
     {

--- a/src/DbSqlLikeMem.Sqlite.Test/Query/QueryExecutorExtrasTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Query/QueryExecutorExtrasTests.cs
@@ -28,6 +28,7 @@ public sealed class QueryExecutorExtrasTests(
     /// PT: Testa o comportamento de GroupByAndAggregationsShouldComputeCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void GroupByAndAggregationsShouldComputeCorrectly()
     {
         // Arrange
@@ -65,6 +66,7 @@ GROUP BY grp";
     /// PT: Testa o comportamento de OrderByLimitOffsetShouldPageCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void OrderByLimitOffsetShouldPageCorrectly()
     {
         // Arrange
@@ -114,6 +116,7 @@ public class SqlTranslatorTests
     /// PT: Testa o comportamento de TranslateBasicWhereAndOrderBySqlCorrect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Query")]
     public void TranslateBasicWhereAndOrderBySqlCorrect()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Sqlite.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -12,6 +12,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de CreateTableAsSelect_ShouldCreateNewTableWithRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void CreateTableAsSelect_ShouldCreateNewTableWithRows()
     {
         var db = new SqliteDbMock();
@@ -44,6 +45,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de InsertIntoSelect_ShouldInsertRowsFromQuery.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void InsertIntoSelect_ShouldInsertRowsFromQuery()
     {
         var db = new SqliteDbMock();
@@ -75,6 +77,7 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
     /// PT: Testa o comportamento de UpdateJoinDerivedSelect_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void UpdateJoinDerivedSelect_ShouldUpdateRows()
     {
         var db = new SqliteDbMock();
@@ -114,6 +117,7 @@ WHERE u.tenantid = 10";
     /// PT: Testa o comportamento de DeleteJoinDerivedSelect_ShouldDeleteRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SelectIntoInsertSelectUpdateDeleteFromSelect")]
     public void DeleteJoinDerivedSelect_ShouldDeleteRows()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqlValueHelperTests .cs
@@ -14,6 +14,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_ByName.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldReadDapperParameter_ByName()
     {
         using var cnn = new SqliteConnectionMock();
@@ -34,6 +35,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldThrow_WhenParameterMissing()
     {
         Assert.Throws<SqliteMockException>(() =>
@@ -45,6 +47,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldParseInList_ToListOfResolvedValues.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldParseInList_ToListOfResolvedValues()
     {
         var v = SqliteValueHelper.Resolve("(1, 2, 3)", DbType.Int32, isNullable: false, pars: null, colDict: null);
@@ -58,6 +61,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_NullOnNonNullable_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_NullOnNonNullable_ShouldThrow()
     {
         Assert.Throws<SqliteMockException>(() =>
@@ -69,6 +73,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Json_ShouldReturnJsonDocument_WhenValid.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Json_ShouldReturnJsonDocument_WhenValid()
     {
         var v = SqliteValueHelper.Resolve("{\"a\":1}", DbType.Object, isNullable: false, pars: null, colDict: null);
@@ -82,6 +87,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Like_ShouldMatch_SqliteStyle.
     /// </summary>
     [Theory]
+    [Trait("Category", "SqlValueHelperTests ")]
     [InlineData("John", "%oh%", true)]
     [InlineData("John", "J_hn", true)]
     [InlineData("John", "J__n", true)]
@@ -97,6 +103,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Enum_ShouldValidateAgainstColumnDef.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Enum_ShouldValidateAgainstColumnDef()
     {
 
@@ -120,6 +127,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_Set_ShouldReturnHashSet_AndValidate.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_Set_ShouldReturnHashSet_AndValidate()
     {
         var tb = new SqliteDbMock().AddTable("tb");
@@ -151,6 +159,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateStringSize.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateStringSize()
     {
 
@@ -177,6 +186,7 @@ public sealed class SqlValueHelperTests(
     /// PT: Testa o comportamento de Resolve_ShouldValidateDecimalPlaces.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
     public void Resolve_ShouldValidateDecimalPlaces()
     {
         var tb = new SqliteDbMock().AddTable("tb");

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteAdditionalBehaviorCoverageTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteAdditionalBehaviorCoverageTests.cs
@@ -47,6 +47,7 @@ public sealed class SqliteAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNull_And_IsNotNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdditionalBehaviorCoverage")]
     public void Where_IsNull_And_IsNotNull_ShouldWork()
     {
         var nullIds = _cnn.Query<int>("SELECT id FROM users WHERE email IS NULL ORDER BY id").ToList();
@@ -61,6 +62,7 @@ public sealed class SqliteAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_EqualNull_ShouldReturnNoRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdditionalBehaviorCoverage")]
     public void Where_EqualNull_ShouldReturnNoRows()
     {
         // SQLite: any comparison with NULL yields UNKNOWN (i.e., filtered out in WHERE)
@@ -76,6 +78,7 @@ public sealed class SqliteAdditionalBehaviorCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldPreserveLeftRows_WhenNoMatch.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdditionalBehaviorCoverage")]
     public void LeftJoin_ShouldPreserveLeftRows_WhenNoMatch()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -102,6 +105,7 @@ ORDER BY u.id
     /// PT: Testa o comportamento de OrderBy_Desc_ThenAsc_ShouldBeDeterministic.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdditionalBehaviorCoverage")]
     public void OrderBy_Desc_ThenAsc_ShouldBeDeterministic()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -119,6 +123,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdditionalBehaviorCoverage")]
     public void Aggregation_CountStar_Vs_CountColumn_ShouldRespectNulls()
     {
         var r = _cnn.QuerySingle<dynamic>("SELECT COUNT(*) c1, COUNT(email) c2 FROM users");
@@ -132,6 +137,7 @@ ORDER BY amount DESC, id ASC
     /// PT: Testa o comportamento de Having_ShouldFilterGroups.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdditionalBehaviorCoverage")]
     public void Having_ShouldFilterGroups()
     {
         var userIds = _cnn.Query<int>(@"
@@ -150,6 +156,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Where_In_WithParameterList_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdditionalBehaviorCoverage")]
     public void Where_In_WithParameterList_ShouldWork()
     {
         var ids = _cnn.Query<int>("SELECT id FROM users WHERE id IN @ids ORDER BY id", new { ids = param }).ToList();
@@ -161,6 +168,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Insert_WithColumnsOutOfOrder_ShouldMapCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdditionalBehaviorCoverage")]
     public void Insert_WithColumnsOutOfOrder_ShouldMapCorrectly()
     {
         _cnn.Execute("INSERT INTO users (name, id, email) VALUES (@name, @id, @email)", new { id = 4, name = "Zed", email = "zed@x.com" });
@@ -176,6 +184,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Delete_WithInParameterList_ShouldDeleteMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdditionalBehaviorCoverage")]
     public void Delete_WithInParameterList_ShouldDeleteMatchingRows()
     {
         var deleted = _cnn.Execute("DELETE FROM users WHERE id IN @ids", new { ids = param });
@@ -190,6 +199,7 @@ ORDER BY userid
     /// PT: Testa o comportamento de Update_SetExpression_ShouldUpdateRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdditionalBehaviorCoverage")]
     public void Update_SetExpression_ShouldUpdateRows()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteAdvancedSqlGapTests.cs
@@ -47,6 +47,7 @@ public sealed class SqliteAdvancedSqlGapTests : XUnitTestBase
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
     public void Window_RowNumber_PartitionBy_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -67,6 +68,7 @@ ORDER BY tenantid, id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
     public void CorrelatedSubquery_InSelectList_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -87,6 +89,7 @@ ORDER BY u.id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
     public void DateAdd_IntervalDay_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -108,6 +111,7 @@ ORDER BY id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
     public void Date_Function_WithModifier_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -131,6 +135,7 @@ ORDER BY id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
     public void Cast_StringToInt_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT CAST('42' AS SIGNED) AS v").ToList();
@@ -147,6 +152,7 @@ ORDER BY id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
     public void Regexp_Operator_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name REGEXP '^J' ORDER BY id").ToList();
@@ -164,6 +170,7 @@ ORDER BY id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
     public void OrderBy_Field_Function_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users ORDER BY FIELD(id, 3, 1, 2)").ToList();
@@ -179,6 +186,7 @@ ORDER BY id").ToList();
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
     public void Collation_CaseSensitivity_ShouldFollowColumnCollation()
     {
         // Example expectation in SQLite: behavior depends on column collation.

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteAggregationTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteAggregationTests.cs
@@ -31,6 +31,7 @@ public sealed class SqliteAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAggregation")]
     public void GroupBy_WithCountAndSum_ShouldWork()
     {
         const string sql = """
@@ -57,6 +58,7 @@ public sealed class SqliteAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAggregation")]
     public void Having_ShouldFilterAggregates()
     {
         const string sql = """
@@ -76,6 +78,7 @@ public sealed class SqliteAggregationTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteAggregation")]
     public void Distinct_Order_Limit_Offset_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteDataParameterCollectionMockTest.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteDataParameterCollectionMockTest.cs
@@ -11,6 +11,7 @@ public sealed class SqliteDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteDataParameterCollectionMockTest")]
     public void ParameterCollection_Normalize_ShouldWork_ForAtQuestionAndQuotedNames()
     {
         Assert.Equal("id", SqliteDataParameterCollectionMock.NormalizeParameterName("@id"));
@@ -25,6 +26,7 @@ public sealed class SqliteDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_Add_DuplicateName_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteDataParameterCollectionMockTest")]
     public void ParameterCollection_Add_DuplicateName_ShouldThrow()
     {
         var pars = new SqliteDataParameterCollectionMock();
@@ -38,6 +40,7 @@ public sealed class SqliteDataParameterCollectionMockTest(
     /// PT: Testa o comportamento de ParameterCollection_RemoveAt_ShouldReindexDictionary.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteDataParameterCollectionMockTest")]
     public void ParameterCollection_RemoveAt_ShouldReindexDictionary()
     {
         var pars = new SqliteDataParameterCollectionMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteJoinTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteJoinTests.cs
@@ -39,6 +39,7 @@ public sealed class SqliteJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de LeftJoin_ShouldKeepAllLeftRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteJoin")]
     public void LeftJoin_ShouldKeepAllLeftRows()
     {
         const string sql = """
@@ -59,6 +60,7 @@ public sealed class SqliteJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de RightJoin_ShouldKeepAllRightRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteJoin")]
     public void RightJoin_ShouldKeepAllRightRows()
     {
         const string sql = """
@@ -93,6 +95,7 @@ public sealed class SqliteJoinTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ON_WithMultipleConditions_AND_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteJoin")]
     public void Join_ON_WithMultipleConditions_AND_ShouldWork()
     {
         const string sql = """

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteLinqProviderTest.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteLinqProviderTest.cs
@@ -23,6 +23,7 @@ public sealed class SqliteLinqProviderTest
     /// PT: Testa o comportamento de LinqProvider_ShouldQueryWhereAndReturnRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteLinqProviderTest")]
     public void LinqProvider_ShouldQueryWhereAndReturnRows()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteMockTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteMockTests.cs
@@ -36,6 +36,7 @@ public sealed class SqliteMockTests
     /// PT: Testa o comportamento de TestInsert.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteMock")]
     public void TestInsert()
     {
         using var command = new SqliteCommandMock(_connection)
@@ -52,6 +53,7 @@ public sealed class SqliteMockTests
     /// PT: Testa o comportamento de TestUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteMock")]
     public void TestUpdate()
     {
         using var command = new SqliteCommandMock(_connection)
@@ -71,6 +73,7 @@ public sealed class SqliteMockTests
     /// PT: Testa o comportamento de TestDelete.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteMock")]
     public void TestDelete()
     {
         using var command = new SqliteCommandMock(_connection)
@@ -90,6 +93,7 @@ public sealed class SqliteMockTests
     /// PT: Testa o comportamento de TestTransactionCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteMock")]
     public void TestTransactionCommit()
     {
         using (var transaction = _connection.BeginTransaction())
@@ -125,6 +129,7 @@ public sealed class SqliteMockTests
     /// PT: Testa o comportamento de TestTransactionCommitInsertUpdate.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteMock")]
     public void TestTransactionCommitInsertUpdate()
     {
         using var cmd = _connection.CreateCommand();
@@ -147,6 +152,7 @@ public sealed class SqliteMockTests
     /// PT: Testa o comportamento de TestTransactionRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteMock")]
     public void TestTransactionRollback()
     {
         using (var transaction = _connection.BeginTransaction())

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteSelectAndWhereMoreCoverageTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteSelectAndWhereMoreCoverageTests.cs
@@ -41,6 +41,7 @@ public sealed class SqliteSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Between_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSelectAndWhereMoreCoverage")]
     public void Where_Between_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id BETWEEN 2 AND 3 ORDER BY id").ToList();
@@ -52,6 +53,7 @@ public sealed class SqliteSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NotIn_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSelectAndWhereMoreCoverage")]
     public void Where_NotIn_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id NOT IN (1,3)").ToList();
@@ -64,6 +66,7 @@ public sealed class SqliteSelectAndWhereMoreCoverageTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ExistsSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSelectAndWhereMoreCoverage")]
     public void Where_ExistsSubquery_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -85,6 +88,7 @@ ORDER BY u.id").ToList();
     /// PT: Testa o comportamento de Select_CaseWhen_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSelectAndWhereMoreCoverage")]
     public void Select_CaseWhen_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -104,6 +108,7 @@ ORDER BY id").ToList();
     /// PT: Testa o comportamento de Select_IfNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSelectAndWhereMoreCoverage")]
     public void Select_IfNull_ShouldWork()
     {
         var row = _cnn.QuerySingle<dynamic>("SELECT IFNULL(email,'(none)') AS em FROM users WHERE id = 2");

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteSqlCompatibilityGapTests.cs
@@ -44,6 +44,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Precedence_AND_ShouldBindStrongerThan_OR.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Where_Precedence_AND_ShouldBindStrongerThan_OR()
     {
         // SQLite precedence: AND binds stronger than OR.
@@ -57,6 +58,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_OR_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Where_OR_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id = 1 OR id = 3").ToList();
@@ -68,6 +70,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_ParenthesesGrouping_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Where_ParenthesesGrouping_ShouldWork()
     {
         // (id=1 OR id=2) AND email IS NULL => only user 2
@@ -81,6 +84,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_Arithmetic_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Select_Expressions_Arithmetic_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, id + 1 AS nextId FROM users ORDER BY id").ToList();
@@ -92,6 +96,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_CASE_WHEN_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Select_Expressions_CASE_WHEN_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CASE WHEN email IS NULL THEN 0 ELSE 1 END AS hasEmail FROM users ORDER BY id").ToList();
@@ -103,6 +108,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IF_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Select_Expressions_IF_ShouldWork()
     {
         // SQLite: IF(cond, then, else)
@@ -115,6 +121,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Select_Expressions_IIF_ShouldWork_AsAliasForIF.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Select_Expressions_IIF_ShouldWork_AsAliasForIF()
     {
         // Not native SQLite, but requested as convenience.
@@ -127,6 +134,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_COALESCE_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Functions_COALESCE_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, COALESCE(NULL, email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -138,6 +146,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_IFNULL_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Functions_IFNULL_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, IFNULL(email, 'none') AS em FROM users ORDER BY id").ToList();
@@ -149,6 +158,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Functions_CONCAT_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Functions_CONCAT_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, CONCAT(name, '#', id) AS tag FROM users ORDER BY id").ToList();
@@ -160,6 +170,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Distinct_ShouldBeConsistent.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Distinct_ShouldBeConsistent()
     {
         // duplicate names
@@ -173,6 +184,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Join_ComplexOn_WithOr_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Join_ComplexOn_WithOr_ShouldWork()
     {
         // include orders joined when (o.userId = u.id OR o.userId = 0)
@@ -193,6 +205,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de GroupBy_Having_ShouldSupportAggregates.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void GroupBy_Having_ShouldSupportAggregates()
     {
         var rows = _cnn.Query<dynamic>(
@@ -210,6 +223,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de OrderBy_ShouldSupportAlias_And_Ordinal.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void OrderBy_ShouldSupportAlias_And_Ordinal()
     {
         var rows1 = _cnn.Query<dynamic>("SELECT id, id + 1 AS x FROM users ORDER BY x DESC").ToList();
@@ -225,6 +239,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Union_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -240,6 +255,7 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Union_Inside_SubSelect_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -258,6 +274,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Cte_With_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Cte_With_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>(
@@ -271,6 +288,7 @@ ORDER BY id
     /// PT: Testa o comportamento de Typing_ImplicitCasts_And_Collation_ShouldMatchSqliteDefault.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
     public void Typing_ImplicitCasts_And_Collation_ShouldMatchSqliteDefault()
     {
         // Many SQLite installations use case-insensitive collations by default.

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteTransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteTransactionReliabilityTests.cs
@@ -11,6 +11,7 @@ public sealed class SqliteTransactionReliabilityTests
     /// PT: Garante que rollback para savepoint restaure o estado intermediário.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteTransactionReliability")]
     public void SavepointRollbackShouldRestoreIntermediateState()
     {
         var db = new SqliteDbMock();
@@ -38,6 +39,7 @@ public sealed class SqliteTransactionReliabilityTests
     /// PT: Garante que o modelo simplificado de isolamento seja determinístico e visível.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteTransactionReliability")]
     public void IsolationLevelShouldBeExposedDeterministically()
     {
         var db = new SqliteDbMock();
@@ -55,6 +57,7 @@ public sealed class SqliteTransactionReliabilityTests
     /// PT: Garante que o suporte a release de savepoint siga as regras de compatibilidade do provedor.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteTransactionReliability")]
     public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
     {
         var db = new SqliteDbMock();
@@ -72,6 +75,7 @@ public sealed class SqliteTransactionReliabilityTests
     /// PT: Garante que escritas concorrentes mantenham dados consistentes com thread safety habilitado.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteTransactionReliability")]
     public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
     {
         var db = new SqliteDbMock { ThreadSafe = true };

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteTransactionTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteTransactionTests.cs
@@ -27,6 +27,7 @@ public sealed class SqliteTransactionTests(
     /// PT: Testa o comportamento de TransactionCommitShouldPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteTransaction")]
     public void TransactionCommitShouldPersistData()
     {
         // Arrange
@@ -59,6 +60,7 @@ public sealed class SqliteTransactionTests(
     /// PT: Testa o comportamento de TransactionRollbackShouldNotPersistData.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteTransaction")]
     public void TransactionRollbackShouldNotPersistData()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs
@@ -30,6 +30,7 @@ public sealed class SqliteUnionLimitAndJsonCompatibilityTests : XUnitTestBase
     /// PT: Testa o comportamento de UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteUnionLimitAndJsonCompatibility")]
     public void UnionAll_ShouldKeepDuplicates_UnionShouldRemoveDuplicates()
     {
         // UNION ALL keeps duplicates
@@ -54,6 +55,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de Limit_OffsetCommaSyntax_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteUnionLimitAndJsonCompatibility")]
     public void Limit_OffsetCommaSyntax_ShouldWork()
     {
         // SQLite supports: LIMIT offset, count
@@ -66,6 +68,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de Limit_OffsetKeywordSyntax_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteUnionLimitAndJsonCompatibility")]
     public void Limit_OffsetKeywordSyntax_ShouldWork()
     {
         // SQLite supports: LIMIT count OFFSET offset
@@ -78,6 +81,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonExtract_SimpleObjectPath_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteUnionLimitAndJsonCompatibility")]
     public void JsonExtract_SimpleObjectPath_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id, JSON_EXTRACT(payload, '$.a.b') AS v FROM t ORDER BY id").ToList();
@@ -94,6 +98,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de OrderBy_NullsFirst_ShouldApplyExplicitNullOrdering.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteUnionLimitAndJsonCompatibility")]
     public void OrderBy_NullsFirst_ShouldApplyExplicitNullOrdering()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM t ORDER BY payload NULLS FIRST, id").ToList();
@@ -106,6 +111,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Testa o comportamento de JsonFunction_ShouldThrow_WhenNotSupportedByDialect.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteUnionLimitAndJsonCompatibility")]
     public void JsonFunction_ShouldThrow_WhenNotSupportedByDialect()
     {
         Assert.Throws<NotSupportedException>(() =>
@@ -117,6 +123,7 @@ SELECT id FROM t WHERE id = 1
     /// PT: Garante que o UNION normalize literais numéricos equivalentes em uma única linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteUnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeEquivalentNumericTypes()
     {
         var rows = _cnn.Query<dynamic>(@"
@@ -133,6 +140,7 @@ SELECT 1 AS v
     /// PT: Garante que o UNION rejeite tipos de coluna incompatíveis entre partes do SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteUnionLimitAndJsonCompatibility")]
     public void Union_ShouldValidateIncompatibleColumnTypes()
     {
         Assert.Throws<InvalidOperationException>(() =>
@@ -150,6 +158,7 @@ SELECT 'x' AS v
     /// PT: Garante que o schema do UNION mantenha os aliases da primeira projeção SELECT.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteUnionLimitAndJsonCompatibility")]
     public void Union_ShouldNormalizeSchemaToFirstSelectAlias()
     {
         var rows = _cnn.Query<dynamic>(@"

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteWhereParserAndExecutorTests.cs
@@ -38,6 +38,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEquality_ShouldUseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_IndexedEquality_ShouldUseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -58,6 +59,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_IndexedEqualityWithParameter_ShouldUseCompositeIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -86,6 +88,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexedEqualityWithCompositeValuesContainingSeparator_ShouldReturnCorrectRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_IndexedEqualityWithCompositeValuesContainingSeparator_ShouldReturnCorrectRow()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -111,6 +114,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_IndexWithIncludeCoveringProjection_ShouldExposeRequestedColumnsInIndex()
     {
         var table = _cnn.GetTable("users");
@@ -135,6 +139,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_IndexWithoutRequestedColumn_ShouldFallbackToTableRow()
     {
         var table = _cnn.GetTable("users");
@@ -156,6 +161,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_NonIndexedPredicate_ShouldNotIncreaseIndexLookupMetric()
     {
         var before = _cnn.Metrics.IndexLookups;
@@ -174,6 +180,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IN_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_IN_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id IN (1,3)").ToList();
@@ -187,6 +194,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_IsNotNull_ShouldFilter.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_IsNotNull_ShouldFilter()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE email IS NOT NULL").ToList();
@@ -198,6 +206,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Operators_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_Operators_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE id >= 2 AND id <= 3").ToList();
@@ -212,6 +221,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_Like_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_Like_ShouldWork()
     {
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name LIKE '%oh%'").ToList();
@@ -224,6 +234,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_FindInSet_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_FindInSet_ShouldWork()
     {
         // FIND_IN_SET('b', tags) -> John(a,b) e Jane(b,c)
@@ -236,6 +247,7 @@ public sealed class SqliteWhereParserAndExecutorTests : XUnitTestBase
     /// PT: Testa o comportamento de Where_AND_ShouldBeCaseInsensitive_InRealLife.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqliteWhereParserAndExecutor")]
     public void Where_AND_ShouldBeCaseInsensitive_InRealLife()
     {
         // esse teste é pra pegar o bug clássico: split só em " AND " / " and "

--- a/src/DbSqlLikeMem.Sqlite.Test/StoredProcedureExecutionTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/StoredProcedureExecutionTests.cs
@@ -32,6 +32,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldValidateRequiredInputs()
     {
         // Arrange
@@ -72,6 +73,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenMissingRequiredInput()
     {
         // Arrange
@@ -110,6 +112,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputIsNull()
     {
         // Arrange
@@ -148,6 +151,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldPopulateOutParameters_DefaultValue()
     {
         // Arrange
@@ -195,6 +199,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteReader_CallSyntax_ShouldValidateAndReturnEmptyResultset()
     {
         // Arrange
@@ -229,6 +234,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldPopulateReturnValueDefaultZero.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldKeepReturnValueUnset_WhenProviderDoesNotSupportDirection()
     {
         using var c = new SqliteConnectionMock();
@@ -260,6 +266,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_StoredProcedure_ShouldThrow_WhenRequiredInputDirectionIsOutput.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void ExecuteNonQuery_StoredProcedure_ShouldNotThrow_WhenProviderCannotRepresentOutputDirection()
     {
         using var c = new SqliteConnectionMock();
@@ -289,6 +296,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldWork()
     {
         // Arrange
@@ -322,6 +330,7 @@ public sealed class StoredProcedureExecutionTests(
     /// PT: Testa o comportamento de DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureExecution")]
     public void DapperExecute_CommandTypeStoredProcedure_ShouldThrow_OnMissingParam()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs
@@ -12,6 +12,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldValidateRequiredInAndOutParams.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldValidateRequiredInAndOutParams()
     {
         using var c = new SqliteConnectionMock();
@@ -43,6 +44,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de StoredProcedure_ShouldThrowWhenMissingRequiredParam.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void StoredProcedure_ShouldThrowWhenMissingRequiredParam()
     {
         using var c = new SqliteConnectionMock();
@@ -66,6 +68,7 @@ public sealed class StoredProcedureSignatureTests(
     /// PT: Testa o comportamento de CallStatement_ShouldValidateAgainstRegisteredProcedure.
     /// </summary>
     [Fact]
+    [Trait("Category", "StoredProcedureSignature")]
     public void CallStatement_ShouldValidateAgainstRegisteredProcedure()
     {
         using var c = new SqliteConnectionMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteDeleteStrategyTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteDeleteStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class SqliteCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_1_linha.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_1_linha()
     {
         var db = new SqliteDbMock();
@@ -35,6 +36,7 @@ public sealed class SqliteCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_remove_varias_linhas.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_remove_varias_linhas()
     {
         var db = new SqliteDbMock();
@@ -59,6 +61,7 @@ public sealed class SqliteCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_quando_nao_acha_retorna_0()
     {
         var db = new SqliteDbMock();
@@ -80,6 +83,7 @@ public sealed class SqliteCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_tabela_inexistente_dispara.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_tabela_inexistente_dispara()
     {
         var db = new SqliteDbMock();
@@ -95,6 +99,7 @@ public sealed class SqliteCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_sql_invalido_sem_FROM_dispara()
     {
         var db = new SqliteDbMock();
@@ -114,6 +119,7 @@ public sealed class SqliteCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_bloqueia_quando_fk_referencia()
     {
         var db = new SqliteDbMock();
@@ -140,6 +146,7 @@ public sealed class SqliteCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void ExecuteNonQuery_DELETE_funciona_com_ThreadSafe_true_ou_false(bool threadSafe)
@@ -162,6 +169,7 @@ public sealed class SqliteCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_case_insensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_case_insensitive()
     {
         var db = new SqliteDbMock();
@@ -182,6 +190,7 @@ public sealed class SqliteCommandDeleteTests(
     /// PT: Testa o comportamento de ExecuteNonQuery_DELETE_com_parametro_se_suportado.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void ExecuteNonQuery_DELETE_com_parametro_se_suportado()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertOnDuplicateTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertOnDuplicateTests.cs
@@ -13,6 +13,7 @@ public class SqliteInsertOnDuplicateTests(
     /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldInsertWhenNoConflict.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataSqliteVersion]
     public void Insert_OnDuplicate_ShouldInsertWhenNoConflict(int version)
     {
@@ -38,6 +39,7 @@ public class SqliteInsertOnDuplicateTests(
     /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateExistingRow_ByPrimaryKey_UsingValues.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataSqliteVersion]
     public void Insert_OnDuplicate_ShouldUpdateExistingRow_ByPrimaryKey_UsingValues(int version)
     {
@@ -65,6 +67,7 @@ public class SqliteInsertOnDuplicateTests(
     /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateExistingRow_ByUniqueIndex.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataSqliteVersion]
     public void Insert_OnDuplicate_ShouldUpdateExistingRow_ByUniqueIndex(int version)
     {
@@ -95,6 +98,7 @@ public class SqliteInsertOnDuplicateTests(
     /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateUsingLiteralAndParam.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataSqliteVersion]
     public void Insert_OnDuplicate_ShouldUpdateUsingLiteralAndParam(int version)
     {
@@ -127,6 +131,7 @@ public class SqliteInsertOnDuplicateTests(
     /// PT: Testa o comportamento de Insert_OnDuplicate_ShouldUpdateAggragating.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [MemberDataSqliteVersion]
     public void Insert_OnDuplicate_ShouldUpdateAggragating(int version)
     {

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertStrategyCoverageTests.cs
@@ -12,6 +12,7 @@ public sealed class SqliteInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_MultiRowValues_ShouldInsertAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_MultiRowValues_ShouldInsertAllRows()
     {
         var db = new SqliteDbMock();
@@ -40,6 +41,7 @@ public sealed class SqliteInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de Insert_WithIdentityColumnOmitted_ShouldAutoIncrement.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Insert_WithIdentityColumnOmitted_ShouldAutoIncrement()
     {
         var db = new SqliteDbMock();
@@ -70,6 +72,7 @@ public sealed class SqliteInsertStrategyCoverageTests(
     /// PT: Testa o comportamento de InsertSelect_ShouldInsertRowsFromSelect.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertSelect_ShouldInsertRowsFromSelect()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertStrategyExtrasTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertStrategyExtrasTests.cs
@@ -11,6 +11,7 @@ public sealed class SqliteInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de MultiRowInsertShouldAddAllRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void MultiRowInsertShouldAddAllRows()
     {
         // Arrange
@@ -38,6 +39,7 @@ public sealed class SqliteInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertWithDefaultValueAndIdentityShouldApplyDefaults.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertWithDefaultValueAndIdentityShouldApplyDefaults()
     {
         // Arrange
@@ -69,6 +71,7 @@ public sealed class SqliteInsertStrategyExtrasTests(
     /// PT: Testa o comportamento de InsertDuplicatePrimaryKeyShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertDuplicatePrimaryKeyShouldThrow()
     {
         // Arrange
@@ -100,6 +103,7 @@ public class SqliteDeleteStrategyForeignKeyTests
     /// PT: Testa o comportamento de DeleteReferencedRowShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void DeleteReferencedRowShouldThrow()
     {
         // Arrange parent
@@ -139,6 +143,7 @@ public class SqliteUpdateStrategyExtrasTests
     /// PT: Testa o comportamento de UpdateMultipleConditionsShouldOnlyAffectMatchingRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateMultipleConditionsShouldOnlyAffectMatchingRows()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertStrategyTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class SqliteInsertStrategyTests(
     /// PT: Testa o comportamento de InsertIntoTableShouldAddNewRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void InsertIntoTableShouldAddNewRow()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteTransactionTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteTransactionTests.cs
@@ -12,6 +12,7 @@ public sealed class SqliteTransactionTests(
     /// PT: Testa o comportamento de TransactionShouldCommit.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldCommit()
     {
         // Arrange
@@ -46,6 +47,7 @@ public sealed class SqliteTransactionTests(
     /// PT: Testa o comportamento de TransactionShouldRollback.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TransactionShouldRollback()
     {
         // Arrange

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteTriggerStrategyTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteTriggerStrategyTests.cs
@@ -11,6 +11,7 @@ public sealed class SqliteTriggerStrategyTests
     /// PT: Garante que um gatilho AFTER INSERT seja executado para uma tabela não temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void NonTemporaryTable_ShouldExecuteAfterInsertTrigger()
     {
         var db = new SqliteDbMock();
@@ -33,6 +34,7 @@ public sealed class SqliteTriggerStrategyTests
     /// PT: Garante que os gatilhos não sejam executados para uma tabela temporária.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void TemporaryTable_ShouldNotExecuteAfterInsertTrigger()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteUpdateStrategyCoverageTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteUpdateStrategyCoverageTests.cs
@@ -12,6 +12,7 @@ public sealed class SqliteUpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNullableColumnToNull_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNullableColumnToNull_ShouldWork()
     {
         var db = new SqliteDbMock();
@@ -37,6 +38,7 @@ public sealed class SqliteUpdateStrategyCoverageTests(
     /// PT: Testa o comportamento de Update_SetNotNullableColumnToNull_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_SetNotNullableColumnToNull_ShouldThrow()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteUpdateStrategyTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteUpdateStrategyTests.cs
@@ -12,6 +12,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de UpdateTableShouldModifyExistingRow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void UpdateTableShouldModifyExistingRow()
     {
         // Arrange
@@ -40,6 +41,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldReturnZero_WhenNoRowsMatchWhere.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldReturnZero_WhenNoRowsMatchWhere()
     {
         var db = new SqliteDbMock();
@@ -65,6 +67,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleRows_WhenWhereMatchesMultiple()
     {
         var db = new SqliteDbMock();
@@ -93,6 +96,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldHandleWhereWithAnd_CaseInsensitive.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldHandleWhereWithAnd_CaseInsensitive()
     {
         var db = new SqliteDbMock();
@@ -121,6 +125,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldUpdateMultipleSetPairs.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldUpdateMultipleSetPairs()
     {
         var db = new SqliteDbMock();
@@ -146,6 +151,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldBeCaseInsensitive_ForUpdateSetWhereKeywords()
     {
         var db = new SqliteDbMock();
@@ -170,6 +176,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldWork_WithThreadSafeTrueOrFalse.
     /// </summary>
     [Theory]
+    [Trait("Category", "Strategy")]
     [InlineData(false)]
     [InlineData(true)]
     public void Update_ShouldWork_WithThreadSafeTrueOrFalse(bool threadSafe)
@@ -196,6 +203,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenTableDoesNotExist.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenTableDoesNotExist()
     {
         var db = new SqliteDbMock();
@@ -214,6 +222,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrow_WhenSqlIsInvalid_NoUpdateToken()
     {
         var db = new SqliteDbMock();
@@ -235,6 +244,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldNotChangeGeneratedColumn_WhenGetGenValueIsNotNull()
     {
         var db = new SqliteDbMock();
@@ -260,6 +270,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldSupportParameter_IfSqlValueHelperSupports.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldSupportParameter_IfSqlValueHelperSupports()
     {
         var db = new SqliteDbMock();
@@ -294,6 +305,7 @@ public sealed class SqliteUpdateStrategyTests(
     /// PT: Testa o comportamento de Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides.
     /// </summary>
     [Fact]
+    [Trait("Category", "Strategy")]
     public void Update_ShouldThrowDuplicateKey_WhenUniqueIndexCollides()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/SubqueryFromAndJoinsTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SubqueryFromAndJoinsTests.cs
@@ -12,6 +12,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de FromSubquery_ShouldReturnFilteredRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void FromSubquery_ShouldReturnFilteredRows()
     {
         using var cnn = new SqliteConnectionMock();
@@ -44,6 +45,7 @@ public sealed class SubqueryFromAndJoinsTests(
     /// PT: Testa o comportamento de JoinSubquery_ShouldJoinCorrectly.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void JoinSubquery_ShouldJoinCorrectly()
     {
         using var cnn = new SqliteConnectionMock();
@@ -88,6 +90,7 @@ ORDER BY u.Id, o.Amount";
     /// PT: Testa o comportamento de NestedSubquery_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "SubqueryFromAndJoins")]
     public void NestedSubquery_ShouldWork()
     {
         using var cnn = new SqliteConnectionMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/TemporaryTable/SqliteTemporaryTableEngineTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/TemporaryTable/SqliteTemporaryTableEngineTests.cs
@@ -12,6 +12,7 @@ public sealed class SqliteTemporaryTableEngineTests
     /// PT: Testa o comportamento de CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "TemporaryTable")]
     public void CreateTemporaryTable_AsSelect_ThenSelect_ShouldReturnProjectedRows()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite.Test/TemporaryTable/SqliteTemporaryTableParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/TemporaryTable/SqliteTemporaryTableParserTests.cs
@@ -10,6 +10,7 @@ public sealed class SqliteTemporaryTableParserTests
     /// PT: Testa o comportamento de ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataSqliteVersion]
     public void ParseMulti_ShouldAccept_CreateTemporaryTable_AsSelect_FollowedBySelect(int version)
     {
@@ -64,6 +65,7 @@ WHERE `tenantid` = 10",
     /// PT: Testa o comportamento de Parse_ShouldAccept_CreateTemporaryTable_Variants.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataBySqliteVersion(nameof(CreateTempTableStatements))]
     public void Parse_ShouldAccept_CreateTemporaryTable_Variants(string sql, int version)
     {
@@ -78,6 +80,7 @@ WHERE `tenantid` = 10",
     /// Auto-generated summary.
     /// </summary>
     [Theory]
+    [Trait("Category", "TemporaryTable")]
     [MemberDataSqliteVersion]
     public void Parse_ShouldAccept_GlobalTemporaryTable(int version)
     {

--- a/src/DbSqlLikeMem.Sqlite.Test/Views/SqliteCreateViewEngineTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Views/SqliteCreateViewEngineTests.cs
@@ -39,6 +39,7 @@ public sealed class SqliteCreateViewEngineTests : XUnitTestBase
     /// PT: Testa o comportamento de CreateView_ThenSelectFromView_ShouldReturnExpectedRows.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ThenSelectFromView_ShouldReturnExpectedRows()
     {
         _cnn.ExecNonQuery(@"
@@ -56,6 +57,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_IsNotMaterialized_ShouldReflectBaseTableChanges.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_IsNotMaterialized_ShouldReflectBaseTableChanges()
     {
         _cnn.ExecNonQuery("CREATE VIEW v_all AS SELECT id FROM users ORDER BY id;");
@@ -72,6 +74,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de CreateOrReplaceView_ShouldChangeDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateOrReplaceView_ShouldChangeDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW v AS SELECT id FROM users WHERE tenantid = 10;");
@@ -88,6 +91,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_NameShouldShadowTable_WhenSameName.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_NameShouldShadowTable_WhenSameName()
     {
         // cria uma tabela física chamada vshadow, com dados diferentes
@@ -109,6 +113,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_CanReferenceAnotherView.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_CanReferenceAnotherView()
     {
         _cnn.ExecNonQuery("CREATE VIEW v1 AS SELECT id FROM users WHERE tenantid = 10;");
@@ -123,6 +128,7 @@ SELECT id, name FROM users WHERE tenantid = 10;
     /// PT: Testa o comportamento de View_WithJoinAndAggregation_ShouldWork.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void View_WithJoinAndAggregation_ShouldWork()
     {
         _cnn.ExecNonQuery(@"
@@ -147,6 +153,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de CreateView_ExistingNameWithoutOrReplace_ShouldThrow.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void CreateView_ExistingNameWithoutOrReplace_ShouldThrow()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdup AS SELECT 1 AS x FROM DUAL;");
@@ -158,6 +165,7 @@ GROUP BY u.id;
     /// PT: Testa o comportamento de DropView_ShouldRemoveDefinition.
     /// </summary>
     [Fact]
+    [Trait("Category", "Views")]
     public void DropView_ShouldRemoveDefinition()
     {
         _cnn.ExecNonQuery("CREATE VIEW vdrop AS SELECT id FROM users;");

--- a/src/DbSqlLikeMem.Sqlite.Test/Views/SqliteCreateViewParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Views/SqliteCreateViewParserTests.cs
@@ -12,6 +12,7 @@ public sealed class SqliteCreateViewParserTests(
     /// PT: Testa o comportamento de ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataSqliteVersion]
     public void ParseMulti_CreateView_ThenSelect_ShouldReturnTwoStatements(int version)
     {
@@ -39,6 +40,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateOrReplaceView_ShouldSetFlag.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataSqliteVersion]
     public void Parse_CreateOrReplaceView_ShouldSetFlag(int version)
     {
@@ -54,6 +56,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataSqliteVersion]
     public void Parse_CreateView_WithExplicitColumnList_ShouldCaptureNames(int version)
     {
@@ -68,6 +71,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_WithBackticks_ShouldWork.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataSqliteVersion]
     public void Parse_CreateView_WithBackticks_ShouldWork(int version)
     {
@@ -82,6 +86,7 @@ SELECT * FROM v_users;
     /// PT: Testa o comportamento de Parse_CreateView_IfNotExists_ShouldBeRejected_BySqliteSpec.
     /// </summary>
     [Theory]
+    [Trait("Category", "Views")]
     [MemberDataSqliteVersion]
     public void Parse_CreateView_IfNotExists_ShouldBeRejected_BySqliteSpec(int version)
     {

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ClassGenerationPlannerTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ClassGenerationPlannerTests.cs
@@ -11,6 +11,7 @@ public class ClassGenerationPlannerTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "ClassGenerationPlanner")]
     public void BuildPlan_WithoutConfiguration_RequiresConfiguration()
     {
         var planner = new ClassGenerationPlanner();
@@ -30,6 +31,7 @@ public class ClassGenerationPlannerTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "ClassGenerationPlanner")]
     public void BuildPlan_WithPartialMappings_ReturnsMissingTypes()
     {
         var planner = new ClassGenerationPlanner();

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ClassGeneratorTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ClassGeneratorTests.cs
@@ -11,6 +11,7 @@ public class ClassGeneratorTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "ClassGenerator")]
     [InlineData("MySql")]
     [InlineData("SqlServer")]
     [InlineData("PostgreSql")]
@@ -55,6 +56,7 @@ public class ClassGeneratorTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "ClassGenerator")]
     public async Task GenerateAsync_ReplacesPatternTokensIncludingDatabaseContext()
     {
         var outputDir = Path.Combine(Path.GetTempPath(), $"dbsql-{Guid.NewGuid():N}");

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GeneratedClassSnapshotReaderTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GeneratedClassSnapshotReaderTests.cs
@@ -11,6 +11,7 @@ public sealed class GeneratedClassSnapshotReaderTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "GeneratedClassSnapshotReader")]
     public async Task ReadAsync_ParsesMetadataAndCheckerDetectsDifference()
     {
         var file = Path.Combine(Path.GetTempPath(), $"dbsql-snapshot-{Guid.NewGuid():N}.cs");

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GenerationRuleSetTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/GenerationRuleSetTests.cs
@@ -11,6 +11,7 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "GenerationRuleSet")]
     [InlineData("customer_order", "CustomerOrder")]
     [InlineData("customer-order", "CustomerOrder")]
     [InlineData("customer.order", "CustomerOrder")]
@@ -29,6 +30,7 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "GenerationRuleSet")]
     [InlineData("tinyint", null, 8, "Flags", "MySql", "Byte")]
     [InlineData("tinyint", 1L, null, "IsEnabled", "MySql", "Boolean")]
     [InlineData("tinyint", null, 1, "IsEnabled", "MySql", "Boolean")]
@@ -53,6 +55,7 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "GenerationRuleSet")]
     [InlineData("binary", 16L, null, "Token", "Guid")]
     [InlineData("varbinary", 16L, null, "Token", "Guid")]
     [InlineData("char", 36L, null, "OrderGuid", "Guid")]
@@ -69,6 +72,7 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "GenerationRuleSet")]
     [InlineData("(now())", false)]
     [InlineData("current_timestamp", false)]
     [InlineData("null", false)]
@@ -84,6 +88,7 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "GenerationRuleSet")]
     [InlineData("('0')", "Boolean", "false")]
     [InlineData("('1')", "Boolean", "true")]
     [InlineData("('abc')", "String", "\"abc\"")]
@@ -99,6 +104,7 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "GenerationRuleSet")]
     public void TryParseEnumValues_ReturnsEntriesForEnumAndSet()
     {
         var enumValues = GenerationRuleSet.TryParseEnumValues("enum('A','B','C')");
@@ -113,6 +119,7 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "GenerationRuleSet")]
     public void TryParseEnumValues_ReturnsEmptyForNonEnumType()
     {
         var values = GenerationRuleSet.TryParseEnumValues("varchar(100)");
@@ -124,6 +131,7 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "GenerationRuleSet")]
     public void TryConvertIfIsNull_ReturnsLambdaWhenPatternMatches()
     {
         var success = GenerationRuleSet.TryConvertIfIsNull("if((`deleted` is null), 1, null)", out var code);
@@ -138,6 +146,7 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "GenerationRuleSet")]
     public void TryConvertIfIsNull_ReturnsFalseWhenPatternDoesNotMatch()
     {
         var success = GenerationRuleSet.TryConvertIfIsNull("coalesce(`deleted`, 1)", out var code);
@@ -151,6 +160,7 @@ public sealed class GenerationRuleSetTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "GenerationRuleSet")]
     public void Literal_EscapesSlashAndQuotes()
     {
         var value = GenerationRuleSet.Literal("c:\\temp\\\"file\"");

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ObjectConsistencyCheckerTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ObjectConsistencyCheckerTests.cs
@@ -11,6 +11,7 @@ public class ObjectConsistencyCheckerTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "ObjectConsistencyChecker")]
     public async Task CheckAsync_WhenObjectMissing_ReturnsMissingStatus()
     {
         var checker = new ObjectConsistencyChecker();
@@ -30,6 +31,7 @@ public class ObjectConsistencyCheckerTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "ObjectConsistencyChecker")]
     public async Task CheckAsync_WhenPropertiesDifferent_ReturnsDifferentStatus()
     {
         var checker = new ObjectConsistencyChecker();

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ObjectFilterServiceTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/ObjectFilterServiceTests.cs
@@ -11,6 +11,7 @@ public class ObjectFilterServiceTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "ObjectFilterService")]
     public void Filter_Equals_ReturnsExactMatches()
     {
         var service = new ObjectFilterService();
@@ -31,6 +32,7 @@ public class ObjectFilterServiceTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "ObjectFilterService")]
     public void Filter_Like_ReturnsContainsMatches()
     {
         var service = new ObjectFilterService();
@@ -51,6 +53,7 @@ public class ObjectFilterServiceTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "ObjectFilterService")]
     public void Filter_EmptyValue_ReturnsAllObjects()
     {
         var service = new ObjectFilterService();

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/QualityRegressionTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/QualityRegressionTests.cs
@@ -11,6 +11,7 @@ public sealed class QualityRegressionTests
     /// Garante que a geração respeita cancelamento e não continua gravando arquivos.
     /// </summary>
     [Fact]
+    [Trait("Category", "QualityRegression")]
     public async Task ClassGenerator_WhenCanceled_StopsWritingFurtherFiles()
     {
         var outputDir = Path.Combine(Path.GetTempPath(), $"dbsql-quality-{Guid.NewGuid():N}");
@@ -78,6 +79,7 @@ public sealed class QualityRegressionTests
     /// Garante fallback para referência padrão quando metadados não estão presentes no arquivo.
     /// </summary>
     [Fact]
+    [Trait("Category", "QualityRegression")]
     public async Task GeneratedClassSnapshotReader_WhenMetadataIsMissing_UsesFallbackReference()
     {
         var file = Path.Combine(Path.GetTempPath(), $"dbsql-snapshot-fallback-{Guid.NewGuid():N}.cs");
@@ -113,6 +115,7 @@ public sealed class QualityRegressionTests
     /// Garante status sincronizado quando propriedades locais e do banco são equivalentes.
     /// </summary>
     [Fact]
+    [Trait("Category", "QualityRegression")]
     public async Task ObjectConsistencyChecker_WhenPropertiesMatch_ReturnsSynchronized()
     {
         var properties = new Dictionary<string, string>

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/SqlDatabaseMetadataProviderTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/SqlDatabaseMetadataProviderTests.cs
@@ -11,6 +11,7 @@ public sealed class SqlDatabaseMetadataProviderTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlDatabaseMetadataProvider")]
     public async Task GetObjectAsync_ReturnsCompleteStructureMetadata()
     {
         var executor = new FakeSqlQueryExecutor();
@@ -56,6 +57,7 @@ public sealed class SqlDatabaseMetadataProviderTests
     /// Verifica se a consulta de listagem MySQL usa o nome do banco extraído da connection string.
     /// </summary>
     [Fact]
+    [Trait("Category", "SqlDatabaseMetadataProvider")]
     public async Task ListObjectsAsync_ForMySql_UsesDatabaseNameFromConnectionString()
     {
         var executor = new FakeSqlQueryExecutor();
@@ -79,6 +81,7 @@ public sealed class SqlDatabaseMetadataProviderTests
     /// Executa esta operação da API.
     /// </summary>
     [Theory]
+    [Trait("Category", "SqlDatabaseMetadataProvider")]
     [InlineData("MySql")]
     [InlineData("SqlServer")]
     [InlineData("PostgreSql")]

--- a/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/StructuredClassContentFactoryTests.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core.Test/StructuredClassContentFactoryTests.cs
@@ -11,6 +11,7 @@ public sealed class StructuredClassContentFactoryTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "StructuredClassContentFactory")]
     public void Build_GeneratesColumnsPkIndexesAndForeignKeysLikeConsole()
     {
         var dbObject = new DatabaseObjectReference(
@@ -38,6 +39,7 @@ public sealed class StructuredClassContentFactoryTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "StructuredClassContentFactory")]
     public void Build_WithCompositePrimaryKey_CreatesPrimaryIndexWithAllFields()
     {
         var dbObject = new DatabaseObjectReference(
@@ -64,6 +66,7 @@ public sealed class StructuredClassContentFactoryTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "StructuredClassContentFactory")]
     public void Build_WithSqlServerStrategy_DoesNotTreatTinyIntAsBoolean()
     {
         var dbObject = new DatabaseObjectReference(
@@ -88,6 +91,7 @@ public sealed class StructuredClassContentFactoryTests
     /// Executa esta operação da API.
     /// </summary>
     [Fact]
+    [Trait("Category", "StructuredClassContentFactory")]
     public void Build_UsesSameTypeRulesAsConsoleGenerator_ForTinyIntAndBit()
     {
         var dbObject = new DatabaseObjectReference(


### PR DESCRIPTION
### Motivation
- Standardize test metadata by ensuring every test method annotated with `[Fact]` or `[Theory]` also includes a `Trait("Category", ...)` tag so test runners and dashboards can group and filter tests consistently.
- Assign sensible categories by test folder or file stem to make test suites (e.g. `Parser`, `Strategy`, `Query`, `Performance`, `Views`, etc.) discoverable and stable.

### Description
- Inserted `[Trait("Category", "...")]` on test attribute blocks for test methods across the repository where a category trait was previously missing, preserving existing `Trait` values where present (e.g. `Performance`).
- Category selection follows folder-scoped heuristics (`Parser`, `Strategy`, `TemporaryTable`, `Views`, `Query`, `Performance`) and falls back to the file/class stem for remaining tests.
- Changes span many test projects under `src/*/*.Test` and equivalent test folders to maintain consistent coverage of all dialect/provider test suites.
- Automated edit inserted traits without modifying existing test logic or data attributes (`InlineData`, `MemberData`, etc.).

### Testing
- Ran a repository scan script that verifies every `[`Fact`]`/`[Theory]` block is followed by a `Trait("Category", ...)` attribute and the check reports `missing 0`, indicating all tests now have categories.
- Confirmed repository-wide change statistics from the automated edit: `271` files updated and `1408` trait insertions added.
- Attempted to run `dotnet test` for a representative test project with `dotnet test src/DbSqlLikeMem.VisualStudioExtension.Core.Test/DbSqlLikeMem.VisualStudioExtension.Core.Test.csproj`, but the environment lacks the `dotnet` CLI so full test execution could not be performed.
- A targeted preview of multiple edited files was inspected to ensure attributes were added in the correct attribute block positions and did not alter test bodies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69951440d95c832cb3202e14e7791743)