### PR TITLE
Stabilize VS extension resource build and add unsupported PIVOT coverage in non-PIVOT dialect tests

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -58,6 +58,12 @@ public sealed class SqlQueryParserCorpusTests(
             yield return Case(sql, why, expectation, minVersion);
         }
 
+
+        // Recursos não suportados pelo dialeto
+        yield return Case(
+            "SELECT t10, t20 FROM (SELECT tenantid, id FROM users) src PIVOT (COUNT(id) FOR tenantid IN (10 AS t10, 20 AS t20)) p",
+            "unsupported: PIVOT clause",
+            SqlCaseExpectation.ThrowNotSupported);
         // Inválidas (ThrowInvalid)
         foreach (var row in InvalidSelectStatements())
         {

--- a/src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -58,6 +58,12 @@ public sealed class SqlQueryParserCorpusTests(
             yield return Case(sql, why, expectation, minVersion);
         }
 
+
+        // Recursos não suportados pelo dialeto
+        yield return Case(
+            "SELECT t10, t20 FROM (SELECT tenantid, id FROM users) src PIVOT (COUNT(id) FOR tenantid IN (10 AS t10, 20 AS t20)) p",
+            "unsupported: PIVOT clause",
+            SqlCaseExpectation.ThrowNotSupported);
         // Inválidas (ThrowInvalid)
         foreach (var row in InvalidSelectStatements())
         {

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -57,6 +57,12 @@ public sealed class SqlQueryParserCorpusTests(
             yield return Case(sql, why, expectation, minVersion);
         }
 
+
+        // Recursos não suportados pelo dialeto
+        yield return Case(
+            "SELECT t10, t20 FROM (SELECT tenantid, id FROM users) src PIVOT (COUNT(id) FOR tenantid IN (10 AS t10, 20 AS t20)) p",
+            "unsupported: PIVOT clause",
+            SqlCaseExpectation.ThrowNotSupported);
         // Inválidas (ThrowInvalid)
         foreach (var row in InvalidSelectStatements())
         {

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlQueryParserCorpusTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqlQueryParserCorpusTests.cs
@@ -58,6 +58,12 @@ public sealed class SqlQueryParserCorpusTests(
             yield return Case(sql, why, expectation, minVersion);
         }
 
+
+        // Recursos não suportados pelo dialeto
+        yield return Case(
+            "SELECT t10, t20 FROM (SELECT tenantid, id FROM users) src PIVOT (COUNT(id) FOR tenantid IN (10 AS t10, 20 AS t20)) p",
+            "unsupported: PIVOT clause",
+            SqlCaseExpectation.ThrowNotSupported);
         // Inválidas (ThrowInvalid)
         foreach (var row in InvalidSelectStatements())
         {

--- a/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
+++ b/src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj
@@ -37,6 +37,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>true</DesignTime>
+      <AutoGen>true</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <EmbeddedResource Update="Properties\Resources.*.resx">
+      <DependentUpon>Resources.resx</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
     <VSCTCompile Include="DbSqlLikeMemExtension.vsct" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>


### PR DESCRIPTION
### Motivation
- Ensure the Visual Studio extension project reliably links `Resources.resx` / `Resources.Designer.cs` / localized `Resources.*.resx` during build to avoid ResourceDictionary/Resources issues in the extension build pipeline.
- Prevent regressions from the recent PIVOT work by making parser test expectations explicit for dialects that do not support `PIVOT`, aligning runtime behavior with the `SupportsPivotClause` capability flag.

### Description
- Added explicit `EmbeddedResource` / `Compile` metadata to `src/DbSqlLikeMem.VisualStudioExtension/DbSqlLikeMem.VisualStudioExtension.csproj` to bind `Resources.resx` with `Resources.Designer.cs` and localized satellite `.resx` files so code-generation and design-time tooling behave consistently.
- Inserted a `ThrowNotSupported` corpus test case for the `PIVOT` query in parser corpus providers that do not support PIVOT: `Sqlite`, `MySql`, `Npgsql`, and `Db2` by updating the respective `SqlQueryParserCorpusTests.cs` files.
- Regenerated backlog/docs with `scripts/generate_gap_backlog.py` to ensure docs remain in sync after changes.
- Committed changes with message: `Stabilize VS extension resources and add unsupported PIVOT corpus coverage` and opened the PR titled accordingly.

### Testing
- ⚠️ Attempted to run `dotnet --info` and `dotnet build src/DbSqlLikeMem.slnx` but the environment lacks the .NET SDK/CLI (`dotnet: command not found`).
- ✅ Ran `python scripts/generate_gap_backlog.py` which completed successfully and wrote `docs/gap-tests-technical-backlog.md`.
- ✅ Verified presence of the new `unsupported: PIVOT clause` corpus test case in the four modified test files via automated checks (static grep/assert scripts).
- ✅ Committed the changes and created the PR; all file diffs reflect the intended fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996958eaf00832c9382bc26416c2f1a)