### PR TITLE
Add PIVOT parsing/execution and window-function support; fix EvalRow.GetByName compile error

### DIFF
--- a/docs/gap-tests-technical-backlog.md
+++ b/docs/gap-tests-technical-backlog.md
@@ -11,14 +11,18 @@ Prioridade calculada por cobertura de providers + risco de regressão - esforço
 | Prioridade | Título | Provider(s) | Esforço | Risco de regressão | Dependências técnicas |
 |---|---|---|---|---|---|
 | P0 | Cast StringToInt | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Alto | AST + precedência de operadores |
+| P0 | Regexp NotOperator | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | AST + precedência de operadores |
 | P0 | Regexp Operator | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | AST + precedência de operadores |
-| P0 | Union | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | AST + precedência de operadores; Normalização de schemas em set operators |
-| P1 | Where OR | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | AST + precedência de operadores |
-| P1 | Cte With | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | G | Médio | AST + precedência de operadores; Suporte a CTE no parser + binding |
-| P1 | Union Inside SubSelect | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | G | Médio | AST + precedência de operadores; Normalização de schemas em set operators |
+| P1 | Union | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | AST + precedência de operadores; Normalização de schemas em set operators |
+| P1 | Union All | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | AST + precedência de operadores; Normalização de schemas em set operators |
+| P1 | Union All Inside SubSelect | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | AST + precedência de operadores; Normalização de schemas em set operators |
+| P2 | Where OR | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | AST + precedência de operadores |
+| P2 | Union Inside SubSelect | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | G | Médio | AST + precedência de operadores; Normalização de schemas em set operators |
 | P2 | Where ParenthesesGrouping | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Baixo | AST + precedência de operadores |
 | P2 | Where Precedence AND ShouldBindStrongerThan OR | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Baixo | AST + precedência de operadores |
+| P2 | Cte With | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Médio | AST + precedência de operadores; Suporte a CTE no parser + binding |
 | P2 | Cast StringToInt NumberType | Oracle | M | Alto | AST + precedência de operadores |
+| P2 | Cte With ShouldRespectVersion | MySQL | G | Médio | AST + precedência de operadores; Suporte a CTE no parser + binding |
 
 ## Épico: Executor
 
@@ -28,12 +32,33 @@ Prioridade calculada por cobertura de providers + risco de regressão - esforço
 | P0 | Distinct ShouldBeConsistent | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | Planejador de execução em memória |
 | P0 | GroupBy Having ShouldSupportAggregates | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | Planejador de execução em memória; Pipeline de agregação + HAVING |
 | P1 | Join ComplexOn WithOr | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória |
+| P1 | Like NotOperator | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | Planejador de execução em memória |
 | P1 | OrderBy Field Function | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | Planejador de execução em memória |
-| P1 | OrderBy ShouldSupportAlias And Ordinal | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | Planejador de execução em memória |
+| P2 | OrderBy ShouldSupportAlias And Ordinal | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | M | Médio | Planejador de execução em memória |
 | P2 | Select Expressions Arithmetic | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | P | Baixo | Planejador de execução em memória |
-| P2 | Window RowNumber PartitionBy | DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window FirstValue And LastValue | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Lag And Lead | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Lag And NthValue WithExpressionOffset | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Lag Lead WithZeroOffset ShouldReturnCurrentRow | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window NthValue | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Ntile | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Ntile WithExpressionBuckets | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window PercentRank And CumeDist | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Rank And DenseRank | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window RowNumber PartitionBy | DB2, Oracle, PostgreSQL, SQL Server, SQLite | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Pivot Count ByTenant | Oracle, SQL Server | P | Baixo | Planejador de execução em memória |
 | P2 | Date Function WithModifier | SQLite | P | Baixo | Planejador de execução em memória |
 | P2 | TimestampAdd Day | DB2 | P | Baixo | Planejador de execução em memória |
+| P2 | Window FirstValue And LastValue ShouldRespectVersion | MySQL | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Lag And Lead ShouldRespectVersion | MySQL | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Lag And NthValue WithExpressionOffset ShouldRespectVersion | MySQL | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Lag Lead WithZeroOffset ShouldRespectVersion | MySQL | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window NthValue ShouldRespectVersion | MySQL | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Ntile ShouldRespectVersion | MySQL | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Ntile WithExpressionBuckets ShouldRespectVersion | MySQL | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window PercentRank And CumeDist ShouldRespectVersion | MySQL | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window Rank And DenseRank ShouldRespectVersion | MySQL | G | Alto | Planejador de execução em memória; Engine de funções de janela |
+| P2 | Window RowNumber PartitionBy ShouldRespectVersion | MySQL | G | Alto | Planejador de execução em memória; Engine de funções de janela |
 
 ## Épico: Funções SQL
 
@@ -60,26 +85,51 @@ Prioridade calculada por cobertura de providers + risco de regressão - esforço
 
 ### Parser
 - [ ] **Cast StringToInt**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Alto`  Dependências: AST + precedência de operadores
+- [ ] **Regexp NotOperator**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: AST + precedência de operadores
 - [ ] **Regexp Operator**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: AST + precedência de operadores
 - [ ] **Union**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: AST + precedência de operadores; Normalização de schemas em set operators
+- [ ] **Union All**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: AST + precedência de operadores; Normalização de schemas em set operators
+- [ ] **Union All Inside SubSelect**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: AST + precedência de operadores; Normalização de schemas em set operators
 - [ ] **Where OR**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: AST + precedência de operadores
-- [ ] **Cte With**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Médio`  Dependências: AST + precedência de operadores; Suporte a CTE no parser + binding
 - [ ] **Union Inside SubSelect**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Médio`  Dependências: AST + precedência de operadores; Normalização de schemas em set operators
 - [ ] **Where ParenthesesGrouping**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Baixo`  Dependências: AST + precedência de operadores
 - [ ] **Where Precedence AND ShouldBindStrongerThan OR**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Baixo`  Dependências: AST + precedência de operadores
+- [ ] **Cte With**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Médio`  Dependências: AST + precedência de operadores; Suporte a CTE no parser + binding
 - [ ] **Cast StringToInt NumberType**  `providers: Oracle` · `esforço: M` · `risco: Alto`  Dependências: AST + precedência de operadores
+- [ ] **Cte With ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Médio`  Dependências: AST + precedência de operadores; Suporte a CTE no parser + binding
 
 ### Executor
 - [ ] **CorrelatedSubquery InSelectList**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Escopo de aliases em subquery correlata
 - [ ] **Distinct ShouldBeConsistent**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Planejador de execução em memória
 - [ ] **GroupBy Having ShouldSupportAggregates**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: Planejador de execução em memória; Pipeline de agregação + HAVING
 - [ ] **Join ComplexOn WithOr**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória
+- [ ] **Like NotOperator**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Planejador de execução em memória
 - [ ] **OrderBy Field Function**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: Planejador de execução em memória
 - [ ] **OrderBy ShouldSupportAlias And Ordinal**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: Planejador de execução em memória
 - [ ] **Select Expressions Arithmetic**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Planejador de execução em memória
-- [ ] **Window RowNumber PartitionBy**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window FirstValue And LastValue**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Lag And Lead**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Lag And NthValue WithExpressionOffset**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Lag Lead WithZeroOffset ShouldReturnCurrentRow**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window NthValue**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Ntile**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Ntile WithExpressionBuckets**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window PercentRank And CumeDist**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Rank And DenseRank**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window RowNumber PartitionBy**  `providers: DB2, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Pivot Count ByTenant**  `providers: Oracle, SQL Server` · `esforço: P` · `risco: Baixo`  Dependências: Planejador de execução em memória
 - [ ] **Date Function WithModifier**  `providers: SQLite` · `esforço: P` · `risco: Baixo`  Dependências: Planejador de execução em memória
 - [ ] **TimestampAdd Day**  `providers: DB2` · `esforço: P` · `risco: Baixo`  Dependências: Planejador de execução em memória
