### PR TITLE
Refatora Execute<TResult> para remover dependência de Dapper

### DIFF
--- a/src/DbSqlLikeMem.Db2/Db2LinqProvider.cs
+++ b/src/DbSqlLikeMem.Db2/Db2LinqProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using System.Reflection;
 
 namespace DbSqlLikeMem.Db2;
@@ -86,39 +85,10 @@ public sealed class Db2QueryProvider(
     public TResult Execute<TResult>(Expression expression)
     {
         ArgumentNullException.ThrowIfNull(expression);
-
-        // Traduz a árvore de expressão em SQL + parâmetros
         var translation = _translator.Translate(expression);
-
         var sql = translation.Sql ?? string.Empty;
-        var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        // IEnumerable (mas não string)
-        if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
-            && typeof(TResult) != typeof(string))
-        {
-            var elementType = typeof(TResult).IsGenericType
-                ? typeof(TResult).GetGenericArguments().First()
-                : typeof(object);
-
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(elementType);
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs)!;
-
-            return (TResult)data;
-        }
-        else
-        {
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(typeof(TResult));
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs);
-
-            return (TResult)data!;
-        }
+        return LinqQueryExecutor.Execute<TResult>(_cnn, sql, translation.Params);
     }
 
     // Implementação não-genérica, exigida pela interface

--- a/src/DbSqlLikeMem.MySql/MySqlLinqProvider.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlLinqProvider.cs
@@ -82,39 +82,10 @@ public sealed class MySqlQueryProvider(
     public TResult Execute<TResult>(Expression expression)
     {
         ArgumentNullExceptionCompatible.ThrowIfNull(expression, nameof(expression));
-
-        // Traduz a árvore de expressão em SQL + parâmetros
         var translation = _translator.Translate(expression);
-
         var sql = translation.Sql ?? string.Empty;
-        var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        // IEnumerable (mas não string)
-        if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
-            && typeof(TResult) != typeof(string))
-        {
-            var elementType = typeof(TResult).IsGenericType
-                ? typeof(TResult).GetGenericArguments().First()
-                : typeof(object);
-
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(elementType);
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs)!;
-
-            return (TResult)data;
-        }
-        else
-        {
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(typeof(TResult));
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs);
-
-            return (TResult)data!;
-        }
+        return LinqQueryExecutor.Execute<TResult>(_cnn, sql, translation.Params);
     }
 
     // Implementação não-genérica, exigida pela interface

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlLinqProvider.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlLinqProvider.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -87,38 +86,10 @@ public sealed class NpgsqlQueryProvider(
     {
         ArgumentNullExceptionCompatible.ThrowIfNull(expression, nameof(expression));
 
-        // Traduz a árvore de expressão em SQL + parâmetros
         var translation = _translator.Translate(expression);
-
         var sql = translation.Sql ?? string.Empty;
-        var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        // IEnumerable (mas não string)
-        if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
-            && typeof(TResult) != typeof(string))
-        {
-            var elementType = typeof(TResult).IsGenericType
-                ? typeof(TResult).GetGenericArguments().First()
-                : typeof(object);
-
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(elementType);
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs)!;
-
-            return (TResult)data;
-        }
-        else
-        {
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(typeof(TResult));
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs);
-
-            return (TResult)data!;
-        }
+        return LinqQueryExecutor.Execute<TResult>(_cnn, sql, translation.Params);
     }
 
     // Implementação não-genérica, exigida pela interface

--- a/src/DbSqlLikeMem.Oracle/OracleLinqProvider.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleLinqProvider.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -86,39 +85,10 @@ public sealed class OracleQueryProvider(
     public TResult Execute<TResult>(Expression expression)
     {
         ArgumentNullExceptionCompatible.ThrowIfNull(expression, nameof(expression));
-
-        // Traduz a árvore de expressão em SQL + parâmetros
         var translation = _translator.Translate(expression);
-
         var sql = translation.Sql ?? string.Empty;
-        var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        // IEnumerable (mas não string)
-        if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
-            && typeof(TResult) != typeof(string))
-        {
-            var elementType = typeof(TResult).IsGenericType
-                ? typeof(TResult).GetGenericArguments().First()
-                : typeof(object);
-
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(elementType);
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs)!;
-
-            return (TResult)data;
-        }
-        else
-        {
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(typeof(TResult));
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs);
-
-            return (TResult)data!;
-        }
+        return LinqQueryExecutor.Execute<TResult>(_cnn, sql, translation.Params);
     }
 
     // Implementação não-genérica, exigida pela interface

