### PR TITLE
perf: add AST LRU cache and hash-based UNION DISTINCT with dialect-aware comparer

### DIFF
--- a/src/DbSqlLikeMem/Parser/SqlQueryAstCache.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryAstCache.cs
@@ -1,0 +1,124 @@
+using System.Globalization;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DbSqlLikeMem;
+
+internal sealed class SqlQueryAstCache
+{
+    private readonly int _capacity;
+    private readonly object _gate = new();
+    private readonly Dictionary<string, CacheEntry> _entries;
+    private readonly LinkedList<string> _lru = [];
+
+    private sealed class CacheEntry(SqlQueryBase query, LinkedListNode<string> node)
+    {
+        public SqlQueryBase Query { get; set; } = query;
+        public LinkedListNode<string> Node { get; } = node;
+    }
+
+    private SqlQueryAstCache(int capacity)
+    {
+        _capacity = capacity;
+        _entries = new Dictionary<string, CacheEntry>(capacity <= 0 ? 1 : capacity, StringComparer.Ordinal);
+    }
+
+    public static SqlQueryAstCache CreateFromEnvironment()
+    {
+        const int defaultCapacity = 256;
+        var raw = Environment.GetEnvironmentVariable("DBSQLLIKEMEM_AST_CACHE_SIZE");
+        if (string.IsNullOrWhiteSpace(raw))
+            return new SqlQueryAstCache(defaultCapacity);
+
+        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < 0)
+            return new SqlQueryAstCache(defaultCapacity);
+
+        return new SqlQueryAstCache(parsed);
+    }
+
+    public static string BuildKey(string sql, string dialectName)
+        => string.Concat(dialectName, "::", NormalizeSql(sql));
+
+    public bool TryGet(string key, out SqlQueryBase query)
+    {
+        if (_capacity <= 0)
+        {
+            query = null!;
+            return false;
+        }
+
+        lock (_gate)
+        {
+            if (!_entries.TryGetValue(key, out var entry))
+            {
+                query = null!;
+                return false;
+            }
+
+            _lru.Remove(entry.Node);
+            _lru.AddFirst(entry.Node);
+            query = entry.Query;
+            return true;
+        }
+    }
+
+    public void Set(string key, SqlQueryBase query)
+    {
+        if (_capacity <= 0)
+            return;
+
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(key, out var entry))
+            {
+                entry.Query = query;
+                _lru.Remove(entry.Node);
+                _lru.AddFirst(entry.Node);
+                return;
+            }
+
+            var node = new LinkedListNode<string>(key);
+            _lru.AddFirst(node);
+            _entries[key] = new CacheEntry(query, node);
+
+            if (_entries.Count <= _capacity)
+                return;
+
+            var tail = _lru.Last;
+            if (tail is null)
+                return;
+
+            _lru.RemoveLast();
+            _entries.Remove(tail.Value);
+        }
+    }
+
+    private static string NormalizeSql(string sql)
+    {
+        var trimmed = sql.Trim();
+        if (trimmed.Length == 0)
+            return string.Empty;
+
+        var sb = new StringBuilder(trimmed.Length);
+        var previousWhitespace = false;
+
+        for (var i = 0; i < trimmed.Length; i++)
+        {
+            var ch = trimmed[i];
+            if (char.IsWhiteSpace(ch))
+            {
+                if (previousWhitespace)
+                    continue;
+
+                sb.Append(' ');
+                previousWhitespace = true;
+                continue;
+            }
+
+            sb.Append(ch);
+            previousWhitespace = false;
+        }
+
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce parse overhead for repeated identical queries by caching normalized ASTs to avoid re-parsing. 
- Replace the quadratic `UNION DISTINCT` duplicate-search (`ContainsRow`) with a hash-based approach to improve performance for large result sets. 
- Avoid unnecessary eager materialization (`ToList`) in non-grouped `SELECT` paths to reduce allocations.
- Reduce reflection overhead when parsing expressions by caching parsed delegate invocations per dialect.

### Description
- Added an optional LRU AST cache `SqlQueryAstCache` configurable via the `DBSQLLIKEMEM_AST_CACHE_SIZE` environment variable and integrated it into `SqlQueryParser.Parse` with a `ParseUncached` fallback and key built from `(dialect, normalized SQL)`; new file: `src/DbSqlLikeMem/Parser/SqlQueryAstCache.cs` and changes in `src/DbSqlLikeMem/Parser/SqlQueryParser.cs`.
- Replaced linear duplicate detection in `UNION` (distinct mode) by building a `HashSet<Dictionary<int, object?>>` with a SQL-aware comparer `SqlRowDictionaryComparer` that uses `EqualsSql`, dialect numeric/string normalization and text-comparison semantics; updated merging loop to use the set for O(n) behavior (`src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs`).
- Parallelized execution of independent `UNION` parts by executing `ExecuteSelect` into a pre-sized `TableResultMock[]` with `Parallel.For` to preserve result slots while enabling concurrency (`src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs`).
- Reduced eager materialization in the non-grouped `SELECT` path by reusing an existing `List<EvalRow>` when `rows` is already a `List<EvalRow>` and only calling `ToList()` when required (`src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs`).
- Added a per-dialect cached delegate for `SqlExpressionParser.ParseWhere` using a `ConcurrentDictionary<Type, Func<string, object, SqlExpr>> _parseWhereDelegateCache` and factory `CreateParseWhereDelegate` to avoid repeated reflection in expression parsing (`src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs`).

### Testing
- Verified repository modifications and staged changes via local git operations and created a commit containing the new cache and UNION changes; commit succeeded.
- Attempted to run .NET tooling (`dotnet --info` / `dotnet test`) but the environment lacks the .NET SDK (`dotnet: command not found`), so no automated unit or integration tests were executed here.
- Static checks done: grep/inspection and small runtime-less edits to ensure compile-time patterns (no runtime test execution possible in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69951fca9b68832cbc87838e67acc77a)