### PR TITLE
Fix NHibernate shared test compilation in base test project

### DIFF
--- a/src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj
+++ b/src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj
@@ -74,6 +74,7 @@
 	<ItemGroup>
 		<Compile Remove="CsvLoaderAndIndexTestBase.cs" />
 		<Compile Remove="ExistsTestsBase.cs" />
+		<Compile Remove="NHibernateSupportTestsBase.cs" />
 		<Compile Remove="StoredProcedureSignatureTestsBase.cs" />
 		<Compile Remove="SelectIntoInsertSelectUpdateDeleteFromSelectTestsBase.cs" />
 	</ItemGroup>

--- a/src/DbSqlLikeMem.Test/NHibernateSupportTestsBase.cs
+++ b/src/DbSqlLikeMem.Test/NHibernateSupportTestsBase.cs
@@ -153,7 +153,7 @@ public abstract class NHibernateSupportTestsBase
         _ = command.ExecuteNonQuery();
     }
 
-    private sealed class NhTestUser
+    private class NhTestUser
     {
         public virtual int Id { get; set; }
 


### PR DESCRIPTION
### Motivation

- The generic `DbSqlLikeMem.Test` project was attempting to compile NHibernate-specific shared tests even when the project did not reference `NHibernate`, causing missing type errors and build failures.
- The `NhTestUser` helper was `sealed` while declaring `virtual` properties, causing `CS0549` errors when NHibernate mapping expects virtual members.

### Description

- Added `<Compile Remove="NHibernateSupportTestsBase.cs" />` to `src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj` to exclude the NHibernate-specific shared test file from the generic test project.
- Changed `private sealed class NhTestUser` to `private class NhTestUser` in `src/DbSqlLikeMem.Test/NHibernateSupportTestsBase.cs` so its `virtual` properties compile correctly for NHibernate mapping usage.

### Testing

- Attempted to run `dotnet build DbSqlLikeMem.sln -v minimal`, but the environment does not have the `dotnet` CLI installed so the build could not be executed and validated (failed with `bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b9586688832c8737732266185300)