### PR TITLE
Add missing Dapper and HNibernate test projects to solution

### DIFF
--- a/src/DbSqlLikeMem.slnx
+++ b/src/DbSqlLikeMem.slnx
@@ -1,12 +1,16 @@
 <Solution>
   <Folder Name="/Db2/">
+    <Project Path="DbSqlLikeMem.Db2.Dapper.Test/DbSqlLikeMem.Db2.Dapper.Test.csproj" />
     <Project Path="DbSqlLikeMem.Db2.HNibernate/DbSqlLikeMem.Db2.HNibernate.csproj" />
+    <Project Path="DbSqlLikeMem.Db2.HNibernate.Test/DbSqlLikeMem.Db2.HNibernate.Test.csproj" />
     <Project Path="DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj" />
     <Project Path="DbSqlLikeMem.Db2/DbSqlLikeMem.Db2.csproj" />
     <Project Path="DbSqlLikeMem.Db2ConsoleGenerator/DbSqlLikeMem.Db2ConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/MySql/">
+    <Project Path="DbSqlLikeMem.MySql.Dapper.Test/DbSqlLikeMem.MySql.Dapper.Test.csproj" />
     <Project Path="DbSqlLikeMem.MySql.HNibernate/DbSqlLikeMem.MySql.HNibernate.csproj" />
+    <Project Path="DbSqlLikeMem.MySql.HNibernate.Test/DbSqlLikeMem.MySql.HNibernate.Test.csproj" />
     <Project Path="DbSqlLikeMem.MySql.MiniProfiler.Test/DbSqlLikeMem.MySql.MiniProfiler.Test.csproj" />
     <Project Path="DbSqlLikeMem.MySql.MiniProfiler/DbSqlLikeMem.MySql.MiniProfiler.csproj" />
     <Project Path="DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj" />
@@ -14,13 +18,17 @@
     <Project Path="DbSqlLikeMem.MySqlConsoleGenerator/DbSqlLikeMem.MySqlConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/Npgsql/">
+    <Project Path="DbSqlLikeMem.Npgsql.Dapper.Test/DbSqlLikeMem.Npgsql.Dapper.Test.csproj" />
     <Project Path="DbSqlLikeMem.Npgsql.HNibernate/DbSqlLikeMem.Npgsql.HNibernate.csproj" />
+    <Project Path="DbSqlLikeMem.Npgsql.HNibernate.Test/DbSqlLikeMem.Npgsql.HNibernate.Test.csproj" />
     <Project Path="DbSqlLikeMem.Npgsql.Test/DbSqlLikeMem.Npgsql.Test.csproj" />
     <Project Path="DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj" />
     <Project Path="DbSqlLikeMem.NpgsqlConsoleGenerator/DbSqlLikeMem.NpgsqlConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/Oracle/">
+    <Project Path="DbSqlLikeMem.Oracle.Dapper.Test/DbSqlLikeMem.Oracle.Dapper.Test.csproj" />
     <Project Path="DbSqlLikeMem.Oracle.HNibernate/DbSqlLikeMem.Oracle.HNibernate.csproj" />
+    <Project Path="DbSqlLikeMem.Oracle.HNibernate.Test/DbSqlLikeMem.Oracle.HNibernate.Test.csproj" />
     <Project Path="DbSqlLikeMem.Oracle.Test/DbSqlLikeMem.Oracle.Test.csproj" />
     <Project Path="DbSqlLikeMem.Oracle/DbSqlLikeMem.Oracle.csproj" />
     <Project Path="DbSqlLikeMem.OracleConsoleGenerator/DbSqlLikeMem.OracleConsoleGenerator.csproj" />
@@ -31,13 +39,17 @@
     <File Path="README.md" />
   </Folder>
   <Folder Name="/Sqlite/">
+    <Project Path="DbSqlLikeMem.Sqlite.Dapper.Test/DbSqlLikeMem.Sqlite.Dapper.Test.csproj" />
     <Project Path="DbSqlLikeMem.Sqlite.HNibernate/DbSqlLikeMem.Sqlite.HNibernate.csproj" />
+    <Project Path="DbSqlLikeMem.Sqlite.HNibernate.Test/DbSqlLikeMem.Sqlite.HNibernate.Test.csproj" />
     <Project Path="DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj" />
     <Project Path="DbSqlLikeMem.Sqlite/DbSqlLikeMem.Sqlite.csproj" />
     <Project Path="DbSqlLikeMem.SqliteConsoleGenerator/DbSqlLikeMem.SqliteConsoleGenerator.csproj" />
   </Folder>
   <Folder Name="/SqlServer/">
+    <Project Path="DbSqlLikeMem.SqlServer.Dapper.Test/DbSqlLikeMem.SqlServer.Dapper.Test.csproj" />
     <Project Path="DbSqlLikeMem.SqlServer.HNibernate/DbSqlLikeMem.SqlServer.HNibernate.csproj" />
+    <Project Path="DbSqlLikeMem.SqlServer.HNibernate.Test/DbSqlLikeMem.SqlServer.HNibernate.Test.csproj" />
     <Project Path="DbSqlLikeMem.SqlServer.Test/DbSqlLikeMem.SqlServer.Test.csproj" />
     <Project Path="DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj" />
     <Project Path="DbSqlLikeMem.SqlServerConsoleGenerator/DbSqlLikeMem.SqlServerConsoleGenerator.csproj" />


### PR DESCRIPTION
### Motivation
- Ensure all newly added test projects are included in the solution so IDEs and CI can discover and build them, and the solution accurately reflects the `src` layout.

### Description
- Updated `src/DbSqlLikeMem.slnx` to add the missing `*.Dapper.Test` and `*.HNibernate.Test` project entries for providers `Db2`, `MySql`, `Npgsql`, `Oracle`, `Sqlite`, and `SqlServer`.
- Kept the provider folder grouping intact so every `src/**/*.csproj` is represented by a matching `Project Path` entry in the solution file.

### Testing
- Ran a Python consistency check that compares all `src/**/*.csproj` entries against `Project Path` declarations in `src/DbSqlLikeMem.slnx`, which reported `missing 0` and `extra 0`.
- Attempted `dotnet sln src/DbSqlLikeMem.slnx list`, but `dotnet` is not available in this environment so the `dotnet`-based validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997d8bd2f8c832c8a7acc6ca409c0b2)