### PR TITLE
Disable NHibernate hbm2ddl keyword lookup in test base

### DIFF
--- a/src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs
+++ b/src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs
@@ -158,6 +158,7 @@ public abstract class NHibernateSupportTestsBase
         configuration.SetProperty(Environment.Dialect, NhDialectClass);
         configuration.SetProperty(Environment.ConnectionProvider, typeof(UserSuppliedConnectionProvider).AssemblyQualifiedName!);
         configuration.SetProperty(Environment.ReleaseConnections, "on_close");
+        configuration.SetProperty("hbm2ddl.keywords", "none");
         if (!string.IsNullOrWhiteSpace(NhDriverClass))
             configuration.SetProperty(Environment.ConnectionDriver, NhDriverClass);
 


### PR DESCRIPTION
### Motivation
- Prevent NHibernate from requesting a connection from `UserSuppliedConnectionProvider` during `BuildSessionFactory()` by disabling schema keyword metadata lookup.

### Description
- Set `hbm2ddl.keywords = none` in `NHibernateSupportTestsBase.BuildConfiguration()` (`src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs`) so the test base does not trigger an early connection fetch and tests can provide the open mock connection.

### Testing
- Attempted to run `dotnet test --filter NHibernate_MappedEntity_SaveAndGet_ShouldWork` but the `dotnet` CLI is not available in this environment, so the automated test run failed with `bash: command not found: dotnet`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699893628800832cbafa01f12414979d)