### PR TITLE
Fix CREATE TABLE parsing for NHibernate schema bootstrap

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Db2MockTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2MockTests.cs
@@ -88,6 +88,21 @@ public sealed class Db2MockTests
         Assert.Empty(_connection.GetTable("users"));
     }
 
+    [Fact]
+    [Trait("Category", "Db2Mock")]
+    public void CreateTable_WithInlinePrimaryKey_ShouldCreateColumnAndAllowInsert()
+    {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "CREATE TABLE users_nh (id INT PRIMARY KEY, name VARCHAR(100))";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText = "INSERT INTO users_nh (id, name) VALUES (1, 'Alice')";
+        var rows = cmd.ExecuteNonQuery();
+
+        Assert.Equal(1, rows);
+        Assert.Equal("Alice", _connection.GetTable("users_nh")[0][1]);
+    }
+
     /// <summary>
     /// EN: Tests TestTransactionCommit behavior.
     /// PT: Testa o comportamento de TestTransactionCommit.

--- a/src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs
@@ -88,6 +88,21 @@ public sealed class MySqlMockTests
         Assert.Empty(_connection.GetTable("users"));
     }
 
+    [Fact]
+    [Trait("Category", "MySqlMock")]
+    public void CreateTable_WithInlinePrimaryKey_ShouldCreateColumnAndAllowInsert()
+    {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "CREATE TABLE users_nh (id INT PRIMARY KEY, name VARCHAR(100))";
+        cmd.ExecuteNonQuery();
+
+        cmd.CommandText = "INSERT INTO users_nh (id, name) VALUES (1, 'Alice')";
+        var rows = cmd.ExecuteNonQuery();
+
+        Assert.Equal(1, rows);
+        Assert.Equal("Alice", _connection.GetTable("users_nh")[0][1]);
+    }
+
     /// <summary>
     /// EN: Tests TestTransactionCommit behavior.
     /// PT: Testa o comportamento de TestTransactionCommit.


### PR DESCRIPTION
### Motivation
- NHibernate schema bootstrap uses statements like `CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))` and the simplified DDL parser previously dropped columns containing `PRIMARY KEY`, causing later `INSERT` to fail with unknown-column errors. 
- The previous attempt to harden `INSERT` column token resolution was unrelated to this regression and was reverted to keep behavior focused and minimal.

### Description
- Reworked `CREATE TABLE (...)` handling in `DbSelectIntoAndInsertSelectStrategies` to accept inline column `PRIMARY KEY` declarations and table-level `PRIMARY KEY(...)` constraints and collect PK column names during parsing. 
- `ParseColumnDefinition` now returns a `PrimaryKey` flag for inline PKs, and a new helper `ParsePrimaryKeyConstraint` extracts columns from `PRIMARY KEY(...)` table constraints; collected PKs are applied with `AddPrimaryKeyIndexes(...)` after columns are created. 
- Removed the unrelated insert-column token-normalization change from `DbInsertStrategy` to avoid introducing new behavior while fixing the real issue. 
- Added tests that reproduce the bootstrap scenario in MySQL and DB2 mocks: `CreateTable_WithInlinePrimaryKey_ShouldCreateColumnAndAllowInsert` in `MySqlMockTests` and `Db2MockTests`.

### Testing
- Added unit tests in `src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs` and `src/DbSqlLikeMem.Db2.Test/Db2MockTests.cs` covering `CREATE TABLE ... id INT PRIMARY KEY ...` followed by `INSERT`. 
- Attempted to run `dotnet test` in this environment to validate the changes, but the `.NET` CLI is not available here and the run failed with `bash: command not found: dotnet`, so automated tests were not executed in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a39b2b98832c9eac44df4596ba37)