### PR TITLE
Fix NHibernate command construction and identifier normalization

### DIFF
--- a/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
@@ -9,6 +9,11 @@ public class MySqlCommandMock(
     MySqlTransactionMock? transaction = null
     ) : DbCommand
 {
+    public MySqlCommandMock()
+        : this(null, null)
+    {
+    }
+
     private bool disposedValue;
 
     /// <summary>

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
@@ -12,6 +12,11 @@ public class NpgsqlCommandMock(
     NpgsqlTransactionMock? transaction = null
     ) : DbCommand
 {
+    public NpgsqlCommandMock()
+        : this(null, null)
+    {
+    }
+
     private bool disposedValue;
 
     /// <summary>

--- a/src/DbSqlLikeMem/Extensions/SqlStringExtencions.cs
+++ b/src/DbSqlLikeMem/Extensions/SqlStringExtencions.cs
@@ -45,9 +45,41 @@ internal static class SqlStringExtencions
     /// </summary>
     public static string NormalizeName(this string name)
     {
-        name = name.Trim();
-        name = name.Trim('`');       // remove `User`
-        name = name.Trim();          // de novo por segurança
-        return name;
+        ArgumentNullExceptionCompatible.ThrowIfNull(name, nameof(name));
+
+        var trimmed = name.Trim();
+        if (trimmed.Length == 0)
+            return string.Empty;
+
+        if (!trimmed.Contains('.'))
+            return StripIdentifierWrappers(trimmed);
+
+        var parts = trimmed.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = 0; i < parts.Length; i++)
+            parts[i] = StripIdentifierWrappers(parts[i]);
+
+        return string.Join('.', parts);
+    }
+
+    private static string StripIdentifierWrappers(string identifier)
+    {
+        var normalized = identifier.Trim();
+
+        while (normalized.Length >= 2)
+        {
+            var first = normalized[0];
+            var last = normalized[^1];
+            var hasWrapperPair =
+                (first == '`' && last == '`') ||
+                (first == '"' && last == '"') ||
+                (first == '[' && last == ']');
+
+            if (!hasWrapperPair)
+                break;
+
+            normalized = normalized[1..^1].Trim();
+        }
+
+        return normalized;
     }
 }


### PR DESCRIPTION
### Motivation
- NHibernate tests were failing due to reflection-based activation attempts creating command objects without parameterless constructors and insert column resolution mismatches when identifiers were quoted or qualified.
- The goal is to allow NHibernate to instantiate command mocks and to normalize quoted/dotted identifiers so column lookup (`id` vs `"id"`/`[id]`/`` `id` ``) succeeds.

### Description
- Added explicit parameterless constructors to `NpgsqlCommandMock` and `MySqlCommandMock` so reflection-based creation (e.g. `Activator.CreateInstance`) succeeds. 
- Reworked `NormalizeName` in `SqlStringExtencions.cs` to unwrap identifier wrappers (`"name"`, `` `name` ``, `[name]`) and to normalize each segment of dotted identifiers separately. 
- Introduced `StripIdentifierWrappers` helper to iteratively remove matching wrapper pairs from identifier segments to ensure consistent lookup against `TableMock.Columns`.

### Testing
- Attempted to run `dotnet test`, but the environment lacks the `dotnet` tool so tests could not be executed (`command not found`).
- Ran `git diff --check` and static checks which reported no whitespace/diff errors and validated the source edits.
- Verified via source inspection that `NormalizeName` now handles quoted and dotted identifiers and that the added constructors are present for reflection-based activation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989ca8d444832c812e8a2917e34a8e)