### PR TITLE
Enforce dialect feature gates for JSON/operators and window functions; stabilize numeric hashing and index locators

### DIFF
--- a/src/DbSqlLikeMem.MySql/MySqlDialect.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDialect.cs
@@ -34,6 +34,8 @@ internal sealed class MySqlDialect : SqlDialectBase
  
     internal const int WithCteMinVersion = 8;
     internal const int MergeMinVersion = int.MaxValue;
+    internal const int WindowFunctionsMinVersion = 8;
+    internal const int JsonExtractMinVersion = 5;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
@@ -99,6 +101,7 @@ internal sealed class MySqlDialect : SqlDialectBase
     /// </summary>
     public override bool SupportsWithCte => Version >= WithCteMinVersion;
     public override bool SupportsWithRecursive => Version >= WithCteMinVersion;
+    public override bool SupportsWindowFunctions => Version >= WindowFunctionsMinVersion;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
@@ -108,8 +111,8 @@ internal sealed class MySqlDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsJsonArrowOperators => true;
-    public override bool SupportsJsonExtractFunction => true;
+    public override bool SupportsJsonArrowOperators => Version >= JsonExtractMinVersion;
+    public override bool SupportsJsonExtractFunction => Version >= JsonExtractMinVersion;
     public override bool SupportsMySqlIndexHints => true;
 
     public override bool SupportsDateAddFunction(string functionName)

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
@@ -37,6 +37,7 @@ internal sealed class NpgsqlDialect : SqlDialectBase
     // parser feature tests expect WITH/CTE support across all tested versions.
     internal const int WithCteMinVersion = 6;
     internal const int MergeMinVersion = 15;
+    internal const int JsonbMinVersion = 9;
 
     /// <summary>
     /// Auto-generated summary.
@@ -98,7 +99,7 @@ internal sealed class NpgsqlDialect : SqlDialectBase
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
-    public override bool SupportsJsonArrowOperators => true;
+    public override bool SupportsJsonArrowOperators => Version >= JsonbMinVersion;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
@@ -31,6 +31,7 @@ internal sealed class SqlServerDialect : SqlDialectBase
     internal const int WithCteMinVersion = 2005;
     internal const int MergeMinVersion = 2008;
     internal const int OffsetFetchMinVersion = 2012;
+    internal const int JsonFunctionsMinVersion = 2016;
 
     /// <summary>
     /// Auto-generated summary.
@@ -82,8 +83,8 @@ internal sealed class SqlServerDialect : SqlDialectBase
     public override bool SupportsWithCte => Version >= WithCteMinVersion;
     // SQL Server supports CTE but not the "WITH RECURSIVE" keyword form.
     public override bool SupportsWithRecursive => false;
-    public override bool SupportsJsonValueFunction => true;
-    public override bool SupportsOpenJsonFunction => true;
+    public override bool SupportsJsonValueFunction => Version >= JsonFunctionsMinVersion;
+    public override bool SupportsOpenJsonFunction => Version >= JsonFunctionsMinVersion;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>

--- a/src/DbSqlLikeMem/Parser/Dialects.cs
+++ b/src/DbSqlLikeMem/Parser/Dialects.cs
@@ -116,6 +116,7 @@ internal interface ISqlDialect
     bool AreUnionColumnTypesCompatible(DbType first, DbType second);
     bool IsIntegerCastTypeName(string typeName);
     bool SupportsDateAddFunction(string functionName);
+    bool SupportsWindowFunctions { get; }
     DbType InferWindowFunctionDbType(WindowFunctionExpr windowFunctionExpr, Func<SqlExpr, DbType> inferArgDbType);
 }
 
@@ -256,6 +257,7 @@ internal abstract class SqlDialectBase : ISqlDialect
     public virtual bool LikeIsCaseInsensitive => true;
     public virtual bool SupportsIfFunction => true;
     public virtual bool SupportsIifFunction => true;
+    public virtual bool SupportsWindowFunctions => true;
     public virtual IReadOnlyCollection<string> NullSubstituteFunctionNames
         => ["IFNULL", "ISNULL", "NVL"];
     public virtual bool ConcatReturnsNullOnNullInput => true;

--- a/src/DbSqlLikeMem/Parser/SqlQueryAstCache.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryAstCache.cs
@@ -36,8 +36,8 @@ internal sealed class SqlQueryAstCache
         return new SqlQueryAstCache(parsed);
     }
 
