### PR TITLE
Add EN/PT XML summaries to MySql/Npgsql/Sqlite test wrappers

### DIFF
--- a/src/DbSqlLikeMem.MySql.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/CsvLoaderAndIndexTests.cs
@@ -1,8 +1,20 @@
 namespace DbSqlLikeMem.MySql.Test;
 
+/// <summary>
+/// EN: Provides MySQL-specific coverage for CSV loading and index behaviors.
+/// PT: Fornece cobertura específica de MySQL para comportamentos de carregamento de CSV e índices.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class CsvLoaderAndIndexTests(
     ITestOutputHelper helper
     ) : CsvLoaderAndIndexTestBase<MySqlDbMock, MySqlMockException>(helper)
 {
+    /// <summary>
+    /// EN: Creates a new MySQL mock database for each scenario.
+    /// PT: Cria um novo banco mock de MySQL para cada cenário.
+    /// </summary>
     protected override MySqlDbMock CreateDb() => new();
 }

--- a/src/DbSqlLikeMem.MySql.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/ExistsTests.cs
@@ -1,8 +1,20 @@
 namespace DbSqlLikeMem.MySql.Test;
 
+/// <summary>
+/// EN: Validates EXISTS and NOT EXISTS semantics for MySQL.
+/// PT: Valida a semântica de EXISTS e NOT EXISTS para MySQL.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class ExistsTests(
         ITestOutputHelper helper
     ) : ExistsTestsBase(helper)
 {
+    /// <summary>
+    /// EN: Creates the MySQL connection mock used in tests.
+    /// PT: Cria o mock de conexão MySQL usado nos testes.
+    /// </summary>
     protected override DbConnectionMockBase CreateConnection() => new MySqlConnectionMock();
 }

--- a/src/DbSqlLikeMem.MySql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -1,11 +1,27 @@
 namespace DbSqlLikeMem.MySql.Test;
 
+/// <summary>
+/// EN: Exercises select-into, insert-select, update, and delete-from-select flows for MySQL.
+/// PT: Exercita fluxos de select-into, insert-select, update e delete-from-select para MySQL.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         ITestOutputHelper helper
     ) : SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase<MySqlDbMock>(helper)
 {
+    /// <summary>
+    /// EN: Creates a new MySQL mock database for each scenario.
+    /// PT: Cria um novo banco mock de MySQL para cada cenário.
+    /// </summary>
     protected override MySqlDbMock CreateDb() => new();
 
+    /// <summary>
+    /// EN: Executes a non-query command using a MySQL mock connection.
+    /// PT: Executa um comando sem retorno usando uma conexão mock de MySQL.
+    /// </summary>
     protected override int ExecuteNonQuery(
         MySqlDbMock db,
         string sql)
@@ -15,6 +31,10 @@ public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         return cmd.ExecuteNonQuery();
     }
 
+    /// <summary>
+    /// EN: Gets the MySQL-specific SQL used to delete from a join with a derived select.
+    /// PT: Obtém o SQL específico de MySQL usado para deletar de um join com select derivado.
+    /// </summary>
     protected override string DeleteJoinDerivedSelectSql
         => "DELETE u FROM users u JOIN (SELECT id FROM users WHERE tenantid = 10) s ON s.id = u.id";
 }

--- a/src/DbSqlLikeMem.MySql.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/StoredProcedureSignatureTests.cs
@@ -1,8 +1,20 @@
 namespace DbSqlLikeMem.MySql.Test;
 
+/// <summary>
+/// EN: Verifies stored procedure signature behavior for MySQL.
+/// PT: Verifica o comportamento de assinatura de procedures para MySQL.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class StoredProcedureSignatureTests(
         ITestOutputHelper helper
     ) : StoredProcedureSignatureTestsBase<MySqlMockException>(helper)
 {
+    /// <summary>
+    /// EN: Creates the MySQL connection mock used in tests.
+    /// PT: Cria o mock de conexão MySQL usado nos testes.
+    /// </summary>
     protected override DbConnectionMockBase CreateConnection() => new MySqlConnectionMock();
 }

--- a/src/DbSqlLikeMem.Npgsql.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/CsvLoaderAndIndexTests.cs
@@ -1,8 +1,20 @@
 namespace DbSqlLikeMem.Npgsql.Test;
 