+- [ ] **Window FirstValue And LastValue ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Lag And Lead ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Lag And NthValue WithExpressionOffset ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Lag Lead WithZeroOffset ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window NthValue ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Ntile ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Ntile WithExpressionBuckets ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window PercentRank And CumeDist ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window Rank And DenseRank ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
+- [ ] **Window RowNumber PartitionBy ShouldRespectVersion**  `providers: MySQL` · `esforço: G` · `risco: Alto`  Dependências: Planejador de execução em memória; Engine de funções de janela
 
 ### Funções SQL
 - [ ] **DateAdd IntervalDay**  `providers: DB2, MySQL, Oracle, PostgreSQL, SQL Server, SQLite` · `esforço: M` · `risco: Médio`  Dependências: Registro/catálogo de funções por provider

--- a/docs/implementation-prompts.md
+++ b/docs/implementation-prompts.md
@@ -5,9 +5,6 @@
 Prompts prontos para colar em outras janelas e implementar as próximas features de maior uso no DbSqlLikeMem, cobrindo **MySQL, SQL Server, Oracle, PostgreSQL (Npgsql), SQLite e DB2**.
 
 > Dica: execute em ordem **P0 → P14**. Os prompts já incluem objetivo, escopo, critérios de aceite e validação.
-Prompts prontos para colar em outras janelas e implementar as próximas features de maior uso no DbSqlLikeMem, cobrindo **MySQL, SQL Server, Oracle, PostgreSQL (Npgsql), SQLite e DB2**.
-
-> Dica: execute em ordem **P0 → P6**. Os prompts já incluem objetivo, escopo, critérios de aceite e validação.
 
 ---
 

--- a/docs/p7-p10-implementation-plan.md
+++ b/docs/p7-p10-implementation-plan.md
@@ -12,51 +12,51 @@ Documento gerado por `scripts/generate_p7_p10_plan.py` para orientar implementa�
 
 | Provider | Arquivos de teste-alvo | Status |
 | --- | --- | --- |
-| MySQL | `src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/Strategy/MySqlDeleteStrategyTests.cs` | ✅ Done |
-| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs` | ✅ Done |
-| Oracle | `src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/Strategy/OracleDeleteStrategyTests.cs` | ✅ Done |
-| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs` | ✅ Done |
-| SQLite | `src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteDeleteStrategyTests.cs` | ✅ Done |
-| DB2 | `src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/Strategy/Db2UpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/Strategy/Db2DeleteStrategyTests.cs` | ✅ Done |
+| MySQL | `src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/Strategy/MySqlDeleteStrategyTests.cs` | ⬜ Pending |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs` | ⬜ Pending |
+| Oracle | `src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/Strategy/OracleDeleteStrategyTests.cs` | ⬜ Pending |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs` | ⬜ Pending |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteDeleteStrategyTests.cs` | ⬜ Pending |
+| DB2 | `src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/Strategy/Db2UpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/Strategy/Db2DeleteStrategyTests.cs` | ⬜ Pending |
 
 ## P8 (Paginação/ordenação)
 
 | Provider | Arquivos de teste-alvo | Status |
 | --- | --- | --- |
-| MySQL | `src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
-| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
-| Oracle | `src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
-| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
-| SQLite | `src/DbSqlLikeMem.Sqlite.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
-| DB2 | `src/DbSqlLikeMem.Db2.Test/Db2UnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
+| MySQL | `src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| Oracle | `src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| DB2 | `src/DbSqlLikeMem.Db2.Test/Db2UnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
 
 ## P9 (JSON)
 
 | Provider | Arquivos de teste-alvo | Status |
 | --- | --- | --- |
-| MySQL | `src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
-| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
-| Oracle | `src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
-| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
-| SQLite | `src/DbSqlLikeMem.Sqlite.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
-| DB2 | `src/DbSqlLikeMem.Db2.Test/Db2UnionLimitAndJsonCompatibilityTests.cs` | ✅ Done |
+| MySQL | `src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| Oracle | `src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| DB2 | `src/DbSqlLikeMem.Db2.Test/Db2UnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
 
 ## P10 (Procedures/OUT params)
 
 | Provider | Arquivos de teste-alvo | Status |
 | --- | --- | --- |
