### PR TITLE
Fix HAVING ordinal resolution for decimal literals

### DIFF
--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -628,6 +628,9 @@ internal abstract class AstQueryExecutorBase(
     {
         switch (value)
         {
+            case decimal m when m >= int.MinValue && m <= int.MaxValue && decimal.Truncate(m) == m:
+                ordinal = (int)m;
+                return true;
             case int i:
                 ordinal = i;
                 return true;


### PR DESCRIPTION
### Motivation
- The SQL expression parser emits numeric literals as `decimal`, which prevented numeric literals like `2` from being recognized as ordinals in HAVING rewrites, causing valid queries such as `HAVING 2 BETWEEN ...` to fail.

### Description
- Treat integral `decimal` literals as valid ordinals by adding a `case decimal` branch to `TryLiteralToIntOrdinal` in `src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs` that checks range and integerness and returns the corresponding `int`.

### Testing
- Attempted to run `dotnet test src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj --filter "Having_BetweenWithOrdinal_ShouldResolveOrdinal" -v minimal`, but the command failed in this environment because `dotnet` is not installed (so automated unit tests could not be executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997bec89ad8832c892cfa39ea10d0d1)