### PR TITLE
Fix visibility of SqlExceptionMessages for test projects

### DIFF
--- a/src/DbSqlLikeMem/Resources/SqlExceptionMessages.cs
+++ b/src/DbSqlLikeMem/Resources/SqlExceptionMessages.cs
@@ -2,7 +2,7 @@ using System.Resources;
 
 namespace DbSqlLikeMem.Resources;
 
-internal static class SqlExceptionMessages
+public static class SqlExceptionMessages
 {
     private static readonly ResourceManager ResourceManager =
         new("DbSqlLikeMem.Resources.SqlExceptionMessages", typeof(SqlExceptionMessages).Assembly);


### PR DESCRIPTION
### Motivation
- Tests and provider assemblies reference `DbSqlLikeMem.Resources` and need access to the resource helper, so `SqlExceptionMessages` must be accessible across assemblies.

### Description
- Changed `SqlExceptionMessages` from `internal` to `public` in `src/DbSqlLikeMem/Resources/SqlExceptionMessages.cs` to restore visibility to test and provider projects.

### Testing
- Attempted to run `dotnet build DbSqlLikeMem.sln` but the `dotnet` CLI is not available in this environment, so no automated build/test run could be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b666d030832c9404f88e8e77195d)