### PR TITLE
NHibernate contract tests: use provider-specific dialects and add update scenario

### DIFF
--- a/docs/providers-and-features.md
+++ b/docs/providers-and-features.md
@@ -23,6 +23,7 @@
 - `CREATE TEMPORARY TABLE` (incluindo variantes `AS SELECT`).
 - Definição de schema via API fluente.
 - Seed de dados e consultas compatíveis com Dapper.
+- Compatibilidade NHibernate via `UserSuppliedConnectionProvider` com suíte de contrato por provider usando dialeto NHibernate específico por banco (SQL nativo, entidade mapeada e transação rollback).
 
 ## Particularidades por banco
 

--- a/src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj
+++ b/src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj
@@ -50,6 +50,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4" />
+		<PackageReference Include="NHibernate" Version="5.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -79,6 +80,7 @@
 		<Compile Include="..\DbSqlLikeMem.Test\ExistsTestsBase.cs" Link="SharedTests\ExistsTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\StoredProcedureSignatureTestsBase.cs" Link="SharedTests\StoredProcedureSignatureTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" Link="SharedTests\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" />
+		<Compile Include="..\DbSqlLikeMem.Test\NHibernateSupportTestsBase.cs" Link="SharedTests\NHibernateSupportTestsBase.cs" />
 	</ItemGroup>
 
 </Project>

--- a/src/DbSqlLikeMem.Db2.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/NHibernateSmokeTests.cs
@@ -1,0 +1,15 @@
+using System.Data.Common;
+
+namespace DbSqlLikeMem.Db2.Test;
+
+public sealed class NHibernateSmokeTests : DbSqlLikeMem.Test.NHibernateSupportTestsBase
+{
+    protected override string NhDialectClass => "NHibernate.Dialect.DB2Dialect, NHibernate";
+
+    protected override DbConnection CreateOpenConnection()
+    {
+        var connection = new Db2ConnectionMock(new Db2DbMock());
+        connection.Open();
+        return connection;
+    }
+}

--- a/src/DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj
+++ b/src/DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj
@@ -57,6 +57,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4" />
+		<PackageReference Include="NHibernate" Version="5.5.2" />
 	</ItemGroup>
 	
 
@@ -88,5 +89,6 @@
 		<Compile Include="..\DbSqlLikeMem.Test\ExistsTestsBase.cs" Link="SharedTests\ExistsTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\StoredProcedureSignatureTestsBase.cs" Link="SharedTests\StoredProcedureSignatureTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" Link="SharedTests\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" />
+		<Compile Include="..\DbSqlLikeMem.Test\NHibernateSupportTestsBase.cs" Link="SharedTests\NHibernateSupportTestsBase.cs" />
 	</ItemGroup>
 </Project>

--- a/src/DbSqlLikeMem.MySql.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/NHibernateSmokeTests.cs
@@ -1,0 +1,15 @@
+using System.Data.Common;
+
+namespace DbSqlLikeMem.MySql.Test;
+
+public sealed class NHibernateSmokeTests : DbSqlLikeMem.Test.NHibernateSupportTestsBase
+{
+    protected override string NhDialectClass => "NHibernate.Dialect.MySQLDialect, NHibernate";
+
+    protected override DbConnection CreateOpenConnection()
+    {
+        var connection = new MySqlConnectionMock(new MySqlDbMock());
+        connection.Open();
+        return connection;
+    }
+}

--- a/src/DbSqlLikeMem.Npgsql.Test/DbSqlLikeMem.Npgsql.Test.csproj
+++ b/src/DbSqlLikeMem.Npgsql.Test/DbSqlLikeMem.Npgsql.Test.csproj
@@ -62,6 +62,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4" />
+		<PackageReference Include="NHibernate" Version="5.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -92,5 +93,6 @@
 		<Compile Include="..\DbSqlLikeMem.Test\ExistsTestsBase.cs" Link="SharedTests\ExistsTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\StoredProcedureSignatureTestsBase.cs" Link="SharedTests\StoredProcedureSignatureTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" Link="SharedTests\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" />
+		<Compile Include="..\DbSqlLikeMem.Test\NHibernateSupportTestsBase.cs" Link="SharedTests\NHibernateSupportTestsBase.cs" />
 	</ItemGroup>
 </Project>

