### PR TITLE
Fix HAVING IN ordinal test expectation

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Db2AggregationTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2AggregationTests.cs
@@ -218,7 +218,7 @@ public sealed class Db2AggregationTests : XUnitTestBase
                   SELECT userId, SUM(amount) AS sumAmount
                   FROM orders
                   GROUP BY userId
-                  HAVING 2 IN (5, 40)
+                  HAVING 2 IN (40)
                   ORDER BY userId
                   """;
 


### PR DESCRIPTION
### Motivation
- The `Having_InWithOrdinal_ShouldResolveOrdinal` test expected a single grouped row but used `HAVING 2 IN (5, 40)`, which matched two groups given the fixture data, so the predicate needed to be corrected.

### Description
- Update `src/DbSqlLikeMem.Db2.Test/Db2AggregationTests.cs` by replacing `HAVING 2 IN (5, 40)` with `HAVING 2 IN (40)` so the IN-list matches the expected grouped result.

### Testing
- Attempted to run `dotnet test --filter "DbSqlLikeMem.Db2.Test.Db2AggregationTests.Having_InWithOrdinal_ShouldResolveOrdinal"`, but the command could not be run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997c2d53678832c9e712608f85856d1)