### PR TITLE
feat(vscode-extension): sincronizar menus de contexto por nível da TreeView

### DIFF
--- a/src/DbSqlLikeMem.VsCodeExtension/README.md
+++ b/src/DbSqlLikeMem.VsCodeExtension/README.md
@@ -6,11 +6,13 @@ Extensão equivalente ao fluxo desenhado para o Visual Studio Extension Core, ad
 
 - Sidebar própria **DbSqlLikeMem** na Activity Bar.
 - Cadastro de conexões (persistidas no `globalState` da extensão).
+- Validação de conexão ao adicionar/editar (com tentativa real para `SqlServer` via `sqlcmd`).
 - TreeView por:
   - Tipo de banco
   - Database
   - Tipo do objeto (`Table`, `View`, `Procedure`)
   - Objeto (`schema.nome`)
+  - Colunas e Foreign Keys (para tabelas SQL Server)
 - Filtro por modo `Like` e `Equals`.
 - Interface gráfica (Manager) para cadastrar/editar/remover conexões e configurar mapeamentos.
 - Configuração de mapeamentos por tipo de objeto (`Table`, `View`, `Procedure`) também no menu de contexto do nó do database.
@@ -19,6 +21,8 @@ Extensão equivalente ao fluxo desenhado para o Visual Studio Extension Core, ad
 - Geração de classes de **repositório** a partir de template com tokens, com prévia de conflitos (sobrescrita).
 - Configuração de templates (botão no topo da view) para modelos e repositórios.
 - Check de consistência para artefatos gerados (teste/model/repositório), com status visual por objeto na árvore.
+- Ações de geração/consistência respeitam o nó selecionado da TreeView (`Database`, `ObjectType` ou objeto individual).
+- Menus de contexto de geração/consistência disponíveis em todos os níveis relevantes da árvore (tipo de banco, database, tipo de objeto, objeto e detalhes como colunas/FKs).
 - Exportação/importação do estado em JSON.
 
 > Atualmente o provedor de metadata é **fake** (retorna objetos fixos) para validar UX e workflow. O próximo passo é substituir pelo provider real por banco.
@@ -122,6 +126,7 @@ Os templates de Model e Repository aceitam os seguintes tokens para substituiç�
 - `{{ObjectType}}`
 - `{{DatabaseType}}`
 - `{{DatabaseName}}`
+- `{{Namespace}}` (quando definido no mapeamento do tipo de objeto)
 
 ### Exemplo rápido de template
 

--- a/src/DbSqlLikeMem.VsCodeExtension/package.json
+++ b/src/DbSqlLikeMem.VsCodeExtension/package.json
@@ -148,6 +148,16 @@
           "command": "dbSqlLikeMem.configureTemplates",
           "when": "view == dbSqlLikeMem.connections",
           "group": "navigation"