--- a/src/DbSqlLikeMem.SqlServer/SqlServerLinqProvider.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerLinqProvider.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -87,38 +86,10 @@ public sealed class SqlServerQueryProvider(
     {
         ArgumentNullExceptionCompatible.ThrowIfNull(expression, nameof(expression));
 
-        // Traduz a árvore de expressão em SQL + parâmetros
         var translation = _translator.Translate(expression);
-
         var sql = translation.Sql ?? string.Empty;
-        var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        // IEnumerable (mas não string)
-        if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
-            && typeof(TResult) != typeof(string))
-        {
-            var elementType = typeof(TResult).IsGenericType
-                ? typeof(TResult).GetGenericArguments().First()
-                : typeof(object);
-
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(elementType);
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs)!;
-
-            return (TResult)data;
-        }
-        else
-        {
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(typeof(TResult));
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs);
-
-            return (TResult)data!;
-        }
+        return LinqQueryExecutor.Execute<TResult>(_cnn, sql, translation.Params);
     }
 
     // Implementação não-genérica, exigida pela interface

--- a/src/DbSqlLikeMem.Sqlite/SqliteLinqProvider.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteLinqProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using System.Reflection;
 
 namespace DbSqlLikeMem.Sqlite;
@@ -86,39 +85,10 @@ public sealed class SqliteQueryProvider(
     public TResult Execute<TResult>(Expression expression)
     {
         ArgumentNullExceptionCompatible.ThrowIfNull(expression, nameof(expression));
-
-        // Traduz a árvore de expressão em SQL + parâmetros
         var translation = _translator.Translate(expression);
-
         var sql = translation.Sql ?? string.Empty;
-        var paramObj = translation.Params; // anonymous object / DynamicParameters / null
 
-        // IEnumerable (mas não string)
-        if (typeof(IEnumerable).IsAssignableFrom(typeof(TResult))
-            && typeof(TResult) != typeof(string))
-        {
-            var elementType = typeof(TResult).IsGenericType
-                ? typeof(TResult).GetGenericArguments().First()
-                : typeof(object);
-
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("Query", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(elementType);
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs)!;
-
-            return (TResult)data;
-        }
-        else
-        {
-            var def = DapperLateBinding.FindSqlMapperMethodWithOptionalTail("QuerySingleOrDefault", genericArgCount: 1);
-            var mi = def.MakeGenericMethod(typeof(TResult));
-
-            var invokeArgs = DapperLateBinding.BuildInvokeArgs(mi.GetParameters(), _cnn, sql, paramObj);
-            var data = mi.Invoke(null, invokeArgs);
-
-            return (TResult)data!;
-        }
+        return LinqQueryExecutor.Execute<TResult>(_cnn, sql, translation.Params);
     }
 
     // Implementação não-genérica, exigida pela interface

--- a/src/DbSqlLikeMem/Linq/LinqQueryExecutor.cs
+++ b/src/DbSqlLikeMem/Linq/LinqQueryExecutor.cs
@@ -1,0 +1,165 @@
+using System.Collections;
+using System.Data;
+using System.Globalization;
+using System.Reflection;
+
+namespace DbSqlLikeMem;
+
+/// <summary>
+/// Executa consultas LINQ traduzidas para SQL sem depender de Dapper.
+/// </summary>
+public static class LinqQueryExecutor
+{
+    /// <summary>
+    /// Executa SQL e materializa o resultado no tipo esperado.
+    /// </summary>
+    public static TResult Execute<TResult>(IDbConnection connection, string sql, object? parameters)
+    {
+        ArgumentNullExceptionCompatible.ThrowIfNull(connection, nameof(connection));
+        ArgumentNullExceptionCompatible.ThrowIfNull(sql, nameof(sql));
+
+        var resultType = typeof(TResult);
+        if (typeof(IEnumerable).IsAssignableFrom(resultType) && resultType != typeof(string))
+        {
+            var elementType = resultType.IsGenericType
+                ? resultType.GetGenericArguments().First()
+                : typeof(object);
+
+            var list = ExecuteMany(connection, sql, parameters, elementType);
+            return (TResult)list;
+        }
+
+        var single = ExecuteSingle(connection, sql, parameters, resultType);
+        return single is null ? default! : (TResult)single;
+    }
+
+    private static object ExecuteMany(IDbConnection connection, string sql, object? parameters, Type elementType)
+    {
+        using var command = CreateCommand(connection, sql, parameters);
+        using var reader = command.ExecuteReader();
+
+        var listType = typeof(List<>).MakeGenericType(elementType);
+        var list = (IList)Activator.CreateInstance(listType)!;
+
+        while (reader.Read())
+            list.Add(MapRecord(reader, elementType));
+
+        return list;
+    }
+
+    private static object? ExecuteSingle(IDbConnection connection, string sql, object? parameters, Type resultType)
+    {
+        using var command = CreateCommand(connection, sql, parameters);
+        using var reader = command.ExecuteReader();
+
+        if (!reader.Read())
+            return resultType.IsValueType ? Activator.CreateInstance(resultType) : null;
+
+        return MapRecord(reader, resultType);
+    }
+
+    private static IDbCommand CreateCommand(IDbConnection connection, string sql, object? parameters)
+    {
+        var command = connection.CreateCommand();
+        command.CommandType = CommandType.Text;
+        command.CommandText = sql;
+        AddParameters(command, parameters);
+        return command;
+    }
+
+    private static void AddParameters(IDbCommand command, object? parameters)
+    {
+        if (parameters is null)
+            return;
+
+        if (parameters is IEnumerable<KeyValuePair<string, object?>> kvps)
+        {
+            foreach (var kvp in kvps)
+                AddParameter(command, kvp.Key, kvp.Value);
+
+            return;
+        }
+
+        var props = parameters.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
+        foreach (var prop in props)
+        {
+            if (!prop.CanRead)
+                continue;
+
+            AddParameter(command, prop.Name, prop.GetValue(parameters));
+        }
+    }
+
+    private static void AddParameter(IDbCommand command, string name, object? value)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value ?? DBNull.Value;
+        command.Parameters.Add(parameter);
+    }
+
+    private static object? MapRecord(IDataRecord record, Type targetType)
+    {
+        if (targetType == typeof(object))
+            return ReadValue(record, 0, typeof(object));
+
+        if (IsSimpleType(targetType))
+            return ReadValue(record, 0, targetType);
+
+        var instance = Activator.CreateInstance(targetType)
+            ?? throw new InvalidOperationException($"Não foi possível instanciar o tipo {targetType}.");
+
+        var columns = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < record.FieldCount; i++)
+            columns[record.GetName(i)] = i;
+
+        var properties = targetType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(p => p.CanWrite);
+
+        foreach (var property in properties)
+        {
+            if (!columns.TryGetValue(property.Name, out var ordinal))
+                continue;
+
+            var value = ReadValue(record, ordinal, property.PropertyType);
+            property.SetValue(instance, value);
+        }
+
+        return instance;
+    }
+
+    private static object? ReadValue(IDataRecord record, int ordinal, Type destinationType)
+    {
+        if (record.IsDBNull(ordinal))
+            return null;
+
+        var rawValue = record.GetValue(ordinal);
+
+        var underlying = Nullable.GetUnderlyingType(destinationType) ?? destinationType;
+        if (underlying.IsInstanceOfType(rawValue))
+            return rawValue;
+
+        if (underlying.IsEnum)
+            return rawValue is string s
+                ? Enum.Parse(underlying, s, ignoreCase: true)
+                : Enum.ToObject(underlying, rawValue);
+
+        if (underlying == typeof(Guid))
+            return rawValue is Guid g ? g : Guid.Parse(rawValue.ToString()!);
+
+        return Convert.ChangeType(rawValue, underlying, CultureInfo.InvariantCulture);
+    }
+
+    private static bool IsSimpleType(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+        return underlying.IsPrimitive
+            || underlying.IsEnum
+            || underlying == typeof(string)
+            || underlying == typeof(decimal)
+            || underlying == typeof(DateTime)
+            || underlying == typeof(DateTimeOffset)
+            || underlying == typeof(TimeSpan)
+            || underlying == typeof(Guid);
+    }
+}