--- a/src/DbSqlLikeMem.Npgsql.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/NHibernateSmokeTests.cs
@@ -1,0 +1,15 @@
+using System.Data.Common;
+
+namespace DbSqlLikeMem.Npgsql.Test;
+
+public sealed class NHibernateSmokeTests : DbSqlLikeMem.Test.NHibernateSupportTestsBase
+{
+    protected override string NhDialectClass => "NHibernate.Dialect.PostgreSQL83Dialect, NHibernate";
+
+    protected override DbConnection CreateOpenConnection()
+    {
+        var connection = new NpgsqlConnectionMock(new NpgsqlDbMock());
+        connection.Open();
+        return connection;
+    }
+}

--- a/src/DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj
+++ b/src/DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj
@@ -57,6 +57,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4" />
+		<PackageReference Include="NHibernate" Version="5.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -86,5 +87,6 @@
 		<Compile Include="..\DbSqlLikeMem.Test\ExistsTestsBase.cs" Link="SharedTests\ExistsTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\StoredProcedureSignatureTestsBase.cs" Link="SharedTests\StoredProcedureSignatureTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" Link="SharedTests\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" />
+		<Compile Include="..\DbSqlLikeMem.Test\NHibernateSupportTestsBase.cs" Link="SharedTests\NHibernateSupportTestsBase.cs" />
 	</ItemGroup>
 </Project>

--- a/src/DbSqlLikeMem.Oracle.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/NHibernateSmokeTests.cs
@@ -1,0 +1,15 @@
+using System.Data.Common;
+
+namespace DbSqlLikeMem.Oracle.Test;
+
+public sealed class NHibernateSmokeTests : DbSqlLikeMem.Test.NHibernateSupportTestsBase
+{
+    protected override string NhDialectClass => "NHibernate.Dialect.Oracle10gDialect, NHibernate";
+
+    protected override DbConnection CreateOpenConnection()
+    {
+        var connection = new OracleConnectionMock(new OracleDbMock());
+        connection.Open();
+        return connection;
+    }
+}

--- a/src/DbSqlLikeMem.SqlServer.Test/DbSqlLikeMem.SqlServer.Test.csproj
+++ b/src/DbSqlLikeMem.SqlServer.Test/DbSqlLikeMem.SqlServer.Test.csproj
@@ -58,6 +58,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4" />
+		<PackageReference Include="NHibernate" Version="5.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -88,5 +89,6 @@
 		<Compile Include="..\DbSqlLikeMem.Test\ExistsTestsBase.cs" Link="SharedTests\ExistsTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\StoredProcedureSignatureTestsBase.cs" Link="SharedTests\StoredProcedureSignatureTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" Link="SharedTests\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" />
+		<Compile Include="..\DbSqlLikeMem.Test\NHibernateSupportTestsBase.cs" Link="SharedTests\NHibernateSupportTestsBase.cs" />
 	</ItemGroup>
 </Project>

--- a/src/DbSqlLikeMem.SqlServer.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/NHibernateSmokeTests.cs
@@ -1,0 +1,15 @@
+using System.Data.Common;
+
+namespace DbSqlLikeMem.SqlServer.Test;
+
+public sealed class NHibernateSmokeTests : DbSqlLikeMem.Test.NHibernateSupportTestsBase
+{
+    protected override string NhDialectClass => "NHibernate.Dialect.MsSql2012Dialect, NHibernate";
+
+    protected override DbConnection CreateOpenConnection()
+    {
+        var connection = new SqlServerConnectionMock(new SqlServerDbMock());
+        connection.Open();
+        return connection;
+    }
+}

--- a/src/DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj
+++ b/src/DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj
@@ -57,6 +57,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4" />
+		<PackageReference Include="NHibernate" Version="5.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -87,5 +88,6 @@
 		<Compile Include="..\DbSqlLikeMem.Test\ExistsTestsBase.cs" Link="SharedTests\ExistsTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\StoredProcedureSignatureTestsBase.cs" Link="SharedTests\StoredProcedureSignatureTestsBase.cs" />
 		<Compile Include="..\DbSqlLikeMem.Test\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" Link="SharedTests\SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" />
+		<Compile Include="..\DbSqlLikeMem.Test\NHibernateSupportTestsBase.cs" Link="SharedTests\NHibernateSupportTestsBase.cs" />
 	</ItemGroup>
 </Project>