+        },
+        {
+          "command": "dbSqlLikeMem.exportState",
+          "when": "view == dbSqlLikeMem.connections",
+          "group": "navigation@8"
+        },
+        {
+          "command": "dbSqlLikeMem.importState",
+          "when": "view == dbSqlLikeMem.connections",
+          "group": "navigation@9"
         }
       ],
       "view/item/context": [
@@ -220,7 +230,7 @@
         {
           "command": "dbSqlLikeMem.checkConsistency",
           "when": "view == dbSqlLikeMem.connections && viewItem == db-objectType",
-          "group": "inline@1",
+          "group": "inline@3",
           "icon": {
             "id": "check"
           }
@@ -252,6 +262,150 @@
         {
           "command": "dbSqlLikeMem.checkConsistency",
           "when": "view == dbSqlLikeMem.connections && viewItem == db-object",
+          "group": "inline@3",
+          "icon": {
+            "id": "check"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateModelClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-objectType",
+          "group": "inline@1",
+          "icon": {
+            "id": "symbol-class"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateRepositoryClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-objectType",
+          "group": "inline@2",
+          "icon": {
+            "id": "repo"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-dbType",
+          "group": "inline@0",
+          "icon": {
+            "id": "gear"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateModelClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-dbType",
+          "group": "inline@1",
+          "icon": {
+            "id": "symbol-class"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateRepositoryClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-dbType",
+          "group": "inline@2",
+          "icon": {
+            "id": "repo"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.checkConsistency",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-dbType",
+          "group": "inline@3",
+          "icon": {
+            "id": "check"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-section",
+          "group": "inline@0",
+          "icon": {
+            "id": "gear"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateModelClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-section",
+          "group": "inline@1",
+          "icon": {
+            "id": "symbol-class"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateRepositoryClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-section",
+          "group": "inline@2",
+          "icon": {
+            "id": "repo"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.checkConsistency",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-section",
+          "group": "inline@3",
+          "icon": {
+            "id": "check"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-column",
+          "group": "inline@0",
+          "icon": {
+            "id": "gear"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateModelClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-column",
+          "group": "inline@1",
+          "icon": {
+            "id": "symbol-class"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateRepositoryClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-column",
+          "group": "inline@2",
+          "icon": {
+            "id": "repo"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.checkConsistency",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-column",
+          "group": "inline@3",
+          "icon": {
+            "id": "check"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-foreignKey",
+          "group": "inline@0",
+          "icon": {
+            "id": "gear"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateModelClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-foreignKey",
+          "group": "inline@1",
+          "icon": {
+            "id": "symbol-class"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.generateRepositoryClasses",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-foreignKey",
+          "group": "inline@2",
+          "icon": {
+            "id": "repo"
+          }
+        },
+        {
+          "command": "dbSqlLikeMem.checkConsistency",
+          "when": "view == dbSqlLikeMem.connections && viewItem == db-foreignKey",
           "group": "inline@3",
           "icon": {
             "id": "check"


### PR DESCRIPTION
### Motivation
- Garantir que ações de geração/consistência sejam disponíveis e funcionem corretamente em todos os níveis relevantes da TreeView (incluindo seções de detalhes como `section`, `column` e `foreignKey`).
- Evitar que comandos acionados em nós de detalhe atuem por fallback sobre toda a conexão em vez de no objeto pai.
- Enriquecer o provedor de metadata para expor colunas e foreign keys e permitir validação ativa da conexão ao salvar/editar/adicionar conexões.

### Description
- Adicionados itens de menu de contexto em `package.json` para `db-section`, `db-column` e `db-foreignKey` com os mesmos comandos de geração/consistência já disponíveis nos outros níveis. 
- `TreeNode` ganhou os tipos `section|column|foreignKey` com `contextValue`/ícones correspondentes, e `createObjectChildren(...)` agora gera nós de seção contendo `connectionId` e `objectRef` para permitir resolução de contexto. 
- `getScopedObjects(...)` passa a tratar `section`, `column` e `foreignKey` como escopo do objeto pai quando `objectRef` está presente, evitando execução ampla indevida; chamadas de geração/checagem usam essa função para obter o conjunto correto de objetos. 
- `SqlMetadataProvider` foi estendido para buscar e anexar `columns` e `foreignKeys` (novas interfaces `DatabaseColumnReference` e `ForeignKeyReference`), com parsing via `parsePipeRows`, ordenação de colunas, e métodos reutilizáveis `executeSqlCmd`/`testConnection`; também foi adicionada a função `validateAndNotifyConnection` usada ao adicionar/editar conexões. 
- Geração de arquivos: `generateClassTemplate(...)` agora aceita `namespace` e encapsula o corpo em `namespace ... { }` quando fornecido (com `indentMultiline`), `GenerationPlan` passou a suportar `namespace`, e os geradores de `model`/`repository` injetam o token `{{Namespace}}` no template; comandos `generateModelClasses`/`generateRepositoryClasses` agora aceitam o `item` selecionado. 
- Atualizado `README.md` para documentar menus por nível e o token `{{Namespace}}` nos templates. 

### Testing
- Executado `cd src/DbSqlLikeMem.VsCodeExtension && npm run compile` e a compilação TypeScript completou com sucesso. 
- Executado `cd src/DbSqlLikeMem.VsCodeExtension && npm run lint` (TypeScript `--noEmit`) e não foram encontrados erros de lint/compilação.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699678259980832ca805609f00bbd2ab)