### PR TITLE
Add bilingual XML summaries to ExecutionPlanTests (MySql & Db2)

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/ExecutionPlanTests.cs
@@ -1,9 +1,21 @@
 namespace DbSqlLikeMem.Db2.Test;
 
+/// <summary>
+/// EN: Validates generation of execution plans for Db2 command execution.
+/// PT: Valida a geração de planos de execução para a execução de comandos Db2.
+/// </summary>
 public sealed class ExecutionPlanTests(
+    /// <summary>
+    /// EN: Receives the test output helper used by the base class.
+    /// PT: Recebe o helper de saída de teste usado pela classe base.
+    /// </summary>
     ITestOutputHelper helper
 ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Ensures ExecuteReader generates an execution plan with expected performance and row metrics.
+    /// PT: Garante que o ExecuteReader gere um plano de execução com métricas esperadas de desempenho e de linhas.
+    /// </summary>
     [Fact]
     [Trait("Category", "ExecutionPlan")]
     public void ExecuteReader_ShouldGenerateExecutionPlan_AndPrintOnTestOutput()

--- a/src/DbSqlLikeMem.MySql.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/ExecutionPlanTests.cs
@@ -1,9 +1,21 @@
 namespace DbSqlLikeMem.MySql.Test;
 
+/// <summary>
+/// EN: Validates generation and persistence of execution plans for MySql command execution.
+/// PT: Valida a geração e a persistência de planos de execução para a execução de comandos MySql.
+/// </summary>
 public sealed class ExecutionPlanTests(
+    /// <summary>
+    /// EN: Receives the test output helper used by the base class.
+    /// PT: Recebe o helper de saída de teste usado pela classe base.
+    /// </summary>
     ITestOutputHelper helper
 ) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Ensures ExecuteReader generates an execution plan with core metrics and prints it in test output.
+    /// PT: Garante que o ExecuteReader gere um plano de execução com métricas principais e o imprima na saída do teste.
+    /// </summary>
     [Fact]
     [Trait("Category", "ExecutionPlan")]
     public void ExecuteReader_ShouldGenerateExecutionPlan_AndPrintOnTestOutput()
@@ -44,6 +56,10 @@ public sealed class ExecutionPlanTests(
         Console.WriteLine("[ExecutionPlan]\n" + cnn.LastExecutionPlan);
     }
 
+    /// <summary>
+    /// EN: Ensures multi-select execution stores an execution plan entry for each result set.
+    /// PT: Garante que a execução com múltiplos selects armazene um plano de execução para cada conjunto de resultados.
+    /// </summary>
     [Fact]
     [Trait("Category", "ExecutionPlan")]
     public void ExecuteReader_MultiSelect_ShouldKeepExecutionPlanList()


### PR DESCRIPTION
### Motivation

- Add XML `<summary>` documentation to resolve CS1591 warnings for publicly visible test classes and members.
- Provide bilingual documentation with English first and Portuguese second to match project conventions and improve test code readability.

### Description

- Added class-level and member-level XML `<summary>` blocks to `src/DbSqlLikeMem.MySql.Test/ExecutionPlanTests.cs` describing purpose, constructor parameter, and main test methods in English then Portuguese.
- Added class-level and member-level XML `<summary>` blocks to `src/DbSqlLikeMem.Db2.Test/ExecutionPlanTests.cs` describing purpose, constructor parameter, and main test method in English then Portuguese.
- Changes are documentation-only and do not modify runtime logic or test behavior, and were committed with the message `Add bilingual XML summaries to execution plan tests`.

### Testing

- Attempted to run `dotnet test src/DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj --no-restore -v minimal`, but the `dotnet` command is not available in this environment so the test run failed.
- No other automated test runs were executed in this environment; changes are limited to XML comments only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699870edef40832ca92c2293d042b4a3)