### PR TITLE
Treat `OPTION` as a clause keyword so DB2 rejects SQL Server `OPTION(...)` hints

### DIFF
--- a/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
@@ -2150,6 +2150,7 @@ internal sealed class SqlQueryParser
         "OUTER"  ,
         "OFFSET" ,
         "FETCH"  ,
+        "OPTION" ,
         "SET"    ,  // UPDATE
         "VALUES" ,  // INSERT
         "SELECT" ,  // INSERT...SELECT (e derived cases)


### PR DESCRIPTION
### Motivation
- Prevent `OPTION` from being parsed as a table alias after `FROM` so the parser will reach the query-hint handling path and raise a dialect-specific rejection for DB2.

### Description
- Added `"OPTION"` to the `ClauseKeywordToken` `HashSet` in `SqlQueryParser.cs` so `IsClauseKeywordToken` returns true for `OPTION`.
- This ensures `TryConsumeQueryHintOption()` is invoked (or the dialect-specific `SqlUnsupported.ForDialect` is raised) instead of producing a generic unexpected-token `InvalidOperationException`.
- Change is a single-line addition in `src/DbSqlLikeMem/Parser/SqlQueryParser.cs` and was committed.

### Testing
- Attempted to run the targeted test `ParseSelect_WithSqlServerOptionHints_ShouldBeRejected` via `dotnet test`, but the environment does not have `dotnet` installed so the test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69974b6d1848832c9b185b6f8ae68b4e)