-    public static string BuildKey(string sql, string dialectName)
-        => string.Concat(dialectName, "::", NormalizeSql(sql));
+    public static string BuildKey(string sql, string dialectName, int dialectVersion)
+        => string.Concat(dialectName, "::v", dialectVersion.ToString(CultureInfo.InvariantCulture), "::", NormalizeSql(sql));
 
     public bool TryGet(string key, out SqlQueryBase query)
     {

--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -221,9 +221,8 @@ internal abstract class AstQueryExecutorBase(
             if (value is null || value is DBNull)
                 return null;
 
-            if ((dialect.SupportsImplicitNumericStringComparison)
-                && decimal.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var numeric))
-                return numeric;
+            if (TryNormalizeNumericHash(value, out var numericHash))
+                return numericHash;
 
             if (value is string text)
                 return dialect.TextComparison == StringComparison.OrdinalIgnoreCase
@@ -231,6 +230,60 @@ internal abstract class AstQueryExecutorBase(
                     : text;
 
             return value;
+        }
+
+        private bool TryNormalizeNumericHash(object value, out string normalized)
+        {
+            normalized = string.Empty;
+
+            if (TryGetNumericValue(value, out var numeric))
+            {
+                normalized = numeric.ToString("G29", CultureInfo.InvariantCulture);
+                return true;
+            }
+
+            if (!dialect.SupportsImplicitNumericStringComparison)
+                return false;
+
+            if (value is string text
+                && decimal.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed))
+            {
+                normalized = parsed.ToString("G29", CultureInfo.InvariantCulture);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetNumericValue(object value, out decimal numeric)
+        {
+            switch (value)
+            {
+                case byte b:
+                    numeric = b;
+                    return true;
+                case short s:
+                    numeric = s;
+                    return true;
+                case int i:
+                    numeric = i;
+                    return true;
+                case long l:
+                    numeric = l;
+                    return true;
+                case float f:
+                    numeric = (decimal)f;
+                    return true;
+                case double d:
+                    numeric = (decimal)d;
+                    return true;
+                case decimal m:
+                    numeric = m;
+                    return true;
+                default:
+                    numeric = default;
+                    return false;
+            }
         }
     }
 
@@ -1038,6 +1091,11 @@ internal abstract class AstQueryExecutorBase(
 
             if (exprAst is WindowFunctionExpr w)
             {
+                if (!(Dialect?.SupportsWindowFunctions ?? true))
+                    throw SqlUnsupported.ForDialect(
+                        Dialect!,
+                        $"window functions ({w.Name})");
+
                 // slot.Map preenchido depois (quando tivermos todas as rows)
                 var slot = new WindowSlot
                 {


### PR DESCRIPTION
### Motivation
- Prevent parser/internal exceptions from leaking when a feature is version-gated by ensuring unsupported syntax throws `NotSupported` deterministically for the dialect/version.
- Make runtime behavior more RDBMS-like by stabilizing numeric hashing/equality and gating window functions by dialect capability.
- Centralize index locator fallback logic and extend ON DUPLICATE evaluation to resolve `VALUES()`/`CALL`/function forms for insert-replace semantics.

### Description
- Added early JSON operator gating in `SqlExpressionParser.ParseWhere` and `ParseScalar` by introducing `EnsureJsonArrowSupport(...)` to throw `SqlUnsupported.ForDialect(...)` for `->/->>/#>/#>>` when not supported by the dialect; this avoids parser `InvalidOperationException` leaks.
- Made SQL Server JSON functions version-aware by adding `JsonFunctionsMinVersion` and changing `SupportsJsonValueFunction`/`SupportsOpenJsonFunction` to `Version >= JsonFunctionsMinVersion`.
- Added `JsonbMinVersion` to `NpgsqlDialect` and `JsonExtractMinVersion`/`WindowFunctionsMinVersion` to `MySqlDialect`, and hooked `SupportsJsonArrowOperators`/`SupportsJsonExtractFunction`/`SupportsWindowFunctions` to those version guards where applicable.
- Extended `SqlQueryAstCache.BuildKey` to include dialect `Version` and added `EnsureDialectSupport(...)`, `EnsureSelectDialectSupport(...)` and `EnsureRowLimitDialectSupport(...)` in `SqlQueryParser.Parse` to validate parsed (and cached) ASTs against dialect capabilities (MERGE, WITH/CTE, OFFSET/FETCH, UNION row-limits and nested derived selects).
- Centralized primary-key locator fallback into `IndexDef.AddRowLocatorColumns(...)` and replaced duplicated locator logic in `IndexDef.Add/Update`/`UpdateIndexesWithRow` with calls to the helper.
- Stabilized numeric hashing/equality in `AstQueryExecutorBase` by introducing `TryNormalizeNumericHash` and `TryGetNumericValue` to produce canonical numeric string hashes and support numeric-string comparisons when allowed by dialect.
- Gate runtime window-function usage by checking `Dialect.SupportsWindowFunctions` and throwing `SqlUnsupported.ForDialect(...)` for unsupported dialects.
- Improved `DbInsertStrategy` to evaluate `VALUES(col)` and `CALL`/`FunctionCall` forms inside `ON DUPLICATE` by adding `EvalCall` and `EvalFunction` handlers that resolve inserted column values.

### Testing
- Ran repository inspections and searches (`rg`) to verify references and updated occurrences for JSON and window-related symbols; these static checks succeeded.
- Targeted failing tests were `PostgreSqlUnionLimitAndJsonCompatibilityTests.JsonPathExtract_ShouldRespectVersion` and `SqlServerUnionLimitAndJsonCompatibilityTests.JsonValue_SimpleObjectPath_ShouldRespectVersion` and were the basis for the fixes.
- Attempted to run focused test commands with `dotnet test` for the Npgsql and SqlServer test projects, but execution failed because the environment lacks the .NET CLI (`bash: command not found: dotnet`).
- Committed the changes locally after static verification; runtime unit test execution could not be completed in this environment due to missing tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995bbf43a7c832cae42adac9c4100ed)