+/// <summary>
+/// EN: Provides PostgreSQL-specific coverage for CSV loading and index behaviors.
+/// PT: Fornece cobertura específica de PostgreSQL para comportamentos de carregamento de CSV e índices.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class CsvLoaderAndIndexTests(
     ITestOutputHelper helper
     ) : CsvLoaderAndIndexTestBase<NpgsqlDbMock, NpgsqlMockException>(helper)
 {
+    /// <summary>
+    /// EN: Creates a new PostgreSQL mock database for each scenario.
+    /// PT: Cria um novo banco mock de PostgreSQL para cada cenário.
+    /// </summary>
     protected override NpgsqlDbMock CreateDb() => new();
 }

--- a/src/DbSqlLikeMem.Npgsql.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/ExistsTests.cs
@@ -1,8 +1,20 @@
 namespace DbSqlLikeMem.Npgsql.Test;
 
+/// <summary>
+/// EN: Validates EXISTS and NOT EXISTS semantics for PostgreSQL.
+/// PT: Valida a semântica de EXISTS e NOT EXISTS para PostgreSQL.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class ExistsTests(
         ITestOutputHelper helper
     ) : ExistsTestsBase(helper)
 {
+    /// <summary>
+    /// EN: Creates the PostgreSQL connection mock used in tests.
+    /// PT: Cria o mock de conexão PostgreSQL usado nos testes.
+    /// </summary>
     protected override DbConnectionMockBase CreateConnection() => new NpgsqlConnectionMock();
 }

--- a/src/DbSqlLikeMem.Npgsql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -1,11 +1,27 @@
 namespace DbSqlLikeMem.Npgsql.Test;
 
+/// <summary>
+/// EN: Exercises select-into, insert-select, update, and delete-from-select flows for PostgreSQL.
+/// PT: Exercita fluxos de select-into, insert-select, update e delete-from-select para PostgreSQL.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         ITestOutputHelper helper
     ) : SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase<NpgsqlDbMock>(helper)
 {
+    /// <summary>
+    /// EN: Creates a new PostgreSQL mock database for each scenario.
+    /// PT: Cria um novo banco mock de PostgreSQL para cada cenário.
+    /// </summary>
     protected override NpgsqlDbMock CreateDb() => new();
 
+    /// <summary>
+    /// EN: Executes a non-query command using a PostgreSQL mock connection.
+    /// PT: Executa um comando sem retorno usando uma conexão mock de PostgreSQL.
+    /// </summary>
     protected override int ExecuteNonQuery(
         NpgsqlDbMock db,
         string sql)

--- a/src/DbSqlLikeMem.Npgsql.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/StoredProcedureSignatureTests.cs
@@ -1,8 +1,20 @@
 namespace DbSqlLikeMem.Npgsql.Test;
 
+/// <summary>
+/// EN: Verifies stored procedure signature behavior for PostgreSQL.
+/// PT: Verifica o comportamento de assinatura de procedures para PostgreSQL.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class StoredProcedureSignatureTests(
         ITestOutputHelper helper
     ) : StoredProcedureSignatureTestsBase<NpgsqlMockException>(helper)
 {
+    /// <summary>
+    /// EN: Creates the PostgreSQL connection mock used in tests.
+    /// PT: Cria o mock de conexão PostgreSQL usado nos testes.
+    /// </summary>
     protected override DbConnectionMockBase CreateConnection() => new NpgsqlConnectionMock();
 }

--- a/src/DbSqlLikeMem.Sqlite.Test/CsvLoaderAndIndexTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/CsvLoaderAndIndexTests.cs
@@ -1,8 +1,20 @@
 namespace DbSqlLikeMem.Sqlite.Test;
 
+/// <summary>
+/// EN: Provides SQLite-specific coverage for CSV loading and index behaviors.
+/// PT: Fornece cobertura específica de SQLite para comportamentos de carregamento de CSV e índices.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class CsvLoaderAndIndexTests(
     ITestOutputHelper helper
     ) : CsvLoaderAndIndexTestBase<SqliteDbMock, SqliteMockException>(helper)
 {
+    /// <summary>
+    /// EN: Creates a new SQLite mock database for each scenario.
+    /// PT: Cria um novo banco mock de SQLite para cada cenário.
+    /// </summary>
     protected override SqliteDbMock CreateDb() => new();
 }

--- a/src/DbSqlLikeMem.Sqlite.Test/ExistsTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/ExistsTests.cs
@@ -1,8 +1,20 @@
 namespace DbSqlLikeMem.Sqlite.Test;
 
+/// <summary>
+/// EN: Validates EXISTS and NOT EXISTS semantics for SQLite.
+/// PT: Valida a semântica de EXISTS e NOT EXISTS para SQLite.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class ExistsTests(
         ITestOutputHelper helper
     ) : ExistsTestsBase(helper)
 {
+    /// <summary>
+    /// EN: Creates the SQLite connection mock used in tests.
+    /// PT: Cria o mock de conexão SQLite usado nos testes.
+    /// </summary>
     protected override DbConnectionMockBase CreateConnection() => new SqliteConnectionMock();
 }

--- a/src/DbSqlLikeMem.Sqlite.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SelectIntoInsertSelectUpdateDeleteFromSelectTests.cs
@@ -1,11 +1,27 @@
 namespace DbSqlLikeMem.Sqlite.Test;
 
+/// <summary>
+/// EN: Exercises select-into, insert-select, update, and delete-from-select flows for SQLite.
+/// PT: Exercita fluxos de select-into, insert-select, update e delete-from-select para SQLite.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class SelectIntoInsertSelectUpdateDeleteFromSelectTests(
         ITestOutputHelper helper
     ) : SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase<SqliteDbMock>(helper)
 {
+    /// <summary>
+    /// EN: Creates a new SQLite mock database for each scenario.
+    /// PT: Cria um novo banco mock de SQLite para cada cenário.
+    /// </summary>
     protected override SqliteDbMock CreateDb() => new();
 
+    /// <summary>
+    /// EN: Executes a non-query command using a SQLite mock connection.
+    /// PT: Executa um comando sem retorno usando uma conexão mock de SQLite.
+    /// </summary>
     protected override int ExecuteNonQuery(
         SqliteDbMock db,
         string sql)

--- a/src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs
@@ -1,8 +1,20 @@
 namespace DbSqlLikeMem.Sqlite.Test;
 
+/// <summary>
+/// EN: Verifies stored procedure signature behavior for SQLite.
+/// PT: Verifica o comportamento de assinatura de procedures para SQLite.
+/// </summary>
+/// <param name="helper">
+/// EN: Output helper used by the test base.
+/// PT: Helper de saída usado pela base de testes.
+/// </param>
 public sealed class StoredProcedureSignatureTests(
         ITestOutputHelper helper
     ) : StoredProcedureSignatureTestsBase<SqliteMockException>(helper)
 {
+    /// <summary>
+    /// EN: Creates the SQLite connection mock used in tests.
+    /// PT: Cria o mock de conexão SQLite usado nos testes.
+    /// </summary>
     protected override DbConnectionMockBase CreateConnection() => new SqliteConnectionMock();
 }


### PR DESCRIPTION
### Motivation
- Reduce CS1591 warnings by adding XML documentation to DB-specific test wrapper classes and their members. 
- Follow the existing documentation pattern with English first and Portuguese second for consistency across test projects. 
- Provide concise docs for the constructor `helper` parameter and the protected overrides used by the tests to improve maintainability.

### Description
- Added bilingual XML `<summary>` blocks to wrapper classes in `DbSqlLikeMem.MySql.Test`, `DbSqlLikeMem.Npgsql.Test`, and `DbSqlLikeMem.Sqlite.Test`. 
- Documented the primary constructor parameter `helper` for each wrapper using `/// <param name="helper">`. 
- Added XML summaries to overridden members flagged by CS1591, including `CreateDb`, `CreateConnection`, `ExecuteNonQuery`, and `DeleteJoinDerivedSelectSql`. 
- Changes touch the CSV loader, EXISTS semantics, select/insert/update/delete flows, and stored-procedure signature test wrappers across the three DB-specific test projects.

### Testing
- Attempted to run a build with `dotnet build` for `DbSqlLikeMem.MySql.Test`, but the `dotnet` CLI is not available in the current environment, so the build could not be executed. 
- No automated tests were run successfully due to the missing `dotnet` tool in the container environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996674a186c832ca77cc11b672d0fc9)