### PR TITLE
Add GROUP BY ordinal support and MySQL index-hint parsing/execution handling

### DIFF
--- a/docs/providers-and-features.md
+++ b/docs/providers-and-features.md
@@ -28,6 +28,11 @@
 
 ### MySQL
 - `INSERT ... ON DUPLICATE KEY UPDATE`: suportado.
+- `USE/IGNORE/FORCE INDEX`: parser + semântica inicial no executor para seleção de índice em predicados de igualdade.
+  - `FOR JOIN` e sem escopo: afetam candidatos de índice no plano de acesso.
+  - `FOR ORDER BY` / `FOR GROUP BY`: comportamento mínimo inicial (parseados, sem otimização dedicada de sort/group no executor).
+  - `FORCE INDEX` em escopos `FOR ORDER BY` / `FOR GROUP BY` valida existência de índices quando a query usa a cláusula correspondente (`ORDER BY` / `GROUP BY`), com fail-fast para índice inexistente.
+  - Em `FOR ORDER BY` / `FOR GROUP BY`, quando o índice hint existe, o plano de acesso a linhas permanece no modo mínimo atual (sem otimização dedicada de ordenação/agrupamento).
 
 ### SQLite
 - `WITH`/CTE: disponível (>= 3).

--- a/src/DbSqlLikeMem.MySql.Test/MySqlWhereParserAndExecutorTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlWhereParserAndExecutorTests.cs
@@ -147,6 +147,329 @@ public sealed class MySqlWhereParserAndExecutorTests : XUnitTestBase
         Assert.Equal(beforeTableHint + 1, _cnn.Metrics.TableHints["users"]);
     }
 
