### PR TITLE
Fix CASE WHEN rewrite type mismatch in AstQueryExecutorBase

### DIFF
--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -591,7 +591,7 @@ internal abstract class AstQueryExecutorBase(
                 }
                 return call with { Args = [.. rewrittenCallArgs] };
             case CaseExpr c:
-                var rewrittenWhens = new List<CaseWhen>(c.Whens.Count);
+                var rewrittenWhens = new List<CaseWhenThen>(c.Whens.Count);
                 foreach (var when in c.Whens)
                 {
                     rewrittenWhens.Add(when with


### PR DESCRIPTION
### Motivation
- Fix a build-breaking type mismatch in `RewriteHavingOrdinals` for `CaseExpr` where `CaseWhen` was incorrectly used instead of the AST `CaseWhenThen`, which produced CS0246/CS1503 errors.

### Description
- Replace `new List<CaseWhen>(...)` with `new List<CaseWhenThen>(...)` in `src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs` so the rewritten `Whens` list matches the `CaseExpr.Whens` element type.

### Testing
- Attempted to run `dotnet build` but it failed in this environment because `dotnet` is not installed (`command not found`).
- Ran a code search with `rg "CaseWhen" -n` to verify references now use `CaseWhenThen`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b587fb80832c8429f95c55f7d6f8)