### PR TITLE
Add accessibility configuration to console generators

### DIFF
--- a/src/DbSqlLikeMem.Db2ConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.Db2ConsoleGenerator/Program.cs
@@ -17,6 +17,7 @@ static partial class Program
         string OutputPath,
         string Schema,
         string Namespace,
+        string? ClassAccessibility = null,
         List<string>? Tables = null);
 
     private sealed record ConnectionInfo(
@@ -105,6 +106,7 @@ static partial class Program
 
                     GenerateTableFile(
                         destiny.Namespace,
+                        destiny.ClassAccessibility,
                         tableName: clean,
                         columns: meta.Columns,
                         primaryKey: meta.PrimaryKey,
@@ -231,6 +233,7 @@ static partial class Program
 
     private static void GenerateTableFile(
         string ns,
+        string? classAccessibility,
         string tableName,
         List<ColumnMeta> columns,
         List<string> primaryKey,
@@ -246,10 +249,17 @@ static partial class Program
 
         w.WriteLine($"namespace {ns};");
         w.WriteLine();
-        w.WriteLine($"public static class {className}");
+        var normalizedAccessibility = string.Equals(classAccessibility, "public", StringComparison.OrdinalIgnoreCase)
+            ? "public"
+            : "internal";
+
+        w.WriteLine($"{normalizedAccessibility} static class {className}");
         w.WriteLine("{");
-        w.WriteLine($"    public static ITableMock {methodName}(        this DbMock db)");
+        w.WriteLine($"    {normalizedAccessibility} static ITableMock {methodName}(this DbMock db)");
         w.WriteLine("    {");
+        if (normalizedAccessibility == "public")
+            w.WriteLine("        ArgumentNullException.ThrowIfNull(db);");
+
         w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
 
         foreach (var c in columns.OrderBy(c => c.Ordinal))

--- a/src/DbSqlLikeMem.Db2ConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.Db2ConsoleGenerator/appsettings.json
@@ -9,7 +9,8 @@
                 {
                     "OutputPath": "Project\\src\\Project.Domain.TestTools\\Db2",
                     "Schema": "public",
-                    "Namespace": "Project.Domain.TestTools.Db2"
+                    "Namespace": "Project.Domain.TestTools.Db2",
+                    "ClassAccessibility": "public"
                 }
             ]
         }

--- a/src/DbSqlLikeMem.MySqlConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.MySqlConsoleGenerator/Program.cs
@@ -17,6 +17,7 @@ static partial class Program
         string OutputPath,
         string Schema,
         string Namespace,
+        string? ClassAccessibility = null,
         List<string>? Tables = null);
 
     private sealed record ConnectionInfo(
@@ -105,6 +106,7 @@ static partial class Program
 
                     GenerateTableFile(
                         destiny.Namespace,
+                        destiny.ClassAccessibility,
                         tableName: clean,
                         columns: meta.Columns,
                         primaryKey: meta.PrimaryKey,
@@ -278,6 +280,7 @@ SELECT KCU.COLUMN_NAME
     // ---------- Geração ----------
     private static void GenerateTableFile(
         string ns,
+        string? classAccessibility,
         string tableName,
         List<ColumnMeta> columns,
         List<string> primaryKey,
@@ -293,11 +296,17 @@ SELECT KCU.COLUMN_NAME
 
         w.WriteLine($"namespace {ns};");
         w.WriteLine();
-        w.WriteLine($"public static class {className}");
+        var normalizedAccessibility = string.Equals(classAccessibility, "public", StringComparison.OrdinalIgnoreCase)
+            ? "public"
+            : "internal";
+
+        w.WriteLine($"{normalizedAccessibility} static class {className}");
         w.WriteLine("{");
-        w.WriteLine($"    public static ITableMock {methodName}(" +
-                    $"        this DbMock db)");
+        w.WriteLine($"    {normalizedAccessibility} static ITableMock {methodName}(this DbMock db)");
         w.WriteLine("    {");
+        if (normalizedAccessibility == "public")
+            w.WriteLine("        ArgumentNullException.ThrowIfNull(db);");
+
         w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
 
         // map: nome → ordinal (de fato já vem na meta)

--- a/src/DbSqlLikeMem.MySqlConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.MySqlConsoleGenerator/appsettings.json
@@ -8,7 +8,8 @@
             "Destinies": [
                 {
                     "OutputPath": "Address\\src\\Address.Domain.TestTools\\Mysql",
-                    "Schema": "Addresses"
+                    "Schema": "Addresses",
+                    "ClassAccessibility": "public"
                 }
             ]
         }

--- a/src/DbSqlLikeMem.NpgsqlConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.NpgsqlConsoleGenerator/Program.cs
@@ -17,6 +17,7 @@ static partial class Program
         string OutputPath,
         string Schema,
         string Namespace,
+        string? ClassAccessibility = null,
         List<string>? Tables = null);
 
     private sealed record ConnectionInfo(
@@ -105,6 +106,7 @@ static partial class Program
 
                     GenerateTableFile(
                         destiny.Namespace,
+                        destiny.ClassAccessibility,
                         tableName: clean,
                         columns: meta.Columns,
                         primaryKey: meta.PrimaryKey,
@@ -231,6 +233,7 @@ static partial class Program
 
     private static void GenerateTableFile(
         string ns,
+        string? classAccessibility,
         string tableName,
         List<ColumnMeta> columns,
         List<string> primaryKey,
@@ -246,10 +249,17 @@ static partial class Program
 
         w.WriteLine($"namespace {ns};");
         w.WriteLine();
-        w.WriteLine($"public static class {className}");
+        var normalizedAccessibility = string.Equals(classAccessibility, "public", StringComparison.OrdinalIgnoreCase)
+            ? "public"
+            : "internal";
+
+        w.WriteLine($"{normalizedAccessibility} static class {className}");
         w.WriteLine("{");
-        w.WriteLine($"    public static ITableMock {methodName}(        this DbMock db)");
+        w.WriteLine($"    {normalizedAccessibility} static ITableMock {methodName}(this DbMock db)");
         w.WriteLine("    {");
+        if (normalizedAccessibility == "public")
+            w.WriteLine("        ArgumentNullException.ThrowIfNull(db);");
+
         w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
 
         foreach (var c in columns.OrderBy(c => c.Ordinal))

--- a/src/DbSqlLikeMem.NpgsqlConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.NpgsqlConsoleGenerator/appsettings.json
@@ -9,7 +9,8 @@
                 {
                     "OutputPath": "Project\\src\\Project.Domain.TestTools\\Npgsql",
                     "Schema": "public",
-                    "Namespace": "Project.Domain.TestTools.Npgsql"
+                    "Namespace": "Project.Domain.TestTools.Npgsql",
+                    "ClassAccessibility": "public"
                 }
             ]
         }

--- a/src/DbSqlLikeMem.OracleConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.OracleConsoleGenerator/Program.cs
@@ -17,6 +17,7 @@ static partial class Program
         string OutputPath,
         string Schema,
         string Namespace,
+        string? ClassAccessibility = null,
         List<string>? Tables = null);
 
     private sealed record ConnectionInfo(
@@ -105,6 +106,7 @@ static partial class Program
 
                     GenerateTableFile(
                         destiny.Namespace,
+                        destiny.ClassAccessibility,
                         tableName: clean,
                         columns: meta.Columns,
                         primaryKey: meta.PrimaryKey,
@@ -231,6 +233,7 @@ static partial class Program
 
     private static void GenerateTableFile(
         string ns,
+        string? classAccessibility,
         string tableName,
         List<ColumnMeta> columns,
         List<string> primaryKey,
@@ -246,10 +249,17 @@ static partial class Program
 
         w.WriteLine($"namespace {ns};");
         w.WriteLine();
-        w.WriteLine($"public static class {className}");
+        var normalizedAccessibility = string.Equals(classAccessibility, "public", StringComparison.OrdinalIgnoreCase)
+            ? "public"
+            : "internal";
+
+        w.WriteLine($"{normalizedAccessibility} static class {className}");
         w.WriteLine("{");
-        w.WriteLine($"    public static ITableMock {methodName}(this DbMock db)");
+        w.WriteLine($"    {normalizedAccessibility} static ITableMock {methodName}(this DbMock db)");
         w.WriteLine("    {");
+        if (normalizedAccessibility == "public")
+            w.WriteLine("        ArgumentNullException.ThrowIfNull(db);");
+
         w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
 
         foreach (var c in columns.OrderBy(c => c.Ordinal))

--- a/src/DbSqlLikeMem.OracleConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.OracleConsoleGenerator/appsettings.json
@@ -9,7 +9,8 @@
                 {
                     "OutputPath": "Project\\src\\Project.Domain.TestTools\\Oracle",
                     "Schema": "public",
-                    "Namespace": "Project.Domain.TestTools.Oracle"
+                    "Namespace": "Project.Domain.TestTools.Oracle",
+                    "ClassAccessibility": "public"
                 }
             ]
         }

--- a/src/DbSqlLikeMem.SqlServerConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.SqlServerConsoleGenerator/Program.cs
@@ -17,6 +17,7 @@ static partial class Program
         string OutputPath,
         string Schema,
         string Namespace,
+        string? ClassAccessibility = null,
         List<string>? Tables = null);
 
     private sealed record ConnectionInfo(
@@ -105,6 +106,7 @@ static partial class Program
 
                     GenerateTableFile(
                         destiny.Namespace,
+                        destiny.ClassAccessibility,
                         tableName: clean,
                         columns: meta.Columns,
                         primaryKey: meta.PrimaryKey,
@@ -231,6 +233,7 @@ static partial class Program
 
     private static void GenerateTableFile(
         string ns,
+        string? classAccessibility,
         string tableName,
         List<ColumnMeta> columns,
         List<string> primaryKey,
@@ -246,10 +249,17 @@ static partial class Program
 
         w.WriteLine($"namespace {ns};");
         w.WriteLine();
-        w.WriteLine($"public static class {className}");
+        var normalizedAccessibility = string.Equals(classAccessibility, "public", StringComparison.OrdinalIgnoreCase)
+            ? "public"
+            : "internal";
+
+        w.WriteLine($"{normalizedAccessibility} static class {className}");
         w.WriteLine("{");
-        w.WriteLine($"    public static ITableMock {methodName}(        this DbMock db)");
+        w.WriteLine($"    {normalizedAccessibility} static ITableMock {methodName}(this DbMock db)");
         w.WriteLine("    {");
+        if (normalizedAccessibility == "public")
+            w.WriteLine("        ArgumentNullException.ThrowIfNull(db);");
+
         w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
 
         foreach (var c in columns.OrderBy(c => c.Ordinal))

--- a/src/DbSqlLikeMem.SqlServerConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.SqlServerConsoleGenerator/appsettings.json
@@ -9,7 +9,8 @@
                 {
                     "OutputPath": "Project\\src\\Project.Domain.TestTools\\SqlServer",
                     "Schema": "public",
-                    "Namespace": "Project.Domain.TestTools.SqlServer"
+                    "Namespace": "Project.Domain.TestTools.SqlServer",
+                    "ClassAccessibility": "public"
                 }
             ]
         }

--- a/src/DbSqlLikeMem.SqliteConsoleGenerator/Program.cs
+++ b/src/DbSqlLikeMem.SqliteConsoleGenerator/Program.cs
@@ -17,6 +17,7 @@ static partial class Program
         string OutputPath,
         string Schema,
         string Namespace,
+        string? ClassAccessibility = null,
         List<string>? Tables = null);
 
     private sealed record ConnectionInfo(
@@ -105,6 +106,7 @@ static partial class Program
 
                     GenerateTableFile(
                         destiny.Namespace,
+                        destiny.ClassAccessibility,
                         tableName: clean,
                         columns: meta.Columns,
                         primaryKey: meta.PrimaryKey,
@@ -231,6 +233,7 @@ static partial class Program
 
     private static void GenerateTableFile(
         string ns,
+        string? classAccessibility,
         string tableName,
         List<ColumnMeta> columns,
         List<string> primaryKey,
@@ -246,10 +249,17 @@ static partial class Program
 
         w.WriteLine($"namespace {ns};");
         w.WriteLine();
-        w.WriteLine($"public static class {className}");
+        var normalizedAccessibility = string.Equals(classAccessibility, "public", StringComparison.OrdinalIgnoreCase)
+            ? "public"
+            : "internal";
+
+        w.WriteLine($"{normalizedAccessibility} static class {className}");
         w.WriteLine("{");
-        w.WriteLine($"    public static ITableMock {methodName}(        this DbMock db)");
+        w.WriteLine($"    {normalizedAccessibility} static ITableMock {methodName}(this DbMock db)");
         w.WriteLine("    {");
+        if (normalizedAccessibility == "public")
+            w.WriteLine("        ArgumentNullException.ThrowIfNull(db);");
+
         w.WriteLine($"        var table = db.AddTable(\"{tableName}\");");
 
         foreach (var c in columns.OrderBy(c => c.Ordinal))

--- a/src/DbSqlLikeMem.SqliteConsoleGenerator/appsettings.json
+++ b/src/DbSqlLikeMem.SqliteConsoleGenerator/appsettings.json
@@ -9,7 +9,8 @@
                 {
                     "OutputPath": "Project\\src\\Project.Domain.TestTools\\Sqlite",
                     "Schema": "public",
-                    "Namespace": "Project.Domain.TestTools.Sqlite"
+                    "Namespace": "Project.Domain.TestTools.Sqlite",
+                    "ClassAccessibility": "public"
                 }
             ]
         }


### PR DESCRIPTION
### Motivation
- Allow generated table factory classes/methods to be either `internal` (default) or `public` per-destination so consumers can control visibility when scaffolding test helpers and domain test tools. 
- When `public` is selected, follow null-check best practices by validating the `DbMock db` parameter.

### Description
- Added `ClassAccessibility` (optional `string`) to the `DestinyInfo` record for all console generators (`Db2`, `MySql`, `Npgsql`, `Oracle`, `SqlServer`, `Sqlite`).
- Propagated `destiny.ClassAccessibility` into the call to `GenerateTableFile` and changed `GenerateTableFile` signature to accept `string? classAccessibility`.
- Generation now computes `normalizedAccessibility = string.Equals(classAccessibility, "public", ...) ? "public" : "internal"` and emits the corresponding modifier for both the generated static class and the factory method.
- When `normalizedAccessibility` is `public`, the generated factory method includes `ArgumentNullException.ThrowIfNull(db);` to validate the `DbMock db` parameter.
- Updated each generator sample `appsettings.json` to include a `ClassAccessibility` field (set to `"public"` in samples).

### Testing
- Attempted to build the generator projects with `dotnet build` for each console generator, but the environment lacks the .NET CLI and the build could not run (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699735d4278c832ca70c3d3b1cf8c39b)