### PR TITLE
fix: configure FUNDING.yml with christianulson GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
-github: [afonsoft]
+# Funding links displayed in the repository Sponsor button.
+github: [christianulson]
 custom: ["https://buymeacoffee.com/chrisulson"]


### PR DESCRIPTION
### Motivation
- Replace the invalid `github: [afonsoft]` entry so the repository funding config validates and use the repository owner's GitHub Sponsors handle `christianulson` while preserving the external support link.

### Description
- Update `.github/FUNDING.yml` to add a descriptive comment, set `github: [christianulson]`, and keep `custom: ["https://buymeacoffee.com/chrisulson"]`.

### Testing
- Ran `nl -ba .github/FUNDING.yml`, `git status --short`, and created a commit with message `fix: configure funding to use christianulson GitHub Sponsors`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967cfed038832c8ea4dd1b39a2fcf4)