### PR TITLE
Add bilingual XML documentation and enable named-parameter behavior for NHibernate mock drivers

### DIFF
--- a/src/DbSqlLikeMem.Db2.HNibernate/Db2NhMockDriver.cs
+++ b/src/DbSqlLikeMem.Db2.HNibernate/Db2NhMockDriver.cs
@@ -6,6 +6,10 @@ namespace DbSqlLikeMem.Db2.HNibernate;
 /// </summary>
 public sealed class Db2NhMockDriver : ReflectionBasedDriver
 {
+    /// <summary>
+    /// EN: Initializes a NHibernate mock driver for DbSqlLikeMem DB2 provider types.
+    /// PT: Inicializa um driver mock do NHibernate para os tipos do provedor DB2 do DbSqlLikeMem.
+    /// </summary>
     public Db2NhMockDriver()
         : base(
             "DbSqlLikeMem.Db2",
@@ -15,9 +19,21 @@ public sealed class Db2NhMockDriver : ReflectionBasedDriver
     {
     }
 
-    public override bool UseNamedPrefixInSql => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that named parameter prefixes must be rendered in generated SQL text.
+    /// PT: Indica que os prefixos de parâmetros nomeados devem ser renderizados no SQL gerado.
+    /// </summary>
+    public override bool UseNamedPrefixInSql => true;
 
-    public override bool UseNamedPrefixInParameter => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that parameter names are expected to include the named prefix.
+    /// PT: Indica que os nomes dos parâmetros devem incluir o prefixo nomeado.
+    /// </summary>
+    public override bool UseNamedPrefixInParameter => true;
 
-    public override string NamedPrefix => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Gets the named parameter prefix used by this driver.
+    /// PT: Obtém o prefixo de parâmetro nomeado usado por este driver.
+    /// </summary>
+    public override string NamedPrefix => "@";
 }

--- a/src/DbSqlLikeMem.MySql.HNibernate/MySqlNhMockDriver.cs
+++ b/src/DbSqlLikeMem.MySql.HNibernate/MySqlNhMockDriver.cs
@@ -6,6 +6,10 @@ namespace DbSqlLikeMem.MySql.HNibernate;
 /// </summary>
 public sealed class MySqlNhMockDriver : ReflectionBasedDriver
 {
+    /// <summary>
+    /// EN: Initializes a NHibernate mock driver for DbSqlLikeMem MySql provider types.
+    /// PT: Inicializa um driver mock do NHibernate para os tipos do provedor MySql do DbSqlLikeMem.
+    /// </summary>
     public MySqlNhMockDriver()
         : base(
             "DbSqlLikeMem.MySql",
@@ -15,9 +19,21 @@ public sealed class MySqlNhMockDriver : ReflectionBasedDriver
     {
     }
 
-    public override bool UseNamedPrefixInSql => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that named parameter prefixes must be rendered in generated SQL text.
+    /// PT: Indica que os prefixos de parâmetros nomeados devem ser renderizados no SQL gerado.
+    /// </summary>
+    public override bool UseNamedPrefixInSql => true;
 
-    public override bool UseNamedPrefixInParameter => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that parameter names are expected to include the named prefix.
+    /// PT: Indica que os nomes dos parâmetros devem incluir o prefixo nomeado.
+    /// </summary>
+    public override bool UseNamedPrefixInParameter => true;
 
-    public override string NamedPrefix => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Gets the named parameter prefix used by this driver.
+    /// PT: Obtém o prefixo de parâmetro nomeado usado por este driver.
+    /// </summary>
+    public override string NamedPrefix => "@";
 }

--- a/src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs
+++ b/src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs
@@ -31,6 +31,10 @@ public abstract class NHibernateSupportTestsBase
     /// </summary>
     protected virtual string? NhDriverClass => null;
 
+    /// <summary>
+    /// EN: Verifies native SQL with a named parameter returns the expected row.
+    /// PT: Verifica se SQL nativo com parâmetro nomeado retorna a linha esperada.
+    /// </summary>
     [Fact]
     [Trait("Category", "NHibernate")]
     public void NHibernate_NativeSql_WithParameter_ShouldReturnExpectedRow()
@@ -51,6 +55,10 @@ public abstract class NHibernateSupportTestsBase
         Assert.Equal("Alice", rows[0]);
     }
 
+    /// <summary>
+    /// EN: Verifies a mapped entity can be saved and loaded using NHibernate.
+    /// PT: Verifica se uma entidade mapeada pode ser salva e carregada usando NHibernate.
+    /// </summary>
     [Fact]
     [Trait("Category", "NHibernate")]
     public void NHibernate_MappedEntity_SaveAndGet_ShouldWork()
@@ -74,6 +82,10 @@ public abstract class NHibernateSupportTestsBase
         Assert.Equal("Bob", loaded!.Name);
     }
 
