### PR TITLE
Fix integer getters to support decimal-backed values in DbDataReaderMockBase

### DIFF
--- a/src/DbSqlLikeMem/Base/DbDataReaderMockBase.cs
+++ b/src/DbSqlLikeMem/Base/DbDataReaderMockBase.cs
@@ -143,17 +143,17 @@ public abstract class DbDataReaderMockBase(
     /// EN: Gets an Int16 value from the specified column.
     /// PT: Obtém valor Int16 da coluna indicada.
     /// </summary>
-    public override short GetInt16(int ordinal) => (short)this[ordinal];
+    public override short GetInt16(int ordinal) => Convert.ToInt16(this[ordinal], System.Globalization.CultureInfo.InvariantCulture);
     /// <summary>
     /// EN: Gets an Int32 value from the specified column.
     /// PT: Obtém valor Int32 da coluna indicada.
     /// </summary>
-    public override int GetInt32(int ordinal) => (int)this[ordinal];
+    public override int GetInt32(int ordinal) => Convert.ToInt32(this[ordinal], System.Globalization.CultureInfo.InvariantCulture);
     /// <summary>
     /// EN: Gets an Int64 value from the specified column.
     /// PT: Obtém valor Int64 da coluna indicada.
     /// </summary>
-    public override long GetInt64(int ordinal) => (long)this[ordinal];
+    public override long GetInt64(int ordinal) => Convert.ToInt64(this[ordinal], System.Globalization.CultureInfo.InvariantCulture);
     /// <summary>
     /// EN: Gets the column name by ordinal.
     /// PT: Obtém o nome da coluna pelo ordinal.


### PR DESCRIPTION
### Motivation
- The MySQL multi-select execution plan test failed with `InvalidCastException` when `GetInt32` tried to cast a `decimal` (e.g. `SELECT 1 AS A`) to `int`, so the reader must tolerate numeric values represented as `decimal`.

### Description
- Replaced direct casts with safe conversions in `DbDataReaderMockBase` by updating `GetInt16`, `GetInt32`, and `GetInt64` to use `Convert.ToInt16/ToInt32/ToInt64` with `System.Globalization.CultureInfo.InvariantCulture` in `src/DbSqlLikeMem/Base/DbDataReaderMockBase.cs`.
- This change allows integer readers to accept numeric values provided as `decimal` (or other convertible numeric types) without throwing `InvalidCastException`.

### Testing
- Attempted to run the failing test with `dotnet test src/DbSqlLikeMem.MySql.Test/DbSqlLikeMem.MySql.Test.csproj --filter "ExecutionPlanTests.ExecuteReader_MultiSelect_ShouldKeepExecutionPlanList"`, but the container does not have `dotnet` installed, producing `bash: command not found: dotnet`, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699879200ba4832cb2c6b95772472c0b)