### PR TITLE
Add parameterless Db2CommandMock constructor for NHibernate

### DIFF
--- a/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
@@ -9,6 +9,14 @@ public class Db2CommandMock(
     Db2TransactionMock? transaction = null
     ) : DbCommand
 {
+    /// <summary>
+    /// EN: Parameterless constructor required for reflection-based providers.
+    /// PT: Construtor sem parâmetros exigido por providers baseados em reflexão.
+    /// </summary>
+    public Db2CommandMock() : this(null, null)
+    {
+    }
+
     private bool disposedValue;
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- Provide a public parameterless constructor so reflection-based providers (such as NHibernate's command factory) can instantiate `Db2CommandMock` without throwing `MissingMethodException`.

### Description
- Added a public parameterless constructor `Db2CommandMock()` that delegates to the existing constructor via `this(null, null)` in `src/DbSqlLikeMem.Db2/Db2CommandMock.cs`.

### Testing
- Attempted to run `dotnet test src/DbSqlLikeMem.Db2.NHibernate.Test/DbSqlLikeMem.Db2.NHibernate.Test.csproj --filter "NHibernate_MappedEntity_SaveAndGet_ShouldWork"`, but the command failed because `dotnet` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699899e72a6c832c8397a0a39caad1a9)