### PR TITLE
Fix PIVOT grouping to exclude aggregate argument column

### DIFF
--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -847,9 +847,12 @@ internal abstract class AstQueryExecutorBase(
             .ToList();
 
         var forColumnNormalized = pivot.ForColumnRaw[(pivot.ForColumnRaw.LastIndexOf('.') + 1)..];
+        var aggregateArgNormalized = pivot.AggregateArgRaw[(pivot.AggregateArgRaw.LastIndexOf('.') + 1)..];
         var groupColumns = source.ColumnNames
             .Where(c => !c.Equals(pivot.ForColumnRaw, StringComparison.OrdinalIgnoreCase)
-                        && !c.Equals(forColumnNormalized, StringComparison.OrdinalIgnoreCase))
+                        && !c.Equals(forColumnNormalized, StringComparison.OrdinalIgnoreCase)
+                        && !c.Equals(pivot.AggregateArgRaw, StringComparison.OrdinalIgnoreCase)
+                        && !c.Equals(aggregateArgNormalized, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
         static string BuildGroupKey(EvalRow row, IEnumerable<string> columns)


### PR DESCRIPTION
### Motivation
- Prevent `PIVOT` from implicitly grouping by the aggregate argument column (e.g. `COUNT(id)`), which could produce multiple rows instead of a single aggregated row for non-pivoted dimensions.

### Description
- In `src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs` add `aggregateArgNormalized` and exclude both `pivot.AggregateArgRaw` and its normalized name from the implicit `groupColumns` so the aggregate argument column is not treated as a grouping key.

### Testing
- Attempted to run the targeted test with `dotnet test src/DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj --filter "FullyQualifiedName~Pivot_Count_ByTenant_ShouldWork"`, but the run failed in this environment because `dotnet` is not installed (no automated tests executed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996950300a0832c8f93759def97b161)