-| MySQL | `src/DbSqlLikeMem.MySql.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/StoredProcedureSignatureTests.cs` | ✅ Done |
-| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/StoredProcedureSignatureTests.cs` | ✅ Done |
-| Oracle | `src/DbSqlLikeMem.Oracle.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/StoredProcedureSignatureTests.cs` | ✅ Done |
-| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/StoredProcedureSignatureTests.cs` | ✅ Done |
-| SQLite | `src/DbSqlLikeMem.Sqlite.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs` | ✅ Done |
-| DB2 | `src/DbSqlLikeMem.Db2.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/StoredProcedureSignatureTests.cs` | ✅ Done |
+| MySQL | `src/DbSqlLikeMem.MySql.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
+| Oracle | `src/DbSqlLikeMem.Oracle.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
+| DB2 | `src/DbSqlLikeMem.Db2.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
 
 ## Checklist de saída por PR
 
-- [x] Parser e Dialect atualizados para o pilar.
-- [x] Executor atualizado para os casos do pilar.
+- [ ] Parser e Dialect atualizados para o pilar.
+- [ ] Executor atualizado para os casos do pilar.
 - [ ] Testes do provider alterado verdes.
 - [ ] Smoke tests dos demais providers sem regressão.
-- [x] Documentação de compatibilidade atualizada.
+- [ ] Documentação de compatibilidade atualizada.
 

--- a/src/DbSqlLikeMem.Db2.Test/Db2AdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2AdvancedSqlGapTests.cs
@@ -42,10 +42,6 @@ public sealed class Db2AdvancedSqlGapTests : XUnitTestBase
     /// EN: Tests Window_RowNumber_PartitionBy_ShouldWork behavior.
     /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
     /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
-    /// </summary>
     [Fact]
     [Trait("Category", "Db2AdvancedSqlGap")]
     public void Window_RowNumber_PartitionBy_ShouldWork()
@@ -60,12 +56,213 @@ ORDER BY tenantid, id").ToList();
     }
 
     /// <summary>
+    /// EN: Tests Window_Rank_And_DenseRank_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Rank_And_DenseRank_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_Rank_And_DenseRank_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid) AS rk,
+       DENSE_RANK() OVER (ORDER BY tenantid) AS dr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 3], [.. rows.Select(r => (int)r.rk)]);
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.dr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_Ntile_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(2) OVER (ORDER BY id) AS tile
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_PercentRank_And_CumeDist_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_PercentRank_And_CumeDist_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_PercentRank_And_CumeDist_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       PERCENT_RANK() OVER (ORDER BY tenantid) AS pr,
+       CUME_DIST() OVER (ORDER BY tenantid) AS cd
+FROM users
+ORDER BY id").ToList();
+
+        var pr = rows.Select(r => Convert.ToDouble(r.pr)).ToArray();
+        var cd = rows.Select(r => Convert.ToDouble(r.cd)).ToArray();
+
+        Assert.Equal([0d, 0d, 1d], pr);
+        Assert.True(Math.Abs(cd[0] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[1] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[2] - 1d) <= 1e-9);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_Lead_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_Lead_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_Lag_And_Lead_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id) OVER (ORDER BY id) AS prev_id,
+       LEAD(id, 1, 99) OVER (ORDER BY id) AS next_id
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([null, 1, 2], [.. rows.Select(r => (int?)r.prev_id)]);
+        Assert.Equal([2, 3, 99], [.. rows.Select(r => (int)r.next_id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_FirstValue_And_LastValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_FirstValue_And_LastValue_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_FirstValue_And_LastValue_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(name) OVER (ORDER BY id) AS first_name,
+       LAST_VALUE(name) OVER (ORDER BY id) AS last_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["John", "John", "John"], [.. rows.Select(r => (string)r.first_name)]);
+        Assert.Equal(["Jane", "Jane", "Jane"], [.. rows.Select(r => (string)r.last_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_NthValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_NthValue_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_NthValue_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTH_VALUE(name, 2) OVER (ORDER BY id) AS second_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.second_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow behavior.
+    /// PT: Testa o comportamento de Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 0, -1) OVER (ORDER BY id) AS lag0,
+       LEAD(id, 0, -1) OVER (ORDER BY id) AS lead0
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lag0)]);
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lead0)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Regexp_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Regexp_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Regexp_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT REGEXP '^J' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Like_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Like_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Like_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT LIKE 'J%' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 1 + 0, -1) OVER (ORDER BY id) AS lag_expr,
+       NTH_VALUE(name, 1 + 1) OVER (ORDER BY id) AS nth_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([-1, 1, 2], [.. rows.Select(r => (int)r.lag_expr)]);
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.nth_expr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_WithExpressionBuckets_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_WithExpressionBuckets_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_Ntile_WithExpressionBuckets_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(1 + 1) OVER (ORDER BY id) AS tile_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile_expr)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
-    /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
     /// </summary>
     [Fact]
     [Trait("Category", "Db2AdvancedSqlGap")]
@@ -84,10 +281,6 @@ ORDER BY u.id").ToList();
     /// EN: Tests DateAdd_IntervalDay_ShouldWork behavior.
     /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
     /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
-    /// </summary>
     [Fact]
     [Trait("Category", "Db2AdvancedSqlGap")]
     public void DateAdd_IntervalDay_ShouldWork()
@@ -105,10 +298,9 @@ ORDER BY id").ToList();
     }
 
 
-
     /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
+    /// EN: Tests TimestampAdd_Day_ShouldWork behavior.
+    /// PT: Testa o comportamento de TimestampAdd_Day_ShouldWork.
     /// </summary>
     [Fact]
     [Trait("Category", "Db2AdvancedSqlGap")]
@@ -130,10 +322,6 @@ ORDER BY id").ToList();
     /// EN: Tests Cast_StringToInt_ShouldWork behavior.
     /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
     /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
-    /// </summary>
     [Fact]
     [Trait("Category", "Db2AdvancedSqlGap")]
     public void Cast_StringToInt_ShouldWork()
@@ -146,10 +334,6 @@ ORDER BY id").ToList();
     /// <summary>
     /// EN: Tests Regexp_Operator_ShouldWork behavior.
     /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
-    /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
     /// </summary>
     [Fact]
     [Trait("Category", "Db2AdvancedSqlGap")]
@@ -165,10 +349,6 @@ ORDER BY id").ToList();
     /// EN: Tests OrderBy_Field_Function_ShouldWork behavior.
     /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
     /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
-    /// </summary>
     [Fact]
     [Trait("Category", "Db2AdvancedSqlGap")]
     public void OrderBy_Field_Function_ShouldWork()
@@ -180,10 +360,6 @@ ORDER BY id").ToList();
     /// <summary>
     /// EN: Tests Collation_CaseSensitivity_ShouldFollowColumnCollation behavior.
     /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
-    /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
     /// </summary>
     [Fact]
     [Trait("Category", "Db2AdvancedSqlGap")]

--- a/src/DbSqlLikeMem.Db2.Test/Db2SqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2SqlCompatibilityGapTests.cs
@@ -251,6 +251,24 @@ public sealed class Db2SqlCompatibilityGapTests : XUnitTestBase
     }
 
     /// <summary>
+    /// EN: Tests Union_All_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
+    public void Union_All_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users WHERE id = 1 " +
+            "UNION ALL " +
+            "SELECT id FROM users WHERE id = 1 " +
+            "ORDER BY id").ToList();
+
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests Union_Inside_SubSelect_ShouldWork behavior.
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
@@ -268,6 +286,26 @@ ORDER BY id
 ").ToList();
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id)]);
     }
+
+    /// <summary>
+    /// EN: Tests Union_All_Inside_SubSelect_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_Inside_SubSelect_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2SqlCompatibilityGap")]
+    public void Union_All_Inside_SubSelect_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT * FROM (
+SELECT id FROM users WHERE id = 1
+UNION ALL
+SELECT id FROM users WHERE id = 1
+) X
+ORDER BY id
+").ToList();
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
 
     /// <summary>
     /// EN: Tests Cte_With_ShouldWork behavior.

--- a/src/DbSqlLikeMem.MySql.Test/MySqlAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlAdvancedSqlGapTests.cs
@@ -77,6 +77,352 @@ ORDER BY tenantid, id").ToList();
     }
 
     /// <summary>
+    /// EN: Tests Window_Rank_And_DenseRank_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Rank_And_DenseRank_ShouldWork.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    [MemberDataMySqlVersion]
+    public void Window_Rank_And_DenseRank_ShouldRespectVersion(int version)
+    {
+        using var cnn = CreateConnection(version);
+        cnn.Open();
+
+        if (version < MySqlWindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid) AS rk,
+       DENSE_RANK() OVER (ORDER BY tenantid) AS dr
+FROM users
+ORDER BY id").ToList());
+            return;
+        }
+
+        var rows = cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid) AS rk,
+       DENSE_RANK() OVER (ORDER BY tenantid) AS dr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 3], [.. rows.Select(r => (int)r.rk)]);
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.dr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_ShouldWork.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    [MemberDataMySqlVersion]
+    public void Window_Ntile_ShouldRespectVersion(int version)
+    {
+        using var cnn = CreateConnection(version);
+        cnn.Open();
+
+        if (version < MySqlWindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(2) OVER (ORDER BY id) AS tile
+FROM users
+ORDER BY id").ToList());
+            return;
+        }
+
+        var rows = cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(2) OVER (ORDER BY id) AS tile
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_PercentRank_And_CumeDist_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_PercentRank_And_CumeDist_ShouldWork.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    [MemberDataMySqlVersion]
+    public void Window_PercentRank_And_CumeDist_ShouldRespectVersion(int version)
+    {
+        using var cnn = CreateConnection(version);
+        cnn.Open();
+
+        if (version < MySqlWindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                cnn.Query<dynamic>(@"
+SELECT id,
+       PERCENT_RANK() OVER (ORDER BY tenantid) AS pr,
+       CUME_DIST() OVER (ORDER BY tenantid) AS cd
+FROM users
+ORDER BY id").ToList());
+            return;
+        }
+
+        var rows = cnn.Query<dynamic>(@"
+SELECT id,
+       PERCENT_RANK() OVER (ORDER BY tenantid) AS pr,
+       CUME_DIST() OVER (ORDER BY tenantid) AS cd
+FROM users
+ORDER BY id").ToList();
+
+        var pr = rows.Select(r => Convert.ToDouble(r.pr)).ToArray();
+        var cd = rows.Select(r => Convert.ToDouble(r.cd)).ToArray();
+
+        Assert.Equal([0d, 0d, 1d], pr);
+        Assert.True(Math.Abs(cd[0] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[1] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[2] - 1d) <= 1e-9);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_Lead_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_Lead_ShouldWork.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    [MemberDataMySqlVersion]
+    public void Window_Lag_And_Lead_ShouldRespectVersion(int version)
+    {
+        using var cnn = CreateConnection(version);
+        cnn.Open();
+
+        if (version < MySqlWindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id) OVER (ORDER BY id) AS prev_id,
+       LEAD(id, 1, 99) OVER (ORDER BY id) AS next_id
+FROM users
+ORDER BY id").ToList());
+            return;
+        }
+
+        var rows = cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id) OVER (ORDER BY id) AS prev_id,
+       LEAD(id, 1, 99) OVER (ORDER BY id) AS next_id
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([null, 1, 2], [.. rows.Select(r => (int?)r.prev_id)]);
+        Assert.Equal([2, 3, 99], [.. rows.Select(r => (int)r.next_id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_FirstValue_And_LastValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_FirstValue_And_LastValue_ShouldWork.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    [MemberDataMySqlVersion]
+    public void Window_FirstValue_And_LastValue_ShouldRespectVersion(int version)
+    {
+        using var cnn = CreateConnection(version);
+        cnn.Open();
+
+        if (version < MySqlWindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(name) OVER (ORDER BY id) AS first_name,
+       LAST_VALUE(name) OVER (ORDER BY id) AS last_name
+FROM users
+ORDER BY id").ToList());
+            return;
+        }
+
+        var rows = cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(name) OVER (ORDER BY id) AS first_name,
+       LAST_VALUE(name) OVER (ORDER BY id) AS last_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["John", "John", "John"], [.. rows.Select(r => (string)r.first_name)]);
+        Assert.Equal(["Jane", "Jane", "Jane"], [.. rows.Select(r => (string)r.last_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_NthValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_NthValue_ShouldWork.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    [MemberDataMySqlVersion]
+    public void Window_NthValue_ShouldRespectVersion(int version)
+    {
+        using var cnn = CreateConnection(version);
+        cnn.Open();
+
+        if (version < MySqlWindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                cnn.Query<dynamic>(@"
+SELECT id,
+       NTH_VALUE(name, 2) OVER (ORDER BY id) AS second_name
+FROM users
+ORDER BY id").ToList());
+            return;
+        }
+
+        var rows = cnn.Query<dynamic>(@"
+SELECT id,
+       NTH_VALUE(name, 2) OVER (ORDER BY id) AS second_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.second_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow behavior.
+    /// PT: Testa o comportamento de Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    [MemberDataMySqlVersion]
+    public void Window_Lag_Lead_WithZeroOffset_ShouldRespectVersion(int version)
+    {
+        using var cnn = CreateConnection(version);
+        cnn.Open();
+
+        if (version < MySqlWindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 0, -1) OVER (ORDER BY id) AS lag0,
+       LEAD(id, 0, -1) OVER (ORDER BY id) AS lead0
+FROM users
+ORDER BY id").ToList());
+            return;
+        }
+
+        var rows = cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 0, -1) OVER (ORDER BY id) AS lag0,
+       LEAD(id, 0, -1) OVER (ORDER BY id) AS lead0
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lag0)]);
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lead0)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Regexp_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Regexp_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    public void Regexp_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT REGEXP '^J' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Like_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Like_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    public void Like_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT LIKE 'J%' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    [MemberDataMySqlVersion]
+    public void Window_Lag_And_NthValue_WithExpressionOffset_ShouldRespectVersion(int version)
+    {
+        using var cnn = CreateConnection(version);
+        cnn.Open();
+
+        if (version < MySqlWindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 1 + 0, -1) OVER (ORDER BY id) AS lag_expr,
+       NTH_VALUE(name, 1 + 1) OVER (ORDER BY id) AS nth_expr
+FROM users
+ORDER BY id").ToList());
+            return;
+        }
+
+        var rows = cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 1 + 0, -1) OVER (ORDER BY id) AS lag_expr,
+       NTH_VALUE(name, 1 + 1) OVER (ORDER BY id) AS nth_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([-1, 1, 2], [.. rows.Select(r => (int)r.lag_expr)]);
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.nth_expr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_WithExpressionBuckets_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_WithExpressionBuckets_ShouldWork.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "MySqlAdvancedSqlGap")]
+    [MemberDataMySqlVersion]
+    public void Window_Ntile_WithExpressionBuckets_ShouldRespectVersion(int version)
+    {
+        using var cnn = CreateConnection(version);
+        cnn.Open();
+
+        if (version < MySqlWindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(1 + 1) OVER (ORDER BY id) AS tile_expr
+FROM users
+ORDER BY id").ToList());
+            return;
+        }
+
+        var rows = cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(1 + 1) OVER (ORDER BY id) AS tile_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile_expr)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
     /// </summary>

--- a/src/DbSqlLikeMem.MySql.Test/MySqlSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlSqlCompatibilityGapTests.cs
@@ -256,6 +256,24 @@ public sealed class MySqlSqlCompatibilityGapTests : XUnitTestBase
     }
 
     /// <summary>
+    /// EN: Tests Union_All_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
+    public void Union_All_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users WHERE id = 1 " +
+            "UNION ALL " +
+            "SELECT id FROM users WHERE id = 1 " +
+            "ORDER BY id").ToList();
+
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests Union_Inside_SubSelect_ShouldWork behavior.
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
@@ -273,6 +291,26 @@ ORDER BY id
 ").ToList();
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id)]);
     }
+
+    /// <summary>
+    /// EN: Tests Union_All_Inside_SubSelect_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_Inside_SubSelect_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlSqlCompatibilityGap")]
+    public void Union_All_Inside_SubSelect_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT * FROM (
+SELECT id FROM users WHERE id = 1
+UNION ALL
+SELECT id FROM users WHERE id = 1
+) X
+ORDER BY id
+").ToList();
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
 
     /// <summary>
     /// EN: Tests Cte_With_ShouldWork behavior.

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlAdvancedSqlGapTests.cs
@@ -56,6 +56,211 @@ ORDER BY tenantid, id").ToList();
     }
 
     /// <summary>
+    /// EN: Tests Window_Rank_And_DenseRank_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Rank_And_DenseRank_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Window_Rank_And_DenseRank_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid) AS rk,
+       DENSE_RANK() OVER (ORDER BY tenantid) AS dr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 3], [.. rows.Select(r => (int)r.rk)]);
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.dr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Window_Ntile_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(2) OVER (ORDER BY id) AS tile
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_PercentRank_And_CumeDist_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_PercentRank_And_CumeDist_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Window_PercentRank_And_CumeDist_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       PERCENT_RANK() OVER (ORDER BY tenantid) AS pr,
+       CUME_DIST() OVER (ORDER BY tenantid) AS cd
+FROM users
+ORDER BY id").ToList();
+
+        var pr = rows.Select(r => Convert.ToDouble(r.pr)).ToArray();
+        var cd = rows.Select(r => Convert.ToDouble(r.cd)).ToArray();
+
+        Assert.Equal([0d, 0d, 1d], pr);
+        Assert.True(Math.Abs(cd[0] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[1] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[2] - 1d) <= 1e-9);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_Lead_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_Lead_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Window_Lag_And_Lead_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id) OVER (ORDER BY id) AS prev_id,
+       LEAD(id, 1, 99) OVER (ORDER BY id) AS next_id
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([null, 1, 2], [.. rows.Select(r => (int?)r.prev_id)]);
+        Assert.Equal([2, 3, 99], [.. rows.Select(r => (int)r.next_id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_FirstValue_And_LastValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_FirstValue_And_LastValue_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Window_FirstValue_And_LastValue_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(name) OVER (ORDER BY id) AS first_name,
+       LAST_VALUE(name) OVER (ORDER BY id) AS last_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["John", "John", "John"], [.. rows.Select(r => (string)r.first_name)]);
+        Assert.Equal(["Jane", "Jane", "Jane"], [.. rows.Select(r => (string)r.last_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_NthValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_NthValue_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Window_NthValue_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTH_VALUE(name, 2) OVER (ORDER BY id) AS second_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.second_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow behavior.
+    /// PT: Testa o comportamento de Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 0, -1) OVER (ORDER BY id) AS lag0,
+       LEAD(id, 0, -1) OVER (ORDER BY id) AS lead0
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lag0)]);
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lead0)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Regexp_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Regexp_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Regexp_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT REGEXP '^J' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Like_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Like_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Like_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT LIKE 'J%' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 1 + 0, -1) OVER (ORDER BY id) AS lag_expr,
+       NTH_VALUE(name, 1 + 1) OVER (ORDER BY id) AS nth_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([-1, 1, 2], [.. rows.Select(r => (int)r.lag_expr)]);
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.nth_expr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_WithExpressionBuckets_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_WithExpressionBuckets_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAdvancedSqlGap")]
+    public void Window_Ntile_WithExpressionBuckets_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(1 + 1) OVER (ORDER BY id) AS tile_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile_expr)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
     /// </summary>

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlSqlCompatibilityGapTests.cs
@@ -251,6 +251,24 @@ public sealed class PostgreSqlSqlCompatibilityGapTests : XUnitTestBase
     }
 
     /// <summary>
+    /// EN: Tests Union_All_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
+    public void Union_All_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users WHERE id = 1 " +
+            "UNION ALL " +
+            "SELECT id FROM users WHERE id = 1 " +
+            "ORDER BY id").ToList();
+
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests Union_Inside_SubSelect_ShouldWork behavior.
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
@@ -268,6 +286,26 @@ ORDER BY id
 ").ToList();
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id)]);
     }
+
+    /// <summary>
+    /// EN: Tests Union_All_Inside_SubSelect_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_Inside_SubSelect_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlSqlCompatibilityGap")]
+    public void Union_All_Inside_SubSelect_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT * FROM (
+SELECT id FROM users WHERE id = 1
+UNION ALL
+SELECT id FROM users WHERE id = 1
+) X
+ORDER BY id
+").ToList();
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
 
     /// <summary>
     /// EN: Tests Cte_With_ShouldWork behavior.

--- a/src/DbSqlLikeMem.Oracle.Test/OracleAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleAdvancedSqlGapTests.cs
@@ -57,6 +57,211 @@ ORDER BY tenantid, id").ToList();
     }
 
     /// <summary>
+    /// EN: Tests Window_Rank_And_DenseRank_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Rank_And_DenseRank_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Window_Rank_And_DenseRank_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid) AS rk,
+       DENSE_RANK() OVER (ORDER BY tenantid) AS dr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 3], [.. rows.Select(r => (int)r.rk)]);
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.dr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Window_Ntile_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(2) OVER (ORDER BY id) AS tile
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_PercentRank_And_CumeDist_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_PercentRank_And_CumeDist_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Window_PercentRank_And_CumeDist_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       PERCENT_RANK() OVER (ORDER BY tenantid) AS pr,
+       CUME_DIST() OVER (ORDER BY tenantid) AS cd
+FROM users
+ORDER BY id").ToList();
+
+        var pr = rows.Select(r => Convert.ToDouble(r.pr)).ToArray();
+        var cd = rows.Select(r => Convert.ToDouble(r.cd)).ToArray();
+
+        Assert.Equal([0d, 0d, 1d], pr);
+        Assert.True(Math.Abs(cd[0] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[1] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[2] - 1d) <= 1e-9);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_Lead_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_Lead_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Window_Lag_And_Lead_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id) OVER (ORDER BY id) AS prev_id,
+       LEAD(id, 1, 99) OVER (ORDER BY id) AS next_id
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([null, 1, 2], [.. rows.Select(r => (int?)r.prev_id)]);
+        Assert.Equal([2, 3, 99], [.. rows.Select(r => (int)r.next_id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_FirstValue_And_LastValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_FirstValue_And_LastValue_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Window_FirstValue_And_LastValue_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(name) OVER (ORDER BY id) AS first_name,
+       LAST_VALUE(name) OVER (ORDER BY id) AS last_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["John", "John", "John"], [.. rows.Select(r => (string)r.first_name)]);
+        Assert.Equal(["Jane", "Jane", "Jane"], [.. rows.Select(r => (string)r.last_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_NthValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_NthValue_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Window_NthValue_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTH_VALUE(name, 2) OVER (ORDER BY id) AS second_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.second_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow behavior.
+    /// PT: Testa o comportamento de Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 0, -1) OVER (ORDER BY id) AS lag0,
+       LEAD(id, 0, -1) OVER (ORDER BY id) AS lead0
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lag0)]);
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lead0)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Regexp_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Regexp_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Regexp_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT REGEXP '^J' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Like_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Like_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Like_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT LIKE 'J%' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 1 + 0, -1) OVER (ORDER BY id) AS lag_expr,
+       NTH_VALUE(name, 1 + 1) OVER (ORDER BY id) AS nth_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([-1, 1, 2], [.. rows.Select(r => (int)r.lag_expr)]);
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.nth_expr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_WithExpressionBuckets_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_WithExpressionBuckets_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Window_Ntile_WithExpressionBuckets_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(1 + 1) OVER (ORDER BY id) AS tile_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile_expr)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
     /// </summary>
@@ -159,6 +364,31 @@ ORDER BY id").ToList();
         // This is intentionally a gap test — decide the mock rule, then implement it consistently.
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name = 'john' ORDER BY id").ToList();
         Assert.Equal([1], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+
+    /// <summary>
+    /// EN: Tests Pivot_Count_ByTenant_ShouldWork behavior.
+    /// PT: Testa o comportamento de Pivot_Count_ByTenant_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAdvancedSqlGap")]
+    public void Pivot_Count_ByTenant_ShouldWork()
+    {
+        var row = _cnn.QuerySingle<dynamic>(@"
+SELECT t10, t20
+FROM (
+    SELECT tenantid, id
+    FROM users
+) src
+PIVOT (
+    COUNT(id)
+    FOR tenantid IN (10 AS t10, 20 AS t20)
+) p");
+
+        Assert.Equal(2, (int)row.t10);
+        Assert.Equal(1, (int)row.t20);
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.Oracle.Test/OracleSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleSqlCompatibilityGapTests.cs
@@ -252,6 +252,24 @@ public sealed class OracleSqlCompatibilityGapTests : XUnitTestBase
     }
 
     /// <summary>
+    /// EN: Tests Union_All_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
+    public void Union_All_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users WHERE id = 1 " +
+            "UNION ALL " +
+            "SELECT id FROM users WHERE id = 1 " +
+            "ORDER BY id").ToList();
+
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests Union_Inside_SubSelect_ShouldWork behavior.
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
@@ -269,6 +287,26 @@ ORDER BY id
 ").ToList();
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id)]);
     }
+
+    /// <summary>
+    /// EN: Tests Union_All_Inside_SubSelect_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_Inside_SubSelect_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleSqlCompatibilityGap")]
+    public void Union_All_Inside_SubSelect_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT * FROM (
+SELECT id FROM users WHERE id = 1
+UNION ALL
+SELECT id FROM users WHERE id = 1
+) X
+ORDER BY id
+").ToList();
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
 
     /// <summary>
     /// EN: Tests Cte_With_ShouldWork behavior.

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -155,6 +155,7 @@ public sealed class SqlQueryParserCorpusTests(
         yield return new object[] { "SELECT id, name FROM users ORDER BY 2 ASC, 1 DESC", "ORDER BY ordinal positions" };
 
         // CASE/COALESCE/CONCAT/IF/IFNULL/IIF
+        yield return new object[] { "SELECT t10, t20 FROM (SELECT tenantid, id FROM users) src PIVOT (COUNT(id) FOR tenantid IN (10 AS t10, 20 AS t20)) p", "PIVOT count by tenant" };
         yield return new object[] { "SELECT id, CASE WHEN email IS NULL THEN 0 ELSE 1 END AS hasEmail FROM users ORDER BY id", "CASE WHEN expression" };
         yield return new object[] { "SELECT id, COALESCE(email, 'none') AS em FROM users ORDER BY id", "COALESCE function" };
         yield return new object[] { "SELECT id, CONCAT(name, '#', id) AS tag FROM users ORDER BY id", "CONCAT function with mixed args" };

--- a/src/DbSqlLikeMem.Oracle/OracleDialect.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDialect.cs
@@ -77,6 +77,7 @@ internal sealed class OracleDialect : SqlDialectBase
     /// Auto-generated summary.
     /// </summary>
     public override bool SupportsMerge => Version >= MergeMinVersion;
+    public override bool SupportsPivotClause => true;
     public override IReadOnlyCollection<string> NullSubstituteFunctionNames => ["NVL"];
     public override bool ConcatReturnsNullOnNullInput => false;
 

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -154,6 +154,7 @@ public sealed class SqlQueryParserCorpusTests(
         yield return new object[] { "SELECT id, name FROM users ORDER BY 2 ASC, 1 DESC", "ORDER BY ordinal positions" };
 
         // CASE/COALESCE/CONCAT/IF/IFNULL/IIF
+        yield return new object[] { "SELECT t10, t20 FROM (SELECT tenantid, id FROM users) src PIVOT (COUNT(id) FOR tenantid IN (10 AS t10, 20 AS t20)) p", "PIVOT count by tenant" };
         yield return new object[] { "SELECT id, CASE WHEN email IS NULL THEN 0 ELSE 1 END AS hasEmail FROM users ORDER BY id", "CASE WHEN expression" };
         yield return new object[] { "SELECT id, COALESCE(email, 'none') AS em FROM users ORDER BY id", "COALESCE function" };
         yield return new object[] { "SELECT id, CONCAT(name, '#', id) AS tag FROM users ORDER BY id", "CONCAT function with mixed args" };

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerAdvancedSqlGapTests.cs
@@ -56,6 +56,211 @@ ORDER BY tenantid, id").ToList();
     }
 
     /// <summary>
+    /// EN: Tests Window_Rank_And_DenseRank_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Rank_And_DenseRank_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_Rank_And_DenseRank_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid) AS rk,
+       DENSE_RANK() OVER (ORDER BY tenantid) AS dr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 3], [.. rows.Select(r => (int)r.rk)]);
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.dr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_Ntile_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(2) OVER (ORDER BY id) AS tile
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_PercentRank_And_CumeDist_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_PercentRank_And_CumeDist_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_PercentRank_And_CumeDist_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       PERCENT_RANK() OVER (ORDER BY tenantid) AS pr,
+       CUME_DIST() OVER (ORDER BY tenantid) AS cd
+FROM users
+ORDER BY id").ToList();
+
+        var pr = rows.Select(r => Convert.ToDouble(r.pr)).ToArray();
+        var cd = rows.Select(r => Convert.ToDouble(r.cd)).ToArray();
+
+        Assert.Equal([0d, 0d, 1d], pr);
+        Assert.True(Math.Abs(cd[0] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[1] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[2] - 1d) <= 1e-9);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_Lead_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_Lead_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_Lag_And_Lead_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id) OVER (ORDER BY id) AS prev_id,
+       LEAD(id, 1, 99) OVER (ORDER BY id) AS next_id
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([null, 1, 2], [.. rows.Select(r => (int?)r.prev_id)]);
+        Assert.Equal([2, 3, 99], [.. rows.Select(r => (int)r.next_id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_FirstValue_And_LastValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_FirstValue_And_LastValue_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_FirstValue_And_LastValue_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(name) OVER (ORDER BY id) AS first_name,
+       LAST_VALUE(name) OVER (ORDER BY id) AS last_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["John", "John", "John"], [.. rows.Select(r => (string)r.first_name)]);
+        Assert.Equal(["Jane", "Jane", "Jane"], [.. rows.Select(r => (string)r.last_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_NthValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_NthValue_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_NthValue_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTH_VALUE(name, 2) OVER (ORDER BY id) AS second_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.second_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow behavior.
+    /// PT: Testa o comportamento de Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 0, -1) OVER (ORDER BY id) AS lag0,
+       LEAD(id, 0, -1) OVER (ORDER BY id) AS lead0
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lag0)]);
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lead0)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Regexp_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Regexp_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Regexp_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT REGEXP '^J' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Like_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Like_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Like_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT LIKE 'J%' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 1 + 0, -1) OVER (ORDER BY id) AS lag_expr,
+       NTH_VALUE(name, 1 + 1) OVER (ORDER BY id) AS nth_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([-1, 1, 2], [.. rows.Select(r => (int)r.lag_expr)]);
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.nth_expr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_WithExpressionBuckets_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_WithExpressionBuckets_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_Ntile_WithExpressionBuckets_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(1 + 1) OVER (ORDER BY id) AS tile_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile_expr)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
     /// </summary>
@@ -143,6 +348,31 @@ ORDER BY id").ToList();
         // This is intentionally a gap test — decide the mock rule, then implement it consistently.
         var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name = 'john' ORDER BY id").ToList();
         Assert.Equal([1], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+
+    /// <summary>
+    /// EN: Tests Pivot_Count_ByTenant_ShouldWork behavior.
+    /// PT: Testa o comportamento de Pivot_Count_ByTenant_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Pivot_Count_ByTenant_ShouldWork()
+    {
+        var row = _cnn.QuerySingle<dynamic>(@"
+SELECT t10, t20
+FROM (
+    SELECT tenantid, id
+    FROM users
+) src
+PIVOT (
+    COUNT(id)
+    FOR tenantid IN (10 AS t10, 20 AS t20)
+) p");
+
+        Assert.Equal(2, (int)row.t10);
+        Assert.Equal(1, (int)row.t20);
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerSqlCompatibilityGapTests.cs
@@ -251,6 +251,24 @@ public sealed class SqlServerSqlCompatibilityGapTests : XUnitTestBase
     }
 
     /// <summary>
+    /// EN: Tests Union_All_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
+    public void Union_All_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users WHERE id = 1 " +
+            "UNION ALL " +
+            "SELECT id FROM users WHERE id = 1 " +
+            "ORDER BY id").ToList();
+
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests Union_Inside_SubSelect_ShouldWork behavior.
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
@@ -268,6 +286,26 @@ ORDER BY id
 ").ToList();
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id)]);
     }
+
+    /// <summary>
+    /// EN: Tests Union_All_Inside_SubSelect_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_Inside_SubSelect_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerSqlCompatibilityGap")]
+    public void Union_All_Inside_SubSelect_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT * FROM (
+SELECT id FROM users WHERE id = 1
+UNION ALL
+SELECT id FROM users WHERE id = 1
+) X
+ORDER BY id
+").ToList();
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
 
     /// <summary>
     /// EN: Tests Cte_With_ShouldWork behavior.

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
@@ -89,6 +89,7 @@ internal sealed class SqlServerDialect : SqlDialectBase
     /// Auto-generated summary.
     /// </summary>
     public override bool SupportsMerge => Version >= MergeMinVersion;
+    public override bool SupportsPivotClause => true;
     public override bool SupportsSqlServerTableHints => true;
     public override IReadOnlyCollection<string> NullSubstituteFunctionNames => ["ISNULL"];
     public override bool ConcatReturnsNullOnNullInput => false;

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteAdvancedSqlGapTests.cs
@@ -42,10 +42,6 @@ public sealed class SqliteAdvancedSqlGapTests : XUnitTestBase
     /// EN: Tests Window_RowNumber_PartitionBy_ShouldWork behavior.
     /// PT: Testa o comportamento de Window_RowNumber_PartitionBy_ShouldWork.
     /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
-    /// </summary>
     [Fact]
     [Trait("Category", "SqliteAdvancedSqlGap")]
     public void Window_RowNumber_PartitionBy_ShouldWork()
@@ -60,12 +56,213 @@ ORDER BY tenantid, id").ToList();
     }
 
     /// <summary>
+    /// EN: Tests Window_Rank_And_DenseRank_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Rank_And_DenseRank_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_Rank_And_DenseRank_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid) AS rk,
+       DENSE_RANK() OVER (ORDER BY tenantid) AS dr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 3], [.. rows.Select(r => (int)r.rk)]);
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.dr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_Ntile_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(2) OVER (ORDER BY id) AS tile
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_PercentRank_And_CumeDist_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_PercentRank_And_CumeDist_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_PercentRank_And_CumeDist_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       PERCENT_RANK() OVER (ORDER BY tenantid) AS pr,
+       CUME_DIST() OVER (ORDER BY tenantid) AS cd
+FROM users
+ORDER BY id").ToList();
+
+        var pr = rows.Select(r => Convert.ToDouble(r.pr)).ToArray();
+        var cd = rows.Select(r => Convert.ToDouble(r.cd)).ToArray();
+
+        Assert.Equal([0d, 0d, 1d], pr);
+        Assert.True(Math.Abs(cd[0] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[1] - (2d / 3d)) <= 1e-9);
+        Assert.True(Math.Abs(cd[2] - 1d) <= 1e-9);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_Lead_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_Lead_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_Lag_And_Lead_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id) OVER (ORDER BY id) AS prev_id,
+       LEAD(id, 1, 99) OVER (ORDER BY id) AS next_id
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([null, 1, 2], [.. rows.Select(r => (int?)r.prev_id)]);
+        Assert.Equal([2, 3, 99], [.. rows.Select(r => (int)r.next_id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_FirstValue_And_LastValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_FirstValue_And_LastValue_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_FirstValue_And_LastValue_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(name) OVER (ORDER BY id) AS first_name,
+       LAST_VALUE(name) OVER (ORDER BY id) AS last_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["John", "John", "John"], [.. rows.Select(r => (string)r.first_name)]);
+        Assert.Equal(["Jane", "Jane", "Jane"], [.. rows.Select(r => (string)r.last_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_NthValue_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_NthValue_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_NthValue_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTH_VALUE(name, 2) OVER (ORDER BY id) AS second_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.second_name)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow behavior.
+    /// PT: Testa o comportamento de Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_Lag_Lead_WithZeroOffset_ShouldReturnCurrentRow()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 0, -1) OVER (ORDER BY id) AS lag0,
+       LEAD(id, 0, -1) OVER (ORDER BY id) AS lead0
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lag0)]);
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.lead0)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Regexp_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Regexp_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Regexp_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT REGEXP '^J' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Like_NotOperator_ShouldWork behavior.
+    /// PT: Testa o comportamento de Like_NotOperator_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Like_NotOperator_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>("SELECT id FROM users WHERE name NOT LIKE 'J%' ORDER BY id").ToList();
+        Assert.Equal([2], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_Lag_And_NthValue_WithExpressionOffset_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       LAG(id, 1 + 0, -1) OVER (ORDER BY id) AS lag_expr,
+       NTH_VALUE(name, 1 + 1) OVER (ORDER BY id) AS nth_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([-1, 1, 2], [.. rows.Select(r => (int)r.lag_expr)]);
+        Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.nth_expr)]);
+    }
+
+
+    /// <summary>
+    /// EN: Tests Window_Ntile_WithExpressionBuckets_ShouldWork behavior.
+    /// PT: Testa o comportamento de Window_Ntile_WithExpressionBuckets_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_Ntile_WithExpressionBuckets_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTILE(1 + 1) OVER (ORDER BY id) AS tile_expr
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.tile_expr)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests CorrelatedSubquery_InSelectList_ShouldWork behavior.
     /// PT: Testa o comportamento de CorrelatedSubquery_InSelectList_ShouldWork.
-    /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
     /// </summary>
     [Fact]
     [Trait("Category", "SqliteAdvancedSqlGap")]
@@ -84,10 +281,6 @@ ORDER BY u.id").ToList();
     /// EN: Tests DateAdd_IntervalDay_ShouldWork behavior.
     /// PT: Testa o comportamento de DateAdd_IntervalDay_ShouldWork.
     /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
-    /// </summary>
     [Fact]
     [Trait("Category", "SqliteAdvancedSqlGap")]
     public void DateAdd_IntervalDay_ShouldWork()
@@ -105,10 +298,9 @@ ORDER BY id").ToList();
     }
 
 
-
     /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
+    /// EN: Tests Date_Function_WithModifier_ShouldWork behavior.
+    /// PT: Testa o comportamento de Date_Function_WithModifier_ShouldWork.
     /// </summary>
     [Fact]
     [Trait("Category", "SqliteAdvancedSqlGap")]
@@ -130,10 +322,6 @@ ORDER BY id").ToList();
     /// EN: Tests Cast_StringToInt_ShouldWork behavior.
     /// PT: Testa o comportamento de Cast_StringToInt_ShouldWork.
     /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
-    /// </summary>
     [Fact]
     [Trait("Category", "SqliteAdvancedSqlGap")]
     public void Cast_StringToInt_ShouldWork()
@@ -146,10 +334,6 @@ ORDER BY id").ToList();
     /// <summary>
     /// EN: Tests Regexp_Operator_ShouldWork behavior.
     /// PT: Testa o comportamento de Regexp_Operator_ShouldWork.
-    /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
     /// </summary>
     [Fact]
     [Trait("Category", "SqliteAdvancedSqlGap")]
@@ -165,10 +349,6 @@ ORDER BY id").ToList();
     /// EN: Tests OrderBy_Field_Function_ShouldWork behavior.
     /// PT: Testa o comportamento de OrderBy_Field_Function_ShouldWork.
     /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
-    /// </summary>
     [Fact]
     [Trait("Category", "SqliteAdvancedSqlGap")]
     public void OrderBy_Field_Function_ShouldWork()
@@ -180,10 +360,6 @@ ORDER BY id").ToList();
     /// <summary>
     /// EN: Tests Collation_CaseSensitivity_ShouldFollowColumnCollation behavior.
     /// PT: Testa o comportamento de Collation_CaseSensitivity_ShouldFollowColumnCollation.
-    /// </summary>
-    /// <summary>
-    /// Executes this API operation.
-    /// Executa esta operação da API.
     /// </summary>
     [Fact]
     [Trait("Category", "SqliteAdvancedSqlGap")]

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteSqlCompatibilityGapTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteSqlCompatibilityGapTests.cs
@@ -251,6 +251,24 @@ public sealed class SqliteSqlCompatibilityGapTests : XUnitTestBase
     }
 
     /// <summary>
+    /// EN: Tests Union_All_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
+    public void Union_All_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users WHERE id = 1 " +
+            "UNION ALL " +
+            "SELECT id FROM users WHERE id = 1 " +
+            "ORDER BY id").ToList();
+
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
+
+    /// <summary>
     /// EN: Tests Union_Inside_SubSelect_ShouldWork behavior.
     /// PT: Testa o comportamento de Union_Inside_SubSelect_ShouldWork.
     /// </summary>
@@ -268,6 +286,26 @@ ORDER BY id
 ").ToList();
         Assert.Equal([1, 2], [.. rows.Select(r => (int)r.id)]);
     }
+
+    /// <summary>
+    /// EN: Tests Union_All_Inside_SubSelect_ShouldWork behavior.
+    /// PT: Testa o comportamento de Union_All_Inside_SubSelect_ShouldWork.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteSqlCompatibilityGap")]
+    public void Union_All_Inside_SubSelect_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT * FROM (
+SELECT id FROM users WHERE id = 1
+UNION ALL
+SELECT id FROM users WHERE id = 1
+) X
+ORDER BY id
+").ToList();
+        Assert.Equal([1, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
 
     /// <summary>
     /// EN: Tests Cte_With_ShouldWork behavior.

--- a/src/DbSqlLikeMem/Parser/Dialects.cs
+++ b/src/DbSqlLikeMem/Parser/Dialects.cs
@@ -117,6 +117,7 @@ internal interface ISqlDialect
     bool IsIntegerCastTypeName(string typeName);
     bool SupportsDateAddFunction(string functionName);
     bool SupportsWindowFunctions { get; }
+    bool SupportsPivotClause { get; }
     DbType InferWindowFunctionDbType(WindowFunctionExpr windowFunctionExpr, Func<SqlExpr, DbType> inferArgDbType);
 }
 
@@ -258,6 +259,7 @@ internal abstract class SqlDialectBase : ISqlDialect
     public virtual bool SupportsIfFunction => true;
     public virtual bool SupportsIifFunction => true;
     public virtual bool SupportsWindowFunctions => true;
+    public virtual bool SupportsPivotClause => false;
     public virtual IReadOnlyCollection<string> NullSubstituteFunctionNames
         => ["IFNULL", "ISNULL", "NVL"];
     public virtual bool ConcatReturnsNullOnNullInput => true;

--- a/src/DbSqlLikeMem/Parser/SqlQueryAst.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryAst.cs
@@ -108,7 +108,20 @@ internal sealed record SqlTableSource(
     string? Alias,
     SqlSelectQuery? Derived,
     SqlQueryParser.UnionChain? DerivedUnion,
-    string? DerivedSql
+    string? DerivedSql,
+    SqlPivotSpec? Pivot
+);
+
+internal sealed record SqlPivotSpec(
+    string AggregateFunction,
+    string AggregateArgRaw,
+    string ForColumnRaw,
+    IReadOnlyList<SqlPivotInItem> InItems
+);
+
+internal sealed record SqlPivotInItem(
+    string ValueRaw,
+    string Alias
 );
 
 /// <summary>


### PR DESCRIPTION
### Motivation
- Fix compilation error CS1061 caused by `EvalRow` lacking a `GetByName(...)` accessor used by pivot/projection code paths. 
- Add support for SQL `PIVOT` so tests and parser corpus that expect pivot behaviour can be exercised end-to-end. 
- Extend executor window-function support (rank, dense_rank, ntile, percent_rank, cume_dist, lag/lead, first_value/last_value, nth_value) and widen parser expression support for `NOT LIKE` / `NOT REGEXP`.

### Description
- Added `EvalRow.GetByName(string)` to `AstQueryExecutorBase` to resolve direct and qualified (`alias.col`) field lookups used by pivot and projection code.
- Implemented PIVOT parsing and model changes: new AST records `SqlPivotSpec` and `SqlPivotInItem`, parser hook `TryParsePivot`, `ParsePivotSpec`, and safe splitting of `IN` items in `SqlQueryParser` and added `PIVOT` checks in `SqlDialect` via `SupportsPivotClause`.
- Implemented pivot execution in `AstQueryExecutorBase` via `ApplyPivotIfNeeded` and `AggregatePivotBucket` that materialize pivoted `TableResultMock` rows; updated dialects (`OracleDialect`, `SqlServerDialect` and base) to advertise pivot support.
- Extended in-memory executor window-function handling with multiple helpers and implementations (`ComputeWindowSlots` expanded, `FillPercentRankOrCumeDist`, `FillLagOrLead`, `FillFirstOrLastValue`, `FillNthValue`, `ResolveNtileBucketCount`, and related helpers) and enhanced expression parser to support `NOT LIKE` and `NOT REGEXP` logic.
- Updated parser corpus tests, many `*AdvancedSqlGapTests` and `*SqlCompatibilityGapTests` across providers and related docs to include PIVOT/union/window-function test cases and to reflect feature flags.

### Testing
- Performed static source verification and cross-file reference checks using `rg` and manual code inspection to ensure the new `GetByName` is present and referenced call sites resolve; this confirmed the CS1061 pivot-related error is addressed.
- Verified through code search that pivot parsing and executor entry points exist (`TryParsePivot`, `ApplyPivotIfNeeded`) and dialect flags (`SupportsPivotClause`) are present. 
- Could not run `dotnet` build or unit tests in this environment because the .NET SDK is not available (`dotnet` not found), so no automated test run was executed here; remaining VisualStudioExtension resource errors appear orthogonal to the core pivot/get-by-name fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699672d8ac04832cb10e5f060e56dd97)