+    /// <summary>
+    /// EN: Verifies mapped entity updates are persisted across sessions.
+    /// PT: Verifica se atualizações de entidade mapeada são persistidas entre sessões.
+    /// </summary>
     [Fact]
     [Trait("Category", "NHibernate")]
     public void NHibernate_MappedEntity_Update_ShouldPersistChanges()
@@ -106,6 +118,10 @@ public abstract class NHibernateSupportTestsBase
         Assert.Equal("After", updated!.Name);
     }
 
+    /// <summary>
+    /// EN: Verifies rolled-back transactions do not persist data changes.
+    /// PT: Verifica se transações com rollback não persistem alterações de dados.
+    /// </summary>
     [Fact]
     [Trait("Category", "NHibernate")]
     public void NHibernate_TransactionRollback_ShouldDiscardChanges()

--- a/src/DbSqlLikeMem.Npgsql.HNibernate/NpgsqlNhMockDriver.cs
+++ b/src/DbSqlLikeMem.Npgsql.HNibernate/NpgsqlNhMockDriver.cs
@@ -6,6 +6,10 @@ namespace DbSqlLikeMem.Npgsql.HNibernate;
 /// </summary>
 public sealed class NpgsqlNhMockDriver : ReflectionBasedDriver
 {
+    /// <summary>
+    /// EN: Initializes a NHibernate mock driver for DbSqlLikeMem Npgsql provider types.
+    /// PT: Inicializa um driver mock do NHibernate para os tipos do provedor Npgsql do DbSqlLikeMem.
+    /// </summary>
     public NpgsqlNhMockDriver()
         : base(
             "DbSqlLikeMem.Npgsql",
@@ -15,9 +19,21 @@ public sealed class NpgsqlNhMockDriver : ReflectionBasedDriver
     {
     }
 
-    public override bool UseNamedPrefixInSql => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that named parameter prefixes must be rendered in generated SQL text.
+    /// PT: Indica que os prefixos de parâmetros nomeados devem ser renderizados no SQL gerado.
+    /// </summary>
+    public override bool UseNamedPrefixInSql => true;
 
-    public override bool UseNamedPrefixInParameter => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that parameter names are expected to include the named prefix.
+    /// PT: Indica que os nomes dos parâmetros devem incluir o prefixo nomeado.
+    /// </summary>
+    public override bool UseNamedPrefixInParameter => true;
 
-    public override string NamedPrefix => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Gets the named parameter prefix used by this driver.
+    /// PT: Obtém o prefixo de parâmetro nomeado usado por este driver.
+    /// </summary>
+    public override string NamedPrefix => "@";
 }

--- a/src/DbSqlLikeMem.Npgsql.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/ExecutionPlanTests.cs
@@ -1,9 +1,25 @@
 namespace DbSqlLikeMem.Npgsql.Test;
 
-public sealed class ExecutionPlanTests(
-    ITestOutputHelper helper
-) : XUnitTestBase(helper)
+/// <summary>
+/// EN: Execution plan coverage tests for Npgsql mock commands.
+/// PT: Testes de cobertura de plano de execução para comandos mock Npgsql.
+/// </summary>
+public sealed class ExecutionPlanTests : XUnitTestBase
 {
+    /// <summary>
+    /// EN: Initializes execution plan tests with xUnit output integration.
+    /// PT: Inicializa os testes de plano de execução com integração de saída do xUnit.
+    /// </summary>
+    /// <param name="helper">EN: xUnit output helper. PT: Helper de saída do xUnit.</param>
+    public ExecutionPlanTests(ITestOutputHelper helper)
+        : base(helper)
+    {
+    }
+
+    /// <summary>
+    /// EN: Ensures command execution generates a readable execution plan in test output.
+    /// PT: Garante que a execução do comando gere um plano de execução legível na saída do teste.
+    /// </summary>
     [Fact]
     [Trait("Category", "ExecutionPlan")]
     public void ExecuteReader_ShouldGenerateExecutionPlan_AndPrintOnTestOutput()

--- a/src/DbSqlLikeMem.Oracle.HNibernate/OracleNhMockDriver.cs
+++ b/src/DbSqlLikeMem.Oracle.HNibernate/OracleNhMockDriver.cs
@@ -6,6 +6,10 @@ namespace DbSqlLikeMem.Oracle.HNibernate;
 /// </summary>
 public sealed class OracleNhMockDriver : ReflectionBasedDriver
 {
+    /// <summary>
+    /// EN: Initializes a NHibernate mock driver for DbSqlLikeMem Oracle provider types.
+    /// PT: Inicializa um driver mock do NHibernate para os tipos do provedor Oracle do DbSqlLikeMem.
+    /// </summary>
     public OracleNhMockDriver()
         : base(
             "DbSqlLikeMem.Oracle",
@@ -15,9 +19,21 @@ public sealed class OracleNhMockDriver : ReflectionBasedDriver
     {
     }
 
-    public override bool UseNamedPrefixInSql => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that named parameter prefixes must be rendered in generated SQL text.
+    /// PT: Indica que os prefixos de parâmetros nomeados devem ser renderizados no SQL gerado.
+    /// </summary>
+    public override bool UseNamedPrefixInSql => true;
 
-    public override bool UseNamedPrefixInParameter => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that parameter names are expected to include the named prefix.
+    /// PT: Indica que os nomes dos parâmetros devem incluir o prefixo nomeado.
+    /// </summary>
+    public override bool UseNamedPrefixInParameter => true;
 
-    public override string NamedPrefix => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Gets the named parameter prefix used by this driver.
+    /// PT: Obtém o prefixo de parâmetro nomeado usado por este driver.
+    /// </summary>
+    public override string NamedPrefix => "@";
 }

--- a/src/DbSqlLikeMem.Oracle.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/ExecutionPlanTests.cs
@@ -1,9 +1,25 @@
 namespace DbSqlLikeMem.Oracle.Test;
 
-public sealed class ExecutionPlanTests(
-    ITestOutputHelper helper
-) : XUnitTestBase(helper)
+/// <summary>
+/// EN: Execution plan coverage tests for Oracle mock commands.
+/// PT: Testes de cobertura de plano de execução para comandos mock Oracle.
+/// </summary>
+public sealed class ExecutionPlanTests : XUnitTestBase
 {
+    /// <summary>
+    /// EN: Initializes execution plan tests with xUnit output integration.
+    /// PT: Inicializa os testes de plano de execução com integração de saída do xUnit.
+    /// </summary>
+    /// <param name="helper">EN: xUnit output helper. PT: Helper de saída do xUnit.</param>
+    public ExecutionPlanTests(ITestOutputHelper helper)
+        : base(helper)
+    {
+    }
+
+    /// <summary>
+    /// EN: Ensures command execution generates a readable execution plan in test output.
+    /// PT: Garante que a execução do comando gere um plano de execução legível na saída do teste.
+    /// </summary>
     [Fact]
     [Trait("Category", "ExecutionPlan")]
     public void ExecuteReader_ShouldGenerateExecutionPlan_AndPrintOnTestOutput()

--- a/src/DbSqlLikeMem.SqlServer.HNibernate/SqlServerNhMockDriver.cs
+++ b/src/DbSqlLikeMem.SqlServer.HNibernate/SqlServerNhMockDriver.cs
@@ -6,6 +6,10 @@ namespace DbSqlLikeMem.SqlServer.HNibernate;
 /// </summary>
 public sealed class SqlServerNhMockDriver : ReflectionBasedDriver
 {
+    /// <summary>
+    /// EN: Initializes a NHibernate mock driver for DbSqlLikeMem SqlServer provider types.
+    /// PT: Inicializa um driver mock do NHibernate para os tipos do provedor SqlServer do DbSqlLikeMem.
+    /// </summary>
     public SqlServerNhMockDriver()
         : base(
             "DbSqlLikeMem.SqlServer",
@@ -15,9 +19,21 @@ public sealed class SqlServerNhMockDriver : ReflectionBasedDriver
     {
     }
 
-    public override bool UseNamedPrefixInSql => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that named parameter prefixes must be rendered in generated SQL text.
+    /// PT: Indica que os prefixos de parâmetros nomeados devem ser renderizados no SQL gerado.
+    /// </summary>
+    public override bool UseNamedPrefixInSql => true;
 
-    public override bool UseNamedPrefixInParameter => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that parameter names are expected to include the named prefix.
+    /// PT: Indica que os nomes dos parâmetros devem incluir o prefixo nomeado.
+    /// </summary>
+    public override bool UseNamedPrefixInParameter => true;
 
-    public override string NamedPrefix => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Gets the named parameter prefix used by this driver.
+    /// PT: Obtém o prefixo de parâmetro nomeado usado por este driver.
+    /// </summary>
+    public override string NamedPrefix => "@";
 }

--- a/src/DbSqlLikeMem.SqlServer.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/ExecutionPlanTests.cs
@@ -1,9 +1,25 @@
 namespace DbSqlLikeMem.SqlServer.Test;
 
-public sealed class ExecutionPlanTests(
-    ITestOutputHelper helper
-) : XUnitTestBase(helper)
+/// <summary>
+/// EN: Execution plan coverage tests for SqlServer mock commands.
+/// PT: Testes de cobertura de plano de execução para comandos mock SqlServer.
+/// </summary>
+public sealed class ExecutionPlanTests : XUnitTestBase
 {
+    /// <summary>
+    /// EN: Initializes execution plan tests with xUnit output integration.
+    /// PT: Inicializa os testes de plano de execução com integração de saída do xUnit.
+    /// </summary>
+    /// <param name="helper">EN: xUnit output helper. PT: Helper de saída do xUnit.</param>
+    public ExecutionPlanTests(ITestOutputHelper helper)
+        : base(helper)
+    {
+    }
+
+    /// <summary>
+    /// EN: Ensures command execution generates a readable execution plan in test output.
+    /// PT: Garante que a execução do comando gere um plano de execução legível na saída do teste.
+    /// </summary>
     [Fact]
     [Trait("Category", "ExecutionPlan")]
     public void ExecuteReader_ShouldGenerateExecutionPlan_AndPrintOnTestOutput()

--- a/src/DbSqlLikeMem.Sqlite.HNibernate/SqliteNhMockDriver.cs
+++ b/src/DbSqlLikeMem.Sqlite.HNibernate/SqliteNhMockDriver.cs
@@ -6,6 +6,10 @@ namespace DbSqlLikeMem.Sqlite.HNibernate;
 /// </summary>
 public sealed class SqliteNhMockDriver : ReflectionBasedDriver
 {
+    /// <summary>
+    /// EN: Initializes a NHibernate mock driver for DbSqlLikeMem Sqlite provider types.
+    /// PT: Inicializa um driver mock do NHibernate para os tipos do provedor Sqlite do DbSqlLikeMem.
+    /// </summary>
     public SqliteNhMockDriver()
         : base(
             "DbSqlLikeMem.Sqlite",
@@ -15,9 +19,21 @@ public sealed class SqliteNhMockDriver : ReflectionBasedDriver
     {
     }
 
-    public override bool UseNamedPrefixInSql => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that named parameter prefixes must be rendered in generated SQL text.
+    /// PT: Indica que os prefixos de parâmetros nomeados devem ser renderizados no SQL gerado.
+    /// </summary>
+    public override bool UseNamedPrefixInSql => true;
 
-    public override bool UseNamedPrefixInParameter => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Indicates that parameter names are expected to include the named prefix.
+    /// PT: Indica que os nomes dos parâmetros devem incluir o prefixo nomeado.
+    /// </summary>
+    public override bool UseNamedPrefixInParameter => true;
 
-    public override string NamedPrefix => throw new NotImplementedException();
+    /// <summary>
+    /// EN: Gets the named parameter prefix used by this driver.
+    /// PT: Obtém o prefixo de parâmetro nomeado usado por este driver.
+    /// </summary>
+    public override string NamedPrefix => "@";
 }

--- a/src/DbSqlLikeMem.Sqlite.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/ExecutionPlanTests.cs
@@ -1,9 +1,25 @@
 namespace DbSqlLikeMem.Sqlite.Test;
 
-public sealed class ExecutionPlanTests(
-    ITestOutputHelper helper
-) : XUnitTestBase(helper)
+/// <summary>
+/// EN: Execution plan coverage tests for Sqlite mock commands.
+/// PT: Testes de cobertura de plano de execução para comandos mock Sqlite.
+/// </summary>
+public sealed class ExecutionPlanTests : XUnitTestBase
 {
+    /// <summary>
+    /// EN: Initializes execution plan tests with xUnit output integration.
+    /// PT: Inicializa os testes de plano de execução com integração de saída do xUnit.
+    /// </summary>
+    /// <param name="helper">EN: xUnit output helper. PT: Helper de saída do xUnit.</param>
+    public ExecutionPlanTests(ITestOutputHelper helper)
+        : base(helper)
+    {
+    }
+
+    /// <summary>
+    /// EN: Ensures command execution generates a readable execution plan in test output.
+    /// PT: Garante que a execução do comando gere um plano de execução legível na saída do teste.
+    /// </summary>
     [Fact]
     [Trait("Category", "ExecutionPlan")]
     public void ExecuteReader_ShouldGenerateExecutionPlan_AndPrintOnTestOutput()


### PR DESCRIPTION
### Motivation

- Fix NHibernate mock drivers that previously threw `NotImplementedException` for named-parameter behavior and silence CS1591 warnings by adding XML documentation. 
- Provide bilingual documentation (English then Portuguese) for public constructors and test surfaces to improve IDE/CI diagnostics and developer experience.

### Description

- Implemented the overrides `UseNamedPrefixInSql`, `UseNamedPrefixInParameter` and `NamedPrefix` to return `true`, `true` and `"@"` respectively in the NHibernate mock drivers for `SqlServer`, `Sqlite`, `MySql`, `Oracle`, `Npgsql` and `Db2`. 
- Added bilingual XML `<summary>` comments (English first, then Portuguese) to driver constructors and the public parameter-prefix properties. 
- Added bilingual XML `<summary>` comments to public test methods in `NHibernateSupportTestsBase` and converted the `ExecutionPlanTests` classes (Sqlite/SqlServer/Oracle/Npgsql) from primary-constructor syntax to explicit constructors so constructor summaries can be attached, and added class/ctor/method summaries. 
- Replaced remaining `throw new NotImplementedException()` occurrences for these properties with concrete implementations to enable named-parameter behavior in tests and integrations.

### Testing

- Verified presence of inserted `<summary>` comments across target files using repository search (`rg`) which succeeded. 
- Attempted to run `dotnet test` to execute unit tests but the .NET SDK is not available in this environment so test execution could not be performed (`dotnet test` failed due to missing SDK). 
- Performed basic repository verification of the changed files to confirm the edits were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986a3309ac832c9ccb7eb01d9958c0)