### PR DESCRIPTION
### Motivation
- Remover a dependência em tempo de execução de `Dapper` nos provedores LINQ e unificar a execução de SQL traduzido usando ADO.NET puro.

### Description
- Adiciona o executor central `LinqQueryExecutor` em `src/DbSqlLikeMem/Linq/LinqQueryExecutor.cs` que expõe `Execute<TResult>(IDbConnection, string, object?)` e auxiliares para criar `IDbCommand`, adicionar parâmetros e materializar resultados.
- Atualiza os provedores LINQ (`SqlServer`, `Npgsql`, `Sqlite`, `MySql`, `Oracle`, `Db2`) para delegarem a execução para `LinqQueryExecutor.Execute<TResult>(_cnn, sql, translation.Params)` em vez de usar `DapperLateBinding`/`SqlMapper` late binding.
- `LinqQueryExecutor` suporta parâmetros passados como dicionário ou objeto anônimo, materializa coleções (`IEnumerable<T>`) e resultados únicos, e faz mapeamentos e conversões para tipos simples, `Nullable<T>`, `enum`, `Guid` e objetos complexos por nome de coluna→propriedade.
- O comportamento antigo via `DapperLateBinding` foi removido dos providers; a classe de interoperabilidade com Dapper permaneceu sem alteração no repositório.

### Testing
- Tentativa de executar testes automatizados com `dotnet test src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj -v minimal` falhou porque o SDK .NET não está presente no ambiente (`bash: command not found: dotnet`), portanto nenhum teste automatizado foi executado com sucesso neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69984db22c58832ca4c9d3803b530532)