### PR TITLE
Add missing NHibernate projects to DbSqlLikeMem solution

### DIFF
--- a/src/DbSqlLikeMem.slnx
+++ b/src/DbSqlLikeMem.slnx
@@ -1,10 +1,12 @@
 <Solution>
   <Folder Name="/Db2/">
+    <Project Path="DbSqlLikeMem.Db2.HNibernate/DbSqlLikeMem.Db2.HNibernate.csproj" />
     <Project Path="DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj" />
     <Project Path="DbSqlLikeMem.Db2/DbSqlLikeMem.Db2.csproj" />
     <Project Path="DbSqlLikeMem.Db2ConsoleGenerator/DbSqlLikeMem.Db2ConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/MySql/">
+    <Project Path="DbSqlLikeMem.MySql.HNibernate/DbSqlLikeMem.MySql.HNibernate.csproj" />
     <Project Path="DbSqlLikeMem.MySql.MiniProfiler.Test/DbSqlLikeMem.MySql.MiniProfiler.Test.csproj" />
     <Project Path="DbSqlLikeMem.MySql.MiniProfiler/DbSqlLikeMem.MySql.MiniProfiler.csproj" />
     <Project Path="DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj" />
@@ -12,11 +14,13 @@
     <Project Path="DbSqlLikeMem.MySqlConsoleGenerator/DbSqlLikeMem.MySqlConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/Npgsql/">
+    <Project Path="DbSqlLikeMem.Npgsql.HNibernate/DbSqlLikeMem.Npgsql.HNibernate.csproj" />
     <Project Path="DbSqlLikeMem.Npgsql.Test/DbSqlLikeMem.Npgsql.Test.csproj" />
     <Project Path="DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj" />
     <Project Path="DbSqlLikeMem.NpgsqlConsoleGenerator/DbSqlLikeMem.NpgsqlConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/Oracle/">
+    <Project Path="DbSqlLikeMem.Oracle.HNibernate/DbSqlLikeMem.Oracle.HNibernate.csproj" />
     <Project Path="DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj" />
     <Project Path="DbSqlLikeMem.Oracle/DbSqlLikeMem.Oracle.csproj" />
     <Project Path="DbSqlLikeMem.OracleConsoleGenerator/DbSqlLikeMem.OracleConsoleGenerator.csproj" />
@@ -27,11 +31,13 @@
     <File Path="README.md" />
   </Folder>
   <Folder Name="/Sqlite/">
+    <Project Path="DbSqlLikeMem.Sqlite.HNibernate/DbSqlLikeMem.Sqlite.HNibernate.csproj" />
     <Project Path="DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj" />
     <Project Path="DbSqlLikeMem.Sqlite/DbSqlLikeMem.Sqlite.csproj" />
     <Project Path="DbSqlLikeMem.SqliteConsoleGenerator/DbSqlLikeMem.SqliteConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/SqlServer/">
+    <Project Path="DbSqlLikeMem.SqlServer.HNibernate/DbSqlLikeMem.SqlServer.HNibernate.csproj" />
     <Project Path="DbSqlLikeMem.SqlServer.Test/DbSqlLikeMem.SqlServer.Test.csproj" />
     <Project Path="DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj" />
     <Project Path="DbSqlLikeMem.SqlServerConsoleGenerator/DbSqlLikeMem.SqlServerConsoleGenerator.csproj" />


### PR DESCRIPTION
### Motivation
- The solution was missing provider-specific NHibernate projects which should be included to keep provider implementations discoverable and buildable from the main solution.

### Description
- Added the six `*.HNibernate` project entries to `src/DbSqlLikeMem.slnx` under their corresponding provider folders: `Db2`, `MySql`, `Npgsql`, `Oracle`, `Sqlite`, and `SqlServer`.
- The updated file is `src/DbSqlLikeMem.slnx` and the change inserts the following project paths: `DbSqlLikeMem.*.HNibernate/DbSqlLikeMem.*.HNibernate.csproj` for each provider.

### Testing
- Attempted to run `dotnet sln src/DbSqlLikeMem.slnx list`, but `dotnet` is not available in this environment so no solution/listing or build tests could be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997d1e7c5b8832cb47b05824670638d)