--- a/src/DbSqlLikeMem.Sqlite.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/NHibernateSmokeTests.cs
@@ -1,0 +1,15 @@
+using System.Data.Common;
+
+namespace DbSqlLikeMem.Sqlite.Test;
+
+public sealed class NHibernateSmokeTests : DbSqlLikeMem.Test.NHibernateSupportTestsBase
+{
+    protected override string NhDialectClass => "NHibernate.Dialect.SQLiteDialect, NHibernate";
+
+    protected override DbConnection CreateOpenConnection()
+    {
+        var connection = new SqliteConnectionMock(new SqliteDbMock());
+        connection.Open();
+        return connection;
+    }
+}

--- a/src/DbSqlLikeMem.Test/NHibernateSupportTestsBase.cs
+++ b/src/DbSqlLikeMem.Test/NHibernateSupportTestsBase.cs
@@ -1,0 +1,182 @@
+using System.Data.Common;
+using NHibernate.Cfg;
+using NHibernate.Connection;
+using NHibernate.Mapping.ByCode;
+using NHibernate.Mapping.ByCode.Conformist;
+
+namespace DbSqlLikeMem.Test;
+
+/// <summary>
+/// EN: Shared NHibernate integration contract tests for provider mock connections.
+/// PT: Testes de contrato de integração NHibernate compartilhados para conexões mock por provedor.
+/// </summary>
+public abstract class NHibernateSupportTestsBase
+{
+    /// <summary>
+    /// EN: NHibernate dialect class full name used by this provider contract run.
+    /// PT: Nome completo da classe de dialeto do NHibernate usada nesta execução por provedor.
+    /// </summary>
+    protected abstract string NhDialectClass { get; }
+
+    /// <summary>
+    /// EN: Creates and opens a provider-specific mock connection.
+    /// PT: Cria e abre uma conexão mock específica de provedor.
+    /// </summary>
+    protected abstract DbConnection CreateOpenConnection();
+
+    [Fact]
+    [Trait("Category", "NHibernate")]
+    public void NHibernate_NativeSql_WithParameter_ShouldReturnExpectedRow()
+    {
+        using var connection = CreateOpenConnection();
+        ExecuteNonQuery(connection, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))");
+        ExecuteNonQuery(connection, "INSERT INTO users (id, name) VALUES (1, 'Alice')");
+
+        using var sessionFactory = BuildConfiguration().BuildSessionFactory();
+        using var session = sessionFactory.WithOptions().Connection(connection).OpenSession();
+
+        var rows = session
+            .CreateSQLQuery("SELECT name FROM users WHERE id = :id")
+            .SetParameter("id", 1)
+            .List();
+
+        Assert.Single(rows);
+        Assert.Equal("Alice", rows[0]);
+    }
+
+    [Fact]
+    [Trait("Category", "NHibernate")]
+    public void NHibernate_MappedEntity_SaveAndGet_ShouldWork()
+    {
+        using var connection = CreateOpenConnection();
+        ExecuteNonQuery(connection, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))");
+
+        using var sessionFactory = BuildConfiguration(withMappings: true).BuildSessionFactory();
+        using (var session = sessionFactory.WithOptions().Connection(connection).OpenSession())
+        using (var tx = session.BeginTransaction())
+        {
+            session.Save(new NhTestUser { Id = 2, Name = "Bob" });
+            session.Flush();
+            tx.Commit();
+        }
+
+        using var verifySession = sessionFactory.WithOptions().Connection(connection).OpenSession();
+        var loaded = verifySession.Get<NhTestUser>(2);
+
+        Assert.NotNull(loaded);
+        Assert.Equal("Bob", loaded!.Name);
+    }
+
+    [Fact]
+    [Trait("Category", "NHibernate")]
+    public void NHibernate_MappedEntity_Update_ShouldPersistChanges()
+    {
+        using var connection = CreateOpenConnection();
+        ExecuteNonQuery(connection, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))");
+
+        using var sessionFactory = BuildConfiguration(withMappings: true).BuildSessionFactory();
+        using (var session = sessionFactory.WithOptions().Connection(connection).OpenSession())
+        using (var tx = session.BeginTransaction())
+        {
+            session.Save(new NhTestUser { Id = 4, Name = "Before" });
+            tx.Commit();
+        }
+
+        using (var session = sessionFactory.WithOptions().Connection(connection).OpenSession())
+        using (var tx = session.BeginTransaction())
+        {
+            var user = session.Get<NhTestUser>(4);
+            Assert.NotNull(user);
+            user!.Name = "After";
+            session.Flush();
+            tx.Commit();
+        }
+
+        using var verifySession = sessionFactory.WithOptions().Connection(connection).OpenSession();
+        var updated = verifySession.Get<NhTestUser>(4);
+
+        Assert.NotNull(updated);
+        Assert.Equal("After", updated!.Name);
+    }
+
+    [Fact]
+    [Trait("Category", "NHibernate")]
+    public void NHibernate_TransactionRollback_ShouldDiscardChanges()
+    {
+        using var connection = CreateOpenConnection();
+        ExecuteNonQuery(connection, "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))");
+
+        using var sessionFactory = BuildConfiguration().BuildSessionFactory();
+        using (var session = sessionFactory.WithOptions().Connection(connection).OpenSession())
+        using (var tx = session.BeginTransaction())
+        {
+            session
+                .CreateSQLQuery("INSERT INTO users (id, name) VALUES (:id, :name)")
+                .SetParameter("id", 3)
+                .SetParameter("name", "Rollback")
+                .ExecuteUpdate();
+
+            tx.Rollback();
+        }
+
+        using var verifySession = sessionFactory.WithOptions().Connection(connection).OpenSession();
+        var count = Convert.ToInt32(
+            verifySession
+                .CreateSQLQuery("SELECT COUNT(*) FROM users WHERE id = :id")
+                .SetParameter("id", 3)
+                .UniqueResult());
+
+        Assert.Equal(0, count);
+    }
+
+    private Configuration BuildConfiguration(bool withMappings = false)
+    {
+        var configuration = new Configuration();
+        configuration.SetProperty(Environment.Dialect, NhDialectClass);
+        configuration.SetProperty(Environment.ConnectionProvider, typeof(UserSuppliedConnectionProvider).AssemblyQualifiedName!);
+        configuration.SetProperty(Environment.ReleaseConnections, "on_close");
+
+        if (withMappings)
+        {
+            var mapper = new ModelMapper();
+            mapper.AddMapping<NhTestUserMap>();
+            configuration.AddMapping(mapper.CompileMappingForAllExplicitlyAddedEntities());
+        }
+
+        return configuration;
+    }
+
+    private static void ExecuteNonQuery(DbConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        _ = command.ExecuteNonQuery();
+    }
+
+    private sealed class NhTestUser
+    {
+        public virtual int Id { get; set; }
+
+        public virtual string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class NhTestUserMap : ClassMapping<NhTestUser>
+    {
+        public NhTestUserMap()
+        {
+            Table("users");
+
+            Id(x => x.Id, map =>
+            {
+                map.Column("id");
+                map.Generator(Generators.Assigned);
+            });
+
+            Property(x => x.Name, map =>
+            {
+                map.Column("name");
+                map.NotNullable(true);
+            });
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Make NHibernate contract tests more realistic by configuring a provider-specific NHibernate dialect instead of a single `GenericDialect` for all providers.
- Improve ORM coverage by verifying entity update/flush/reload behavior in addition to raw SQL and basic `Save`/`Get` flows.
- Ensure each provider exercise can drive NHibernate SQL generation and dialect-specific behavior via per-provider configuration.

### Description

- Introduced a shared test base `NHibernateSupportTestsBase` that exposes an abstract `NhDialectClass` and uses it in `BuildConfiguration` to configure NHibernate per provider, and added a new `NHibernate_MappedEntity_Update_ShouldPersistChanges` test scenario.
- Added lightweight per-provider test classes `NHibernateSmokeTests` for MySQL, SQL Server, PostgreSQL (Npgsql), Oracle, SQLite and DB2 which override `NhDialectClass` and `CreateOpenConnection()` to return the provider mock connection.
- Added `NHibernate` package references and linked the shared `NHibernateSupportTestsBase.cs` into the provider test projects so the contract suite compiles for each provider.
- Updated `docs/providers-and-features.md` to note that the NHibernate contract suite runs with a provider-specific NHibernate dialect.

### Testing

- Verified presence of the new contract member `NhDialectClass`, the update test `NHibernate_MappedEntity_Update_ShouldPersistChanges`, `UserSuppliedConnectionProvider` usage, and the docs change using repository searches (`rg`), which succeeded.
- Attempted to run a targeted test with `dotnet test` for a provider-specific NHibernate smoke test, but the environment lacks the .NET SDK so the test run could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979e59da50832c96b22423762e42da)