+
+    /// <summary>
+    /// EN: Ensures FORCE INDEX FOR JOIN validates missing indexes on joined tables.
+    /// PT: Garante que FORCE INDEX FOR JOIN valide índices inexistentes em tabelas de JOIN.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Join_ForceIndexForJoin_WithMissingIndex_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _cnn.Query<dynamic>(
+                "SELECT u.id FROM users u JOIN users u2 FORCE INDEX FOR JOIN (ix_missing) ON u2.id = u.id WHERE u.id = 1")
+            .ToList());
+
+        Assert.Contains("FORCE INDEX", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures FORCE INDEX FOR JOIN with existing index keeps join execution working.
+    /// PT: Garante que FORCE INDEX FOR JOIN com índice existente mantenha a execução do join.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Join_ForceIndexForJoin_WithExistingIndex_ShouldExecute()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT u.id FROM users u JOIN users u2 FORCE INDEX FOR JOIN (ix_users_name) ON u2.name = u.name WHERE u.id = 1")
+            .ToList();
+
+        Assert.Single(rows);
+        Assert.Equal(1, (int)rows[0].id);
+    }
+
+    /// <summary>
+    /// EN: Ensures USE INDEX prioritizes the hinted index when available.
+    /// PT: Garante que USE INDEX priorize o índice indicado quando disponível.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Where_UseIndex_ShouldPrioritizeHintedIndex()
+    {
+        var beforeName = _cnn.Metrics.IndexHints.TryGetValue("ix_users_name", out var nameHits) ? nameHits : 0;
+        var beforeComposite = _cnn.Metrics.IndexHints.TryGetValue("ix_users_name_email", out var compositeHits) ? compositeHits : 0;
+
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users USE INDEX (ix_users_name) WHERE name = 'Bob' AND email = 'bob@x.com'")
+            .ToList();
+
+        Assert.Single(rows);
+        Assert.Equal(3, (int)rows[0].id);
+        Assert.Equal(beforeName + 1, _cnn.Metrics.IndexHints["ix_users_name"]);
+        Assert.Equal(beforeComposite, _cnn.Metrics.IndexHints.TryGetValue("ix_users_name_email", out var afterComposite) ? afterComposite : 0);
+    }
+
+    /// <summary>
+    /// EN: Ensures IGNORE INDEX prevents using the ignored index.
+    /// PT: Garante que IGNORE INDEX evite o uso do índice ignorado.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Where_IgnoreIndex_ShouldAvoidIgnoredIndex()
+    {
+        var beforeName = _cnn.Metrics.IndexHints.TryGetValue("ix_users_name", out var nameHits) ? nameHits : 0;
+        var beforeComposite = _cnn.Metrics.IndexHints.TryGetValue("ix_users_name_email", out var compositeHits) ? compositeHits : 0;
+
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users IGNORE INDEX (ix_users_name_email) WHERE name = 'Bob' AND email = 'bob@x.com'")
+            .ToList();
+
+        Assert.Single(rows);
+        Assert.Equal(3, (int)rows[0].id);
+        Assert.Equal(beforeName + 1, _cnn.Metrics.IndexHints["ix_users_name"]);
+        Assert.Equal(beforeComposite, _cnn.Metrics.IndexHints.TryGetValue("ix_users_name_email", out var afterComposite) ? afterComposite : 0);
+    }
+
+    /// <summary>
+    /// EN: Ensures FORCE INDEX with a missing index fails fast.
+    /// PT: Garante que FORCE INDEX com índice inexistente falhe rapidamente.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Where_ForceIndex_WithMissingIndex_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _cnn.Query<dynamic>("SELECT id FROM users FORCE INDEX (ix_missing) WHERE name = 'John'").ToList());
+
+        Assert.Contains("FORCE INDEX", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures FORCE INDEX FOR ORDER BY validates referenced indexes even with minimal runtime scope handling.
+    /// PT: Garante que FORCE INDEX FOR ORDER BY valide índices referenciados mesmo com tratamento mínimo de escopo em runtime.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Where_ForceIndexForOrderBy_WithMissingIndex_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _cnn.Query<dynamic>("SELECT id FROM users FORCE INDEX FOR ORDER BY (ix_missing) WHERE name = 'Bob' AND email = 'bob@x.com' ORDER BY name").ToList());
+
+        Assert.Contains("FORCE INDEX", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures FORCE INDEX FOR GROUP BY validates referenced indexes even with minimal runtime scope handling.
+    /// PT: Garante que FORCE INDEX FOR GROUP BY valide índices referenciados mesmo com tratamento mínimo de escopo em runtime.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Where_ForceIndexForGroupBy_WithMissingIndex_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _cnn.Query<dynamic>("SELECT name, COUNT(*) AS c FROM users FORCE INDEX FOR GROUP BY (ix_missing) WHERE name = 'Bob' AND email = 'bob@x.com' GROUP BY name").ToList());
+
+        Assert.Contains("FORCE INDEX", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures FORCE INDEX FOR ORDER BY missing index is ignored when query has no ORDER BY clause.
+    /// PT: Garante que FORCE INDEX FOR ORDER BY com índice inexistente seja ignorado quando a query não tem ORDER BY.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Where_ForceIndexForOrderBy_WithoutOrderByClause_ShouldNotThrow()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users FORCE INDEX FOR ORDER BY (ix_missing) WHERE name = 'Bob' AND email = 'bob@x.com'")
+            .ToList();
+
+        Assert.Single(rows);
+        Assert.Equal(3, (int)rows[0].id);
+    }
+
+    /// <summary>
+    /// EN: Ensures FORCE INDEX FOR GROUP BY missing index is ignored when query has no GROUP BY clause.
+    /// PT: Garante que FORCE INDEX FOR GROUP BY com índice inexistente seja ignorado quando a query não tem GROUP BY.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Where_ForceIndexForGroupBy_WithoutGroupByClause_ShouldNotThrow()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users FORCE INDEX FOR GROUP BY (ix_missing) WHERE name = 'Bob' AND email = 'bob@x.com'")
+            .ToList();
+
+        Assert.Single(rows);
+        Assert.Equal(3, (int)rows[0].id);
+    }
+
+    /// <summary>
+    /// EN: Ensures FORCE INDEX FOR GROUP BY keeps default row-access planning when hinted index exists.
+    /// PT: Garante que FORCE INDEX FOR GROUP BY mantenha o planejamento padrão de acesso a linhas quando o índice existe.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Where_ForceIndexForGroupBy_WithExistingIndex_ShouldKeepDefaultPlanning()
+    {
+        var beforeComposite = _cnn.Metrics.IndexHints.TryGetValue("ix_users_name_email", out var compositeHits) ? compositeHits : 0;
+
+        var rows = _cnn.Query<dynamic>(
+            "SELECT name, COUNT(*) AS c FROM users FORCE INDEX FOR GROUP BY (ix_users_name) WHERE name = 'Bob' AND email = 'bob@x.com' GROUP BY name")
+            .ToList();
+
+        Assert.Single(rows);
+        Assert.Equal("Bob", (string)rows[0].name);
+        Assert.Equal(1L, (long)rows[0].c);
+        Assert.Equal(beforeComposite + 1, _cnn.Metrics.IndexHints["ix_users_name_email"]);
+    }
+
+    /// <summary>
+    /// EN: Ensures FORCE INDEX FOR ORDER BY keeps default row-access planning when hinted index exists.
+    /// PT: Garante que FORCE INDEX FOR ORDER BY mantenha o planejamento padrão de acesso a linhas quando o índice existe.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Where_ForceIndexForOrderBy_WithExistingIndex_ShouldKeepDefaultPlanning()
+    {
+        var beforeComposite = _cnn.Metrics.IndexHints.TryGetValue("ix_users_name_email", out var compositeHits) ? compositeHits : 0;
+
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id FROM users FORCE INDEX FOR ORDER BY (ix_users_name) WHERE name = 'Bob' AND email = 'bob@x.com' ORDER BY name")
+            .ToList();
+
+        Assert.Single(rows);
+        Assert.Equal(3, (int)rows[0].id);
+        Assert.Equal(beforeComposite + 1, _cnn.Metrics.IndexHints["ix_users_name_email"]);
+    }
+
+    /// <summary>
+    /// EN: Ensures PRIMARY hint resolves to a primary-key-equivalent index in execution.
+    /// PT: Garante que hint PRIMARY resolva para um índice equivalente à chave primária na execução.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void Where_ForcePrimaryHint_ShouldUsePrimaryKeyEquivalentIndex()
+    {
+        var db = new MySqlDbMock();
+        var users = db.AddTable("users");
+        users.AddColumn("id", DbType.Int32, false);
+        users.AddColumn("name", DbType.String, false);
+        users.AddPrimaryKeyIndexes("id");
+        users.CreateIndex("ix_users_pk", ["id"], unique: true);
+        users.Add(new Dictionary<int, object?> { [0] = 1, [1] = "John" });
+
+        using var cnn = new MySqlConnectionMock(db);
+        cnn.Open();
+
+        var beforePk = cnn.Metrics.IndexHints.TryGetValue("ix_users_pk", out var pkHits) ? pkHits : 0;
+
+        var rows = cnn.Query<dynamic>("SELECT name FROM users FORCE INDEX (PRIMARY) WHERE id = 1").ToList();
+
+        Assert.Single(rows);
+        Assert.Equal("John", (string)rows[0].name);
+        Assert.Equal(beforePk + 1, cnn.Metrics.IndexHints["ix_users_pk"]);
+    }
+
+    /// <summary>
+    /// EN: Ensures ORDER BY ordinal position works for projected columns.
+    /// PT: Garante que ORDER BY por posição ordinal funcione para colunas projetadas.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void OrderBy_OrdinalPosition_ShouldSortBySelectedColumn()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT name, id FROM users ORDER BY 2 DESC")
+            .ToList();
+
+        Assert.Equal([3, 2, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
+    /// <summary>
+    /// EN: Ensures ORDER BY alias works for expression projections.
+    /// PT: Garante que ORDER BY por alias funcione para projeções com expressão.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void OrderBy_AliasFromExpression_ShouldSortCorrectly()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id + 10 AS score, id FROM users ORDER BY score DESC")
+            .ToList();
+
+        Assert.Equal([3, 2, 1], [.. rows.Select(r => (int)r.id)]);
+    }
+
+    /// <summary>
+    /// EN: Ensures ORDER BY alias works when alias differs from base column name.
+    /// PT: Garante que ORDER BY por alias funcione quando o alias difere do nome da coluna base.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void OrderBy_AliasDifferentFromColumnName_ShouldSortCorrectly()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT name AS username, id FROM users ORDER BY username DESC")
+            .ToList();
+
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.id)]); // John, Jane, Bob
+    }
+
+    /// <summary>
+    /// EN: Ensures ORDER BY function expression works in execution.
+    /// PT: Garante que ORDER BY com expressão de função funcione na execução.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void OrderBy_FunctionExpression_ShouldSortCorrectly()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT id, name FROM users ORDER BY LOWER(name) ASC")
+            .ToList();
+
+        Assert.Equal([3, 2, 1], [.. rows.Select(r => (int)r.id)]); // Bob, Jane, John
+    }
+
+    /// <summary>
+    /// EN: Ensures ORDER BY qualified column name works against projected rows.
+    /// PT: Garante que ORDER BY com nome de coluna qualificado funcione contra linhas projetadas.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void OrderBy_QualifiedColumnName_ShouldSortCorrectly()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT u.id, u.name FROM users u ORDER BY u.name DESC")
+            .ToList();
+
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.id)]); // John, Jane, Bob
+    }
+
+    /// <summary>
+    /// EN: Ensures GROUP BY ordinal position groups by the projected column.
+    /// PT: Garante que GROUP BY por posição ordinal agrupe pela coluna projetada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void GroupBy_OrdinalPosition_ShouldGroupBySelectedColumn()
+    {
+        var rows = _cnn.Query<dynamic>(
+            "SELECT name, COUNT(*) AS c FROM users GROUP BY 1 ORDER BY name")
+            .ToList();
+
+        Assert.Equal(3, rows.Count);
+        Assert.Equal("Bob", (string)rows[0].name);
+        Assert.Equal(1L, (long)rows[0].c);
+    }
+
+    /// <summary>
+    /// EN: Ensures GROUP BY ordinal out of range throws invalid operation.
+    /// PT: Garante que GROUP BY ordinal fora do intervalo lance invalid operation.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlWhereParserAndExecutor")]
+    public void GroupBy_OrdinalOutOfRange_ShouldThrow()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _cnn.Query<dynamic>("SELECT name, COUNT(*) AS c FROM users GROUP BY 3").ToList());
+
+        Assert.Contains("GROUP BY ordinal", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     /// EN: Tests Where_IN_ShouldFilter behavior.
     /// PT: Testa o comportamento de Where_IN_ShouldFilter.

--- a/src/DbSqlLikeMem/Parser/SqlQueryAst.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryAst.cs
@@ -109,7 +109,29 @@ internal sealed record SqlTableSource(
     SqlSelectQuery? Derived,
     SqlQueryParser.UnionChain? DerivedUnion,
     string? DerivedSql,
-    SqlPivotSpec? Pivot
+    SqlPivotSpec? Pivot,
+    IReadOnlyList<SqlMySqlIndexHint>? MySqlIndexHints = null
+);
+
+internal enum SqlMySqlIndexHintKind
+{
+    Use,
+    Ignore,
+    Force
+}
+
+internal enum SqlMySqlIndexHintScope
+{
+    Any,
+    Join,
+    OrderBy,
+    GroupBy
+}
+
+internal sealed record SqlMySqlIndexHint(
+    SqlMySqlIndexHintKind Kind,
+    SqlMySqlIndexHintScope Scope,
+    IReadOnlyList<string> IndexNames
 );
 
 internal sealed record SqlPivotSpec(


### PR DESCRIPTION
### Motivation
- Provide runtime support for `GROUP BY` ordinal positions (e.g. `GROUP BY 1`) so grouping can reference projected columns by position.  
- Improve MySQL compatibility by parsing and carrying index hints (`USE`, `IGNORE`, `FORCE`) with explicit scopes (`JOIN`, `ORDER BY`, `GROUP BY`) into the executor.  
- Make ORDER/BY resolution and null-handling more robust for aliases/ordinals/qualified names during in-memory execution.  

### Description
- Added `BuildGroupByKeyExpressions` in `AstQueryExecutorBase` which resolves numeric `GROUP BY` ordinals against `SELECT` projection and validates out-of-range or <1 ordinals.  
- Extended AST with `SqlMySqlIndexHintKind`, `SqlMySqlIndexHintScope`, `SqlMySqlIndexHint` and a `MySqlIndexHints` field on `SqlTableSource`, and adjusted `SqlQueryParser` to return and validate parsed index hints (including quoted/`PRIMARY` names).  
- Implemented executor-side handling of index hints: `Source` now carries hints, `TryRowsFromIndex` and `ApplyJoin` consult `BuildMySqlIndexHintPlan` which validates `FORCE INDEX` existence and filters/permits indexes for join-scope hints, plus helpers `ExpandHintIndexNames` and `ResolvePrimaryEquivalentIndexNames`.  
- Improved `ApplyOrderAndLimit` to resolve order keys by alias/name/qualified tail, expose alias-to-index mapping for projected rows, carry explicit `NullsFirst` flags, and updated tests accordingly; added multiple MySQL tests including `GroupBy_OrdinalPosition_ShouldGroupBySelectedColumn` and `GroupBy_OrdinalOutOfRange_ShouldThrow` plus a suite of index-hint parser/executor tests.  

### Testing
- Attempted to run a project build with `dotnet build src/DbSqlLikeMem/DbSqlLikeMem.csproj` and tests with `dotnet test ...`, but the .NET SDK is not available in this environment and both commands failed with `dotnet: command not found`.  
- No automated test execution completed in this environment due to the missing `dotnet` tool, so CI/local test runs are still required to validate behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997275679b0832c9e2a1c6ab1d21472)