### PR TITLE
Add bilingual XML summaries to NHibernate smoke tests

### DIFF
--- a/src/DbSqlLikeMem.Db2.NHibernate.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.Db2.NHibernate.Test/NHibernateSmokeTests.cs
@@ -1,11 +1,27 @@
 namespace DbSqlLikeMem.Db2.NHibernate.Test;
 
+/// <summary>
+/// Runs smoke tests for NHibernate integration using the DB2 in-memory mock provider.
+/// Executa testes de fumaça para integração do NHibernate usando o provedor simulado em memória do DB2.
+/// </summary>
 public sealed class NHibernateSmokeTests : NHibernateSupportTestsBase
 {
+    /// <summary>
+    /// Gets the NHibernate dialect class used to emulate DB2 SQL behavior.
+    /// Obtém a classe de dialeto do NHibernate usada para emular o comportamento SQL do DB2.
+    /// </summary>
     protected override string NhDialectClass => "NHibernate.Dialect.DB2Dialect, NHibernate";
 
+    /// <summary>
+    /// Gets the NHibernate driver class that connects NHibernate to the DB2 mock connection.
+    /// Obtém a classe de driver do NHibernate que conecta o NHibernate à conexão simulada de DB2.
+    /// </summary>
     protected override string NhDriverClass => typeof(Db2NhMockDriver).AssemblyQualifiedName!;
 
+    /// <summary>
+    /// Creates and opens a DB2 mock connection for NHibernate smoke test execution.
+    /// Cria e abre uma conexão simulada de DB2 para execução dos testes de fumaça do NHibernate.
+    /// </summary>
     protected override DbConnection CreateOpenConnection()
     {
         var connection = new Db2ConnectionMock();

--- a/src/DbSqlLikeMem.MySql.NHibernate.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.MySql.NHibernate.Test/NHibernateSmokeTests.cs
@@ -1,11 +1,27 @@
 namespace DbSqlLikeMem.MySql.NHibernate.Test;
 
+/// <summary>
+/// Runs smoke tests for NHibernate integration using the MySQL in-memory mock provider.
+/// Executa testes de fumaça para integração do NHibernate usando o provedor simulado em memória do MySQL.
+/// </summary>
 public sealed class NHibernateSmokeTests : NHibernateSupportTestsBase
 {
+    /// <summary>
+    /// Gets the NHibernate dialect class used to emulate MySQL SQL behavior.
+    /// Obtém a classe de dialeto do NHibernate usada para emular o comportamento SQL do MySQL.
+    /// </summary>
     protected override string NhDialectClass => "NHibernate.Dialect.MySQLDialect, NHibernate";
 
+    /// <summary>
+    /// Gets the NHibernate driver class that connects NHibernate to the MySQL mock connection.
+    /// Obtém a classe de driver do NHibernate que conecta o NHibernate à conexão simulada de MySQL.
+    /// </summary>
     protected override string NhDriverClass => typeof(MySqlNhMockDriver).AssemblyQualifiedName!;
 
+    /// <summary>
+    /// Creates and opens a MySQL mock connection for NHibernate smoke test execution.
+    /// Cria e abre uma conexão simulada de MySQL para execução dos testes de fumaça do NHibernate.
+    /// </summary>
     protected override DbConnection CreateOpenConnection()
     {
         var connection = new MySqlConnectionMock([]);

--- a/src/DbSqlLikeMem.Npgsql.NHibernate.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.NHibernate.Test/NHibernateSmokeTests.cs
@@ -1,11 +1,27 @@
 namespace DbSqlLikeMem.Npgsql.NHibernate.Test;
 
+/// <summary>
+/// Runs smoke tests for NHibernate integration using the PostgreSQL in-memory mock provider.
+/// Executa testes de fumaça para integração do NHibernate usando o provedor simulado em memória do Npgsql.
+/// </summary>
 public sealed class NHibernateSmokeTests : NHibernateSupportTestsBase
 {
+    /// <summary>
+    /// Gets the NHibernate dialect class used to emulate PostgreSQL SQL behavior.
+    /// Obtém a classe de dialeto do NHibernate usada para emular o comportamento SQL do Npgsql.
+    /// </summary>
     protected override string NhDialectClass => "NHibernate.Dialect.PostgreSQL83Dialect, NHibernate";
 
+    /// <summary>
+    /// Gets the NHibernate driver class that connects NHibernate to the PostgreSQL mock connection.
+    /// Obtém a classe de driver do NHibernate que conecta o NHibernate à conexão simulada de Npgsql.
+    /// </summary>
     protected override string NhDriverClass => typeof(NpgsqlNhMockDriver).AssemblyQualifiedName!;
 
+    /// <summary>
+    /// Creates and opens a PostgreSQL mock connection for NHibernate smoke test execution.
+    /// Cria e abre uma conexão simulada de Npgsql para execução dos testes de fumaça do NHibernate.
+    /// </summary>
     protected override DbConnection CreateOpenConnection()
     {
         var connection = new NpgsqlConnectionMock([]);

--- a/src/DbSqlLikeMem.Oracle.NHibernate.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.Oracle.NHibernate.Test/NHibernateSmokeTests.cs
@@ -2,12 +2,28 @@ using DbSqlLikeMem.Oracle.NHibernate;
 
 namespace DbSqlLikeMem.Oracle.Test;
 
+/// <summary>
+/// Runs smoke tests for NHibernate integration using the Oracle in-memory mock provider.
+/// Executa testes de fumaça para integração do NHibernate usando o provedor simulado em memória do Oracle.
+/// </summary>
 public sealed class NHibernateSmokeTests : NHibernateSupportTestsBase
 {
+    /// <summary>
+    /// Gets the NHibernate dialect class used to emulate Oracle SQL behavior.
+    /// Obtém a classe de dialeto do NHibernate usada para emular o comportamento SQL do Oracle.
+    /// </summary>
     protected override string NhDialectClass => "NHibernate.Dialect.Oracle10gDialect, NHibernate";
 
+    /// <summary>
+    /// Gets the NHibernate driver class that connects NHibernate to the Oracle mock connection.
+    /// Obtém a classe de driver do NHibernate que conecta o NHibernate à conexão simulada de Oracle.
+    /// </summary>
     protected override string NhDriverClass => typeof(OracleNhMockDriver).AssemblyQualifiedName!;
 
+    /// <summary>
+    /// Creates and opens a Oracle mock connection for NHibernate smoke test execution.
+    /// Cria e abre uma conexão simulada de Oracle para execução dos testes de fumaça do NHibernate.
+    /// </summary>
     protected override DbConnection CreateOpenConnection()
     {
         var connection = new OracleConnectionMock([]);

--- a/src/DbSqlLikeMem.SqlServer.NHibernate.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.NHibernate.Test/NHibernateSmokeTests.cs
@@ -1,11 +1,27 @@
 namespace DbSqlLikeMem.SqlServer.NHibernate.Test;
 
+/// <summary>
+/// Runs smoke tests for NHibernate integration using the SQL Server in-memory mock provider.
+/// Executa testes de fumaça para integração do NHibernate usando o provedor simulado em memória do SQL Server.
+/// </summary>
 public sealed class NHibernateSmokeTests : NHibernateSupportTestsBase
 {
+    /// <summary>
+    /// Gets the NHibernate dialect class used to emulate SQL Server SQL behavior.
+    /// Obtém a classe de dialeto do NHibernate usada para emular o comportamento SQL do SQL Server.
+    /// </summary>
     protected override string NhDialectClass => "NHibernate.Dialect.MsSql2012Dialect, NHibernate";
 
+    /// <summary>
+    /// Gets the NHibernate driver class that connects NHibernate to the SQL Server mock connection.
+    /// Obtém a classe de driver do NHibernate que conecta o NHibernate à conexão simulada de SQL Server.
+    /// </summary>
     protected override string NhDriverClass => typeof(SqlServerNhMockDriver).AssemblyQualifiedName!;
 
+    /// <summary>
+    /// Creates and opens a SQL Server mock connection for NHibernate smoke test execution.
+    /// Cria e abre uma conexão simulada de SQL Server para execução dos testes de fumaça do NHibernate.
+    /// </summary>
     protected override DbConnection CreateOpenConnection()
     {
         var connection = new SqlServerConnectionMock([]);

--- a/src/DbSqlLikeMem.Sqlite.NHibernate.Test/NHibernateSmokeTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.NHibernate.Test/NHibernateSmokeTests.cs
@@ -1,11 +1,27 @@
 namespace DbSqlLikeMem.Sqlite.NHibernate.Test;
 
+/// <summary>
+/// Runs smoke tests for NHibernate integration using the SQLite in-memory mock provider.
+/// Executa testes de fumaça para integração do NHibernate usando o provedor simulado em memória do SQLite.
+/// </summary>
 public sealed class NHibernateSmokeTests : NHibernateSupportTestsBase
 {
+    /// <summary>
+    /// Gets the NHibernate dialect class used to emulate SQLite SQL behavior.
+    /// Obtém a classe de dialeto do NHibernate usada para emular o comportamento SQL do SQLite.
+    /// </summary>
     protected override string NhDialectClass => "NHibernate.Dialect.SQLiteDialect, NHibernate";
 
+    /// <summary>
+    /// Gets the NHibernate driver class that connects NHibernate to the SQLite mock connection.
+    /// Obtém a classe de driver do NHibernate que conecta o NHibernate à conexão simulada de SQLite.
+    /// </summary>
     protected override string NhDriverClass => typeof(SqliteNhMockDriver).AssemblyQualifiedName!;
 
+    /// <summary>
+    /// Creates and opens a SQLite mock connection for NHibernate smoke test execution.
+    /// Cria e abre uma conexão simulada de SQLite para execução dos testes de fumaça do NHibernate.
+    /// </summary>
     protected override DbConnection CreateOpenConnection()
     {
         var connection = new SqliteConnectionMock([]);


### PR DESCRIPTION
### Motivation
- Address missing XML documentation warnings and provide clear method descriptions for the NHibernate smoke test classes by adding summaries in English followed by Portuguese.
- Ensure each test class and its overridden members (`NhDialectClass`, `NhDriverClass`, `CreateOpenConnection()`) are documented for maintainability and IDE tooltips.

### Description
- Added `/// <summary>` XML documentation to the `NHibernateSmokeTests` class in six test projects: DB2, MySQL, Npgsql(PostgreSQL), Oracle, SQL Server, and SQLite, with English then Portuguese descriptions.
- Documented the overridden members `NhDialectClass`, `NhDriverClass`, and `CreateOpenConnection()` in each file with bilingual summaries.
- Changes are documentation-only and do not alter runtime behavior or test logic.

### Testing
- Verified the modified files contain the new summaries using repository search and `sed`/`rg` checks, which succeeded.
- Attempted to run `dotnet build DbSqlLikeMem.sln -v minimal`, but the environment does not have the `dotnet` CLI installed so the build attempt failed with `command not found: dotnet`.
- All changes were committed locally and a PR was created with the title `Add bilingual XML summaries to NHibernate smoke tests`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989f64b518832c8af8bda0290d1481)