### PR TITLE
feat(vs-extension): extrair cenários de teste por dados filtrados

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowControl.xaml
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/DbSqlLikeMemToolWindowControl.xaml
@@ -67,6 +67,7 @@
                     <MenuItem x:Name="GenerateModelClassesMenuItem" Header="Gerar classes de modelos" Click="OnGenerateModelClassesClick" />
                     <MenuItem x:Name="GenerateRepositoryClassesMenuItem" Header="Gerar classes de repositório" Click="OnGenerateRepositoryClassesClick" />
                     <MenuItem x:Name="CheckConsistencyMenuItem" Header="Checar consistência" Click="OnCheckConsistencyClick" />
+                    <MenuItem x:Name="ExtractScenarioMenuItem" Header="Extrair cenário de teste" Click="OnExtractScenarioClick" />
                 </ContextMenu>
             </TreeView.ContextMenu>
         </TreeView>

--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/TestScenarioDialog.xaml
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/TestScenarioDialog.xaml
@@ -1,0 +1,60 @@
+<Window x:Class="DbSqlLikeMem.VisualStudioExtension.UI.TestScenarioDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Extrair cenário de teste"
+        Height="620"
+        Width="960"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="2*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock VerticalAlignment="Center" Text="Nome do cenário:" Margin="0,0,8,0" />
+            <TextBox x:Name="ScenarioNameTextBox" Grid.Column="1" Margin="0,0,12,0" MinWidth="220" />
+            <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="Tabela:" Margin="0,0,8,0" />
+            <ComboBox x:Name="TableComboBox" Grid.Column="3" DisplayMemberPath="DisplayName" />
+        </Grid>
+
+        <Grid Grid.Row="1" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock VerticalAlignment="Center" Text="Filtro SQL (WHERE):" Margin="0,0,8,0" />
+            <TextBox x:Name="FilterTextBox" Grid.Column="1" Margin="0,0,12,0" />
+            <CheckBox x:Name="IncludeParentsCheckBox" Grid.Column="2" VerticalAlignment="Center" Content="Incluir dados de tabelas pai (FK)" Margin="0,0,12,0" />
+            <Button Grid.Column="3" Content="Carregar dados" Padding="12,4" Click="OnLoadDataClick" />
+        </Grid>
+
+        <WrapPanel Grid.Row="2" Margin="0,0,0,8">
+            <Button Content="Marcar todos" Padding="12,4" Margin="0,0,8,0" Click="OnSelectAllClick" />
+            <Button Content="Desmarcar todos" Padding="12,4" Margin="0,0,8,0" Click="OnClearSelectionClick" />
+        </WrapPanel>
+
+        <DataGrid x:Name="RowsGrid"
+                  Grid.Row="3"
+                  AutoGenerateColumns="True"
+                  CanUserAddRows="False"
+                  SelectionMode="Extended"
+                  IsReadOnly="False" />
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Extrair cenário" Padding="14,5" Margin="0,0,8,0" Click="OnExtractClick" />
+            <Button Content="Fechar" Padding="14,5" Click="OnCloseClick" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/DbSqlLikeMem.VisualStudioExtension/UI/TestScenarioDialog.xaml.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension/UI/TestScenarioDialog.xaml.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace DbSqlLikeMem.VisualStudioExtension.UI;
+
+public partial class TestScenarioDialog : Window
+{
+    public event Func<Task>? LoadDataRequested;
+    public event Func<Task>? ExtractRequested;
+
+    public string ScenarioName => ScenarioNameTextBox.Text.Trim();
+    public DbSqlLikeMemToolWindowViewModel.ScenarioTableOption? SelectedTable => TableComboBox.SelectedItem as DbSqlLikeMemToolWindowViewModel.ScenarioTableOption;
+    public string FilterText => FilterTextBox.Text.Trim();
+    public bool IncludeParentReferences => IncludeParentsCheckBox.IsChecked == true;
+
+    public TestScenarioDialog(IReadOnlyCollection<DbSqlLikeMemToolWindowViewModel.ScenarioTableOption> tables)
+    {
+        InitializeComponent();
+        TableComboBox.ItemsSource = tables;
+        TableComboBox.SelectedIndex = tables.Count > 0 ? 0 : -1;
+    }
+
+    public void SetPreselectedTable(string schema, string table)
+    {
+        foreach (var item in TableComboBox.Items)
+        {
+            if (item is DbSqlLikeMemToolWindowViewModel.ScenarioTableOption option
+                && string.Equals(option.Schema, schema, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(option.TableName, table, StringComparison.OrdinalIgnoreCase))
+            {
+                TableComboBox.SelectedItem = option;
+                break;
+            }
+        }
+    }
+
+    public void SetRows(DataTable dataTable)
+    {
+        RowsGrid.ItemsSource = dataTable.DefaultView;
+        if (RowsGrid.Columns.Count > 0)
+        {
+            RowsGrid.Columns[0].DisplayIndex = 0;
+            RowsGrid.Columns[0].Width = 90;
+        }
+    }
+
+    public void SetBusy(bool isBusy)
+    {
+        Cursor = isBusy ? System.Windows.Input.Cursors.Wait : null;
+        IsEnabled = !isBusy;
+    }
+
+    public List<IReadOnlyDictionary<string, object?>> GetSelectedRows()
+    {
+        var selected = new List<IReadOnlyDictionary<string, object?>>();
+        if (RowsGrid.ItemsSource is not DataView view)
+        {
+            return selected;
+        }
+
+        foreach (DataRowView rowView in view)
+        {
+            if (rowView.Row.Field<bool>("_Selected") != true)
+            {
+                continue;
+            }
+
+            var data = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            foreach (DataColumn column in view.Table.Columns)
+            {
+                if (column.ColumnName == "_Selected")
+                {
+                    continue;
+                }
+
+                var value = rowView.Row[column.ColumnName];
+                data[column.ColumnName] = value == DBNull.Value ? null : value;
+            }
+
+            selected.Add(data);
+        }
+
+        return selected;
+    }
+
+    private void OnLoadDataClick(object sender, RoutedEventArgs e)
+        => _ = LoadDataRequested?.Invoke();
+
+    private void OnExtractClick(object sender, RoutedEventArgs e)
+        => _ = ExtractRequested?.Invoke();
+
+    private void OnCloseClick(object sender, RoutedEventArgs e)
+        => Close();
+
+    private void OnSelectAllClick(object sender, RoutedEventArgs e)
+        => SetSelection(true);
+
+    private void OnClearSelectionClick(object sender, RoutedEventArgs e)
+        => SetSelection(false);
+
+    private void SetSelection(bool selected)
+    {
+        if (RowsGrid.ItemsSource is not DataView view)
+        {
+            return;
+        }
+
+        foreach (DataRowView rowView in view)
+        {
+            rowView.Row["_Selected"] = selected;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Permitir ao usuário criar cenários de teste a partir de dados reais do banco selecionando tabela, aplicando filtro SQL e marcando linhas para extração.
- Fornecer opção de incluir dados de referências (FK) das tabelas pai quando desejado. 
- Integrar esse fluxo na árvore da extensão do Visual Studio para facilitar a reprodução de cenários em testes automatizados.

### Description
- Adiciona o diálogo WPF `TestScenarioDialog` com campos de nome, seleção de tabela, filtro (WHERE), grid de preview, botões para marcar/desmarcar linhas e ação de extração. (arquivos adicionados: `TestScenarioDialog.xaml` e `TestScenarioDialog.xaml.cs`).
- Inclui item de contexto `Extrair cenário de teste` na árvore da extensão e implementa o fluxo no code-behind (`DbSqlLikeMemToolWindowControl.xaml` / `.xaml.cs`) para abrir o diálogo, carregar preview, permitir seleção e disparar a extração.
- Estende o ViewModel (`DbSqlLikeMemToolWindowViewModel.cs`) com: `ScenarioTableOption` record; `ListScenarioTablesAsync`, `PreviewScenarioRowsAsync`, `ExtractScenarioAsync` e `LoadParentRowsByForeignKeysAsync`; mais helpers para montar queries limitadas por dialeto, quote de identificadores e formatação de literais; e serialização do cenário em JSON gravado em `%LocalAppData%/DbSqlLikeMem/Scenarios`.

### Testing
- `dotnet build` foi tentado (`dotnet build src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj`) e falhou no ambiente atual porque o comando `dotnet` não está disponível. (falha)
- `msbuild -version` foi tentado e falhou porque `msbuild` não está disponível no ambiente atual. (falha)
- Nenhum teste automatizado do projeto pôde ser executado neste ambiente; a alteração foi compilada localmente não verificável aqui por falta das ferramentas de build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69966a0046a8832ca6c4b35d9a213c21)