### PR TITLE
Consolidate provider aggregation/HAVING tests and tighten HAVING ordinal validation

### DIFF
--- a/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AggregationTests.cs
+++ b/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AggregationTests.cs
@@ -1,273 +1,29 @@
-﻿namespace DbSqlLikeMem.Db2.Dapper.Test;
+namespace DbSqlLikeMem.Db2.Dapper.Test;
 
 /// <summary>
-/// Auto-generated summary.
+/// EN: Runs shared aggregation/HAVING scenarios for DB2 and keeps DB2-specific coverage.
+/// PT: Executa cenários compartilhados de agregação/HAVING para DB2 e mantém cobertura específica de DB2.
 /// </summary>
-public sealed class Db2AggregationTests : XUnitTestBase
+public sealed class Db2AggregationTests : AggregationHavingOrdinalTestsBase<Db2DbMock, Db2ConnectionMock>
 {
-    private readonly Db2ConnectionMock _cnn;
-
     /// <summary>
-    /// Auto-generated summary.
+    /// EN: Initializes DB2 aggregation tests.
+    /// PT: Inicializa os testes de agregação do DB2.
     /// </summary>
+    /// <param name="helper">EN: Output helper. PT: Helper de saída.</param>
     public Db2AggregationTests(ITestOutputHelper helper) : base(helper)
     {
-        var db = new Db2DbMock();
-        var orders = db.AddTable("orders");
-        orders.AddColumn("id", DbType.Int32, false);
-        orders.AddColumn("userId", DbType.Int32, false);
-        orders.AddColumn("amount", DbType.Decimal, false, decimalPlaces: 2);
-
-        orders.Add(new Dictionary<int, object?> { [0] = 1, [1] = 1, [2] = 10m });
-        orders.Add(new Dictionary<int, object?> { [0] = 2, [1] = 1, [2] = 30m });
-        orders.Add(new Dictionary<int, object?> { [0] = 3, [1] = 2, [2] = 5m });
-
-        _cnn = new Db2ConnectionMock(db);
-        _cnn.Open();
     }
 
-    /// <summary>
-    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
-    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void GroupBy_WithCountAndSum_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, COUNT(id) AS total, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  ORDER BY userId
-                  """;
+    /// <inheritdoc />
+    protected override Db2DbMock CreateDb() => new();
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
+    /// <inheritdoc />
+    protected override Db2ConnectionMock CreateConnection(Db2DbMock db) => new(db);
 
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[0].total);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
+    /// <inheritdoc />
+    protected override List<dynamic> Query(string sql) => Connection.Query<dynamic>(sql).ToList();
 
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(1, (int)rows[1].total);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Tests Having_ShouldFilterAggregates behavior.
-    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void Having_ShouldFilterAggregates()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount >= 10
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING aggregate alias can be combined with ORDER BY ordinal in grouped execution.
-    /// PT: Garante que alias de agregação no HAVING possa ser combinado com ORDER BY ordinal na execução agrupada.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void Having_AggregateAlias_WithOrderByOrdinal_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount > 0
-                  ORDER BY 2 DESC
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Ensures invalid HAVING alias in grouped execution throws a clear validation error.
-    /// PT: Garante que alias inválido no HAVING em execução agrupada lance erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void Having_InvalidAlias_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING missing_alias > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING reference", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal expression resolves to the corresponding projected select item.
-    /// PT: Garante que expressão ordinal no HAVING resolva para o item projetado correspondente no SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void Having_OrdinalExpression_ShouldResolveSelectedColumn()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[1].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING mixed with ordinal and aggregate resolves ordinal to the select-item expression.
-    /// PT: Garante que HAVING misto com ordinal e agregação resolva o ordinal para a expressão do item do SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void Having_MixedOrdinalAndAggregate_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 10 AND SUM(amount) > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING CASE expression resolves ordinal references correctly.
-    /// PT: Garante que expressão CASE no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void Having_CaseWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING CASE WHEN 2 > 10 THEN 1 ELSE 0 END = 1
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING BETWEEN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão BETWEEN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void Having_BetweenWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 BETWEEN 35 AND 45
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING IN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão IN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void Having_InWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 IN (40)
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures numeric thresholds in HAVING aggregate comparisons are treated as constants, not ordinals.
-    /// PT: Garante que limites numéricos em comparações de agregação no HAVING sejam tratados como constantes, não ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void Having_AggregateThresholdConstant_ShouldNotBeTreatedAsOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING SUM(amount) > 10
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal out of range throws a clear validation error.
-    /// PT: Garante que ordinal fora do intervalo no HAVING lance um erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "Db2Aggregation")]
-    public void Having_OrdinalOutOfRange_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 3 > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING ordinal", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
     /// <summary>
     /// EN: Tests Distinct_Order_Limit_Offset_ShouldWork behavior.
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
@@ -283,19 +39,8 @@ public sealed class Db2AggregationTests : XUnitTestBase
                   LIMIT 1 OFFSET 1
                   """;
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
+        var rows = Query(sql);
         Assert.Single(rows);
         Assert.Equal(2, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Disposes test resources.
-    /// PT: Descarta os recursos do teste.
-    /// </summary>
-    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
-    protected override void Dispose(bool disposing)
-    {
-        _cnn?.Dispose();
-        base.Dispose(disposing);
     }
 }

--- a/src/DbSqlLikeMem.MySql.Dapper.Test/MySqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.MySql.Dapper.Test/MySqlAggregationTests.cs
@@ -1,273 +1,29 @@
 namespace DbSqlLikeMem.MySql.Dapper.Test;
 
 /// <summary>
-/// Auto-generated summary.
+/// EN: Runs shared aggregation/HAVING scenarios for MySQL and keeps MySQL-specific coverage.
+/// PT: Executa cenários compartilhados de agregação/HAVING para MySQL e mantém cobertura específica de MySQL.
 /// </summary>
-public sealed class MySqlAggregationTests : XUnitTestBase
+public sealed class MySqlAggregationTests : AggregationHavingOrdinalTestsBase<MySqlDbMock, MySqlConnectionMock>
 {
-    private readonly MySqlConnectionMock _cnn;
-
     /// <summary>
-    /// Auto-generated summary.
+    /// EN: Initializes MySQL aggregation tests.
+    /// PT: Inicializa os testes de agregação do MySQL.
     /// </summary>
+    /// <param name="helper">EN: Output helper. PT: Helper de saída.</param>
     public MySqlAggregationTests(ITestOutputHelper helper) : base(helper)
     {
-        var db = new MySqlDbMock();
-        var orders = db.AddTable("orders");
-        orders.AddColumn("id", DbType.Int32, false);
-        orders.AddColumn("userId", DbType.Int32, false);
-        orders.AddColumn("amount", DbType.Decimal, false, decimalPlaces: 2);
-
-        orders.Add(new Dictionary<int, object?> { [0] = 1, [1] = 1, [2] = 10m });
-        orders.Add(new Dictionary<int, object?> { [0] = 2, [1] = 1, [2] = 30m });
-        orders.Add(new Dictionary<int, object?> { [0] = 3, [1] = 2, [2] = 5m });
-
-        _cnn = new MySqlConnectionMock(db);
-        _cnn.Open();
     }
 
-    /// <summary>
-    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
-    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void GroupBy_WithCountAndSum_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, COUNT(id) AS total, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  ORDER BY userId
-                  """;
+    /// <inheritdoc />
+    protected override MySqlDbMock CreateDb() => new();
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
+    /// <inheritdoc />
+    protected override MySqlConnectionMock CreateConnection(MySqlDbMock db) => new(db);
 
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[0].total);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
+    /// <inheritdoc />
+    protected override List<dynamic> Query(string sql) => Connection.Query<dynamic>(sql).ToList();
 
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(1, (int)rows[1].total);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Tests Having_ShouldFilterAggregates behavior.
-    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void Having_ShouldFilterAggregates()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount >= 10
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING aggregate alias can be combined with ORDER BY ordinal in grouped execution.
-    /// PT: Garante que alias de agregação no HAVING possa ser combinado com ORDER BY ordinal na execução agrupada.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void Having_AggregateAlias_WithOrderByOrdinal_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount > 0
-                  ORDER BY 2 DESC
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Ensures invalid HAVING alias in grouped execution throws a clear validation error.
-    /// PT: Garante que alias inválido no HAVING em execução agrupada lance erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void Having_InvalidAlias_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING missing_alias > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING reference", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal expression resolves to the corresponding projected select item.
-    /// PT: Garante que expressão ordinal no HAVING resolva para o item projetado correspondente no SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void Having_OrdinalExpression_ShouldResolveSelectedColumn()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[1].userId);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal out of range throws a clear validation error.
-    /// PT: Garante que ordinal fora do intervalo no HAVING lance um erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void Having_OrdinalOutOfRange_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 3 > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING ordinal", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING mixed with ordinal and aggregate resolves ordinal to the select-item expression.
-    /// PT: Garante que HAVING misto com ordinal e agregação resolva o ordinal para a expressão do item do SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void Having_MixedOrdinalAndAggregate_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 10 AND SUM(amount) > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING CASE expression resolves ordinal references correctly.
-    /// PT: Garante que expressão CASE no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void Having_CaseWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING CASE WHEN 2 > 10 THEN 1 ELSE 0 END = 1
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING BETWEEN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão BETWEEN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void Having_BetweenWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 BETWEEN 35 AND 45
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING IN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão IN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void Having_InWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 IN (40)
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures numeric thresholds in HAVING aggregate comparisons are treated as constants, not ordinals.
-    /// PT: Garante que limites numéricos em comparações de agregação no HAVING sejam tratados como constantes, não ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "MySqlAggregation")]
-    public void Having_AggregateThresholdConstant_ShouldNotBeTreatedAsOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING SUM(amount) > 10
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
     /// <summary>
     /// EN: Tests Distinct_Order_Limit_Offset_ShouldWork behavior.
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
@@ -283,19 +39,8 @@ public sealed class MySqlAggregationTests : XUnitTestBase
                   LIMIT 1 OFFSET 1
                   """;
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
+        var rows = Query(sql);
         Assert.Single(rows);
         Assert.Equal(2, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Disposes test resources.
-    /// PT: Descarta os recursos do teste.
-    /// </summary>
-    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
-    protected override void Dispose(bool disposing)
-    {
-        _cnn?.Dispose();
-        base.Dispose(disposing);
     }
 }

--- a/src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlAggregationTests.cs
@@ -1,273 +1,29 @@
 namespace DbSqlLikeMem.Npgsql.Test;
 
 /// <summary>
-/// Auto-generated summary.
+/// EN: Runs shared aggregation/HAVING scenarios for PostgreSQL and keeps PostgreSQL-specific coverage.
+/// PT: Executa cenários compartilhados de agregação/HAVING para PostgreSQL e mantém cobertura específica de PostgreSQL.
 /// </summary>
-public sealed class PostgreSqlAggregationTests : XUnitTestBase
+public sealed class PostgreSqlAggregationTests : AggregationHavingOrdinalTestsBase<NpgsqlDbMock, NpgsqlConnectionMock>
 {
-    private readonly NpgsqlConnectionMock _cnn;
-
     /// <summary>
-    /// Auto-generated summary.
+    /// EN: Initializes PostgreSQL aggregation tests.
+    /// PT: Inicializa os testes de agregação do PostgreSQL.
     /// </summary>
+    /// <param name="helper">EN: Output helper. PT: Helper de saída.</param>
     public PostgreSqlAggregationTests(ITestOutputHelper helper) : base(helper)
     {
-        var db = new NpgsqlDbMock();
-        var orders = db.AddTable("orders");
-        orders.AddColumn("id", DbType.Int32, false);
-        orders.AddColumn("userId", DbType.Int32, false);
-        orders.AddColumn("amount", DbType.Decimal, false, decimalPlaces: 2);
-
-        orders.Add(new Dictionary<int, object?> { [0] = 1, [1] = 1, [2] = 10m });
-        orders.Add(new Dictionary<int, object?> { [0] = 2, [1] = 1, [2] = 30m });
-        orders.Add(new Dictionary<int, object?> { [0] = 3, [1] = 2, [2] = 5m });
-
-        _cnn = new NpgsqlConnectionMock(db);
-        _cnn.Open();
     }
 
-    /// <summary>
-    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
-    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void GroupBy_WithCountAndSum_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, COUNT(id) AS total, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  ORDER BY userId
-                  """;
+    /// <inheritdoc />
+    protected override NpgsqlDbMock CreateDb() => new();
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
+    /// <inheritdoc />
+    protected override NpgsqlConnectionMock CreateConnection(NpgsqlDbMock db) => new(db);
 
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[0].total);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
+    /// <inheritdoc />
+    protected override List<dynamic> Query(string sql) => Connection.Query<dynamic>(sql).ToList();
 
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(1, (int)rows[1].total);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Tests Having_ShouldFilterAggregates behavior.
-    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void Having_ShouldFilterAggregates()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount >= 10
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING aggregate alias can be combined with ORDER BY ordinal in grouped execution.
-    /// PT: Garante que alias de agregação no HAVING possa ser combinado com ORDER BY ordinal na execução agrupada.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void Having_AggregateAlias_WithOrderByOrdinal_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount > 0
-                  ORDER BY 2 DESC
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Ensures invalid HAVING alias in grouped execution throws a clear validation error.
-    /// PT: Garante que alias inválido no HAVING em execução agrupada lance erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void Having_InvalidAlias_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING missing_alias > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING reference", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal expression resolves to the corresponding projected select item.
-    /// PT: Garante que expressão ordinal no HAVING resolva para o item projetado correspondente no SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void Having_OrdinalExpression_ShouldResolveSelectedColumn()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[1].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING mixed with ordinal and aggregate resolves ordinal to the select-item expression.
-    /// PT: Garante que HAVING misto com ordinal e agregação resolva o ordinal para a expressão do item do SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void Having_MixedOrdinalAndAggregate_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 10 AND SUM(amount) > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING CASE expression resolves ordinal references correctly.
-    /// PT: Garante que expressão CASE no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void Having_CaseWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING CASE WHEN 2 > 10 THEN 1 ELSE 0 END = 1
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING BETWEEN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão BETWEEN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void Having_BetweenWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 BETWEEN 35 AND 45
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING IN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão IN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void Having_InWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 IN (40)
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures numeric thresholds in HAVING aggregate comparisons are treated as constants, not ordinals.
-    /// PT: Garante que limites numéricos em comparações de agregação no HAVING sejam tratados como constantes, não ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void Having_AggregateThresholdConstant_ShouldNotBeTreatedAsOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING SUM(amount) > 10
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal out of range throws a clear validation error.
-    /// PT: Garante que ordinal fora do intervalo no HAVING lance um erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "PostgreSqlAggregation")]
-    public void Having_OrdinalOutOfRange_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 3 > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING ordinal", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
     /// <summary>
     /// EN: Tests Distinct_Order_Limit_Offset_ShouldWork behavior.
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
@@ -283,19 +39,8 @@ public sealed class PostgreSqlAggregationTests : XUnitTestBase
                   LIMIT 1 OFFSET 1
                   """;
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
+        var rows = Query(sql);
         Assert.Single(rows);
         Assert.Equal(2, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Disposes test resources.
-    /// PT: Descarta os recursos do teste.
-    /// </summary>
-    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
-    protected override void Dispose(bool disposing)
-    {
-        _cnn?.Dispose();
-        base.Dispose(disposing);
     }
 }

--- a/src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAggregationTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAggregationTests.cs
@@ -1,275 +1,29 @@
 namespace DbSqlLikeMem.Oracle.Test;
 
 /// <summary>
-/// EN: Defines the class OracleAggregationTests.
-/// PT: Define o(a) class OracleAggregationTests.
+/// EN: Runs shared aggregation/HAVING scenarios for Oracle and keeps Oracle-specific coverage.
+/// PT: Executa cenários compartilhados de agregação/HAVING para Oracle e mantém cobertura específica de Oracle.
 /// </summary>
-public sealed class OracleAggregationTests : XUnitTestBase
+public sealed class OracleAggregationTests : AggregationHavingOrdinalTestsBase<OracleDbMock, OracleConnectionMock>
 {
-    private readonly OracleConnectionMock _cnn;
-
     /// <summary>
-    /// EN: Initializes a new instance of OracleAggregationTests.
-    /// PT: Inicializa uma nova instância de OracleAggregationTests.
+    /// EN: Initializes Oracle aggregation tests.
+    /// PT: Inicializa os testes de agregação do Oracle.
     /// </summary>
+    /// <param name="helper">EN: Output helper. PT: Helper de saída.</param>
     public OracleAggregationTests(ITestOutputHelper helper) : base(helper)
     {
-        var db = new OracleDbMock();
-        var orders = db.AddTable("orders");
-        orders.AddColumn("id", DbType.Int32, false);
-        orders.AddColumn("userId", DbType.Int32, false);
-        orders.AddColumn("amount", DbType.Decimal, false, decimalPlaces: 2);
-
-        orders.Add(new Dictionary<int, object?> { [0] = 1, [1] = 1, [2] = 10m });
-        orders.Add(new Dictionary<int, object?> { [0] = 2, [1] = 1, [2] = 30m });
-        orders.Add(new Dictionary<int, object?> { [0] = 3, [1] = 2, [2] = 5m });
-
-        _cnn = new OracleConnectionMock(db);
-        _cnn.Open();
     }
 
-    /// <summary>
-    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
-    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void GroupBy_WithCountAndSum_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, COUNT(id) AS total, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  ORDER BY userId
-                  """;
+    /// <inheritdoc />
+    protected override OracleDbMock CreateDb() => new();
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
+    /// <inheritdoc />
+    protected override OracleConnectionMock CreateConnection(OracleDbMock db) => new(db);
 
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[0].total);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
+    /// <inheritdoc />
+    protected override List<dynamic> Query(string sql) => Connection.Query<dynamic>(sql).ToList();
 
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(1, (int)rows[1].total);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Tests Having_ShouldFilterAggregates behavior.
-    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void Having_ShouldFilterAggregates()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount >= 10
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING aggregate alias can be combined with ORDER BY ordinal in grouped execution.
-    /// PT: Garante que alias de agregação no HAVING possa ser combinado com ORDER BY ordinal na execução agrupada.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void Having_AggregateAlias_WithOrderByOrdinal_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount > 0
-                  ORDER BY 2 DESC
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Ensures invalid HAVING alias in grouped execution throws a clear validation error.
-    /// PT: Garante que alias inválido no HAVING em execução agrupada lance erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void Having_InvalidAlias_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING missing_alias > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING reference", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal expression resolves to the corresponding projected select item.
-    /// PT: Garante que expressão ordinal no HAVING resolva para o item projetado correspondente no SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void Having_OrdinalExpression_ShouldResolveSelectedColumn()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[1].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING mixed with ordinal and aggregate resolves ordinal to the select-item expression.
-    /// PT: Garante que HAVING misto com ordinal e agregação resolva o ordinal para a expressão do item do SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void Having_MixedOrdinalAndAggregate_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 10 AND SUM(amount) > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING CASE expression resolves ordinal references correctly.
-    /// PT: Garante que expressão CASE no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void Having_CaseWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING CASE WHEN 2 > 10 THEN 1 ELSE 0 END = 1
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING BETWEEN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão BETWEEN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void Having_BetweenWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 BETWEEN 35 AND 45
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING IN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão IN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void Having_InWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 IN (40)
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures numeric thresholds in HAVING aggregate comparisons are treated as constants, not ordinals.
-    /// PT: Garante que limites numéricos em comparações de agregação no HAVING sejam tratados como constantes, não ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void Having_AggregateThresholdConstant_ShouldNotBeTreatedAsOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING SUM(amount) > 10
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal out of range throws a clear validation error.
-    /// PT: Garante que ordinal fora do intervalo no HAVING lance um erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "OracleAggregation")]
-    public void Having_OrdinalOutOfRange_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 3 > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING ordinal", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
     /// <summary>
     /// EN: Tests Distinct_Order_Limit_Offset_ShouldWork behavior.
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
@@ -285,19 +39,8 @@ public sealed class OracleAggregationTests : XUnitTestBase
                   OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY
                   """;
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
+        var rows = Query(sql);
         Assert.Single(rows);
         Assert.Equal(2, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Disposes test resources.
-    /// PT: Descarta os recursos do teste.
-    /// </summary>
-    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
-    protected override void Dispose(bool disposing)
-    {
-        _cnn?.Dispose();
-        base.Dispose(disposing);
     }
 }

--- a/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAggregationTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAggregationTests.cs
@@ -1,273 +1,29 @@
 namespace DbSqlLikeMem.SqlServer.Dapper.Test;
 
 /// <summary>
-/// Auto-generated summary.
+/// EN: Runs shared aggregation/HAVING scenarios for SQL Server and keeps SQL Server-specific coverage.
+/// PT: Executa cenários compartilhados de agregação/HAVING para SQL Server e mantém cobertura específica de SQL Server.
 /// </summary>
-public sealed class SqlServerAggregationTests : XUnitTestBase
+public sealed class SqlServerAggregationTests : AggregationHavingOrdinalTestsBase<SqlServerDbMock, SqlServerConnectionMock>
 {
-    private readonly SqlServerConnectionMock _cnn;
-
     /// <summary>
-    /// Auto-generated summary.
+    /// EN: Initializes SQL Server aggregation tests.
+    /// PT: Inicializa os testes de agregação do SQL Server.
     /// </summary>
+    /// <param name="helper">EN: Output helper. PT: Helper de saída.</param>
     public SqlServerAggregationTests(ITestOutputHelper helper) : base(helper)
     {
-        var db = new SqlServerDbMock();
-        var orders = db.AddTable("orders");
-        orders.AddColumn("id", DbType.Int32, false);
-        orders.AddColumn("userId", DbType.Int32, false);
-        orders.AddColumn("amount", DbType.Decimal, false, decimalPlaces: 2);
-
-        orders.Add(new Dictionary<int, object?> { [0] = 1, [1] = 1, [2] = 10m });
-        orders.Add(new Dictionary<int, object?> { [0] = 2, [1] = 1, [2] = 30m });
-        orders.Add(new Dictionary<int, object?> { [0] = 3, [1] = 2, [2] = 5m });
-
-        _cnn = new SqlServerConnectionMock(db);
-        _cnn.Open();
     }
 
-    /// <summary>
-    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
-    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void GroupBy_WithCountAndSum_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, COUNT(id) AS total, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  ORDER BY userId
-                  """;
+    /// <inheritdoc />
+    protected override SqlServerDbMock CreateDb() => new();
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
+    /// <inheritdoc />
+    protected override SqlServerConnectionMock CreateConnection(SqlServerDbMock db) => new(db);
 
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[0].total);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
+    /// <inheritdoc />
+    protected override List<dynamic> Query(string sql) => Connection.Query<dynamic>(sql).ToList();
 
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(1, (int)rows[1].total);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Tests Having_ShouldFilterAggregates behavior.
-    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void Having_ShouldFilterAggregates()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount >= 10
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING aggregate alias can be combined with ORDER BY ordinal in grouped execution.
-    /// PT: Garante que alias de agregação no HAVING possa ser combinado com ORDER BY ordinal na execução agrupada.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void Having_AggregateAlias_WithOrderByOrdinal_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount > 0
-                  ORDER BY 2 DESC
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Ensures invalid HAVING alias in grouped execution throws a clear validation error.
-    /// PT: Garante que alias inválido no HAVING em execução agrupada lance erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void Having_InvalidAlias_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING missing_alias > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING reference", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal expression resolves to the corresponding projected select item.
-    /// PT: Garante que expressão ordinal no HAVING resolva para o item projetado correspondente no SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void Having_OrdinalExpression_ShouldResolveSelectedColumn()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[1].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING mixed with ordinal and aggregate resolves ordinal to the select-item expression.
-    /// PT: Garante que HAVING misto com ordinal e agregação resolva o ordinal para a expressão do item do SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void Having_MixedOrdinalAndAggregate_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 10 AND SUM(amount) > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING CASE expression resolves ordinal references correctly.
-    /// PT: Garante que expressão CASE no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void Having_CaseWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING CASE WHEN 2 > 10 THEN 1 ELSE 0 END = 1
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING BETWEEN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão BETWEEN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void Having_BetweenWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 BETWEEN 35 AND 45
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING IN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão IN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void Having_InWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 IN (40)
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures numeric thresholds in HAVING aggregate comparisons are treated as constants, not ordinals.
-    /// PT: Garante que limites numéricos em comparações de agregação no HAVING sejam tratados como constantes, não ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void Having_AggregateThresholdConstant_ShouldNotBeTreatedAsOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING SUM(amount) > 10
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal out of range throws a clear validation error.
-    /// PT: Garante que ordinal fora do intervalo no HAVING lance um erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqlServerAggregation")]
-    public void Having_OrdinalOutOfRange_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 3 > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING ordinal", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
     /// <summary>
     /// EN: Tests Distinct_Order_Limit_Offset_ShouldWork behavior.
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
@@ -283,19 +39,8 @@ public sealed class SqlServerAggregationTests : XUnitTestBase
                   OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY
                   """;
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
+        var rows = Query(sql);
         Assert.Single(rows);
         Assert.Equal(2, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Disposes test resources.
-    /// PT: Descarta os recursos do teste.
-    /// </summary>
-    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
-    protected override void Dispose(bool disposing)
-    {
-        _cnn?.Dispose();
-        base.Dispose(disposing);
     }
 }

--- a/src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAggregationTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAggregationTests.cs
@@ -1,273 +1,29 @@
-﻿namespace DbSqlLikeMem.Sqlite.Dapper.Test;
+namespace DbSqlLikeMem.Sqlite.Dapper.Test;
 
 /// <summary>
-/// Auto-generated summary.
+/// EN: Runs shared aggregation/HAVING scenarios for SQLite and keeps SQLite-specific coverage.
+/// PT: Executa cenários compartilhados de agregação/HAVING para SQLite e mantém cobertura específica de SQLite.
 /// </summary>
-public sealed class SqliteAggregationTests : XUnitTestBase
+public sealed class SqliteAggregationTests : AggregationHavingOrdinalTestsBase<SqliteDbMock, SqliteConnectionMock>
 {
-    private readonly SqliteConnectionMock _cnn;
-
     /// <summary>
-    /// Auto-generated summary.
+    /// EN: Initializes SQLite aggregation tests.
+    /// PT: Inicializa os testes de agregação do SQLite.
     /// </summary>
+    /// <param name="helper">EN: Output helper. PT: Helper de saída.</param>
     public SqliteAggregationTests(ITestOutputHelper helper) : base(helper)
     {
-        var db = new SqliteDbMock();
-        var orders = db.AddTable("orders");
-        orders.AddColumn("id", DbType.Int32, false);
-        orders.AddColumn("userId", DbType.Int32, false);
-        orders.AddColumn("amount", DbType.Decimal, false, decimalPlaces: 2);
-
-        orders.Add(new Dictionary<int, object?> { [0] = 1, [1] = 1, [2] = 10m });
-        orders.Add(new Dictionary<int, object?> { [0] = 2, [1] = 1, [2] = 30m });
-        orders.Add(new Dictionary<int, object?> { [0] = 3, [1] = 2, [2] = 5m });
-
-        _cnn = new SqliteConnectionMock(db);
-        _cnn.Open();
     }
 
-    /// <summary>
-    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
-    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void GroupBy_WithCountAndSum_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, COUNT(id) AS total, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  ORDER BY userId
-                  """;
+    /// <inheritdoc />
+    protected override SqliteDbMock CreateDb() => new();
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
+    /// <inheritdoc />
+    protected override SqliteConnectionMock CreateConnection(SqliteDbMock db) => new(db);
 
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[0].total);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
+    /// <inheritdoc />
+    protected override List<dynamic> Query(string sql) => Connection.Query<dynamic>(sql).ToList();
 
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(1, (int)rows[1].total);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Tests Having_ShouldFilterAggregates behavior.
-    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void Having_ShouldFilterAggregates()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount >= 10
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING aggregate alias can be combined with ORDER BY ordinal in grouped execution.
-    /// PT: Garante que alias de agregação no HAVING possa ser combinado com ORDER BY ordinal na execução agrupada.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void Having_AggregateAlias_WithOrderByOrdinal_ShouldWork()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING sumAmount > 0
-                  ORDER BY 2 DESC
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(40m, (decimal)rows[0].sumAmount);
-        Assert.Equal(2, (int)rows[1].userId);
-        Assert.Equal(5m, (decimal)rows[1].sumAmount);
-    }
-
-    /// <summary>
-    /// EN: Ensures invalid HAVING alias in grouped execution throws a clear validation error.
-    /// PT: Garante que alias inválido no HAVING em execução agrupada lance erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void Having_InvalidAlias_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING missing_alias > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING reference", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal expression resolves to the corresponding projected select item.
-    /// PT: Garante que expressão ordinal no HAVING resolva para o item projetado correspondente no SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void Having_OrdinalExpression_ShouldResolveSelectedColumn()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Equal(2, rows.Count);
-        Assert.Equal(1, (int)rows[0].userId);
-        Assert.Equal(2, (int)rows[1].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING mixed with ordinal and aggregate resolves ordinal to the select-item expression.
-    /// PT: Garante que HAVING misto com ordinal e agregação resolva o ordinal para a expressão do item do SELECT.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void Having_MixedOrdinalAndAggregate_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 > 10 AND SUM(amount) > 0
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING CASE expression resolves ordinal references correctly.
-    /// PT: Garante que expressão CASE no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void Having_CaseWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING CASE WHEN 2 > 10 THEN 1 ELSE 0 END = 1
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING BETWEEN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão BETWEEN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void Having_BetweenWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 BETWEEN 35 AND 45
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING IN expression resolves ordinal references correctly.
-    /// PT: Garante que expressão IN no HAVING resolva corretamente referências ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void Having_InWithOrdinal_ShouldResolveOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 2 IN (40)
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures numeric thresholds in HAVING aggregate comparisons are treated as constants, not ordinals.
-    /// PT: Garante que limites numéricos em comparações de agregação no HAVING sejam tratados como constantes, não ordinais.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void Having_AggregateThresholdConstant_ShouldNotBeTreatedAsOrdinal()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING SUM(amount) > 10
-                  ORDER BY userId
-                  """;
-
-        var rows = _cnn.Query<dynamic>(sql).ToList();
-        Assert.Single(rows);
-        Assert.Equal(1, (int)rows[0].userId);
-    }
-
-
-    /// <summary>
-    /// EN: Ensures HAVING ordinal out of range throws a clear validation error.
-    /// PT: Garante que ordinal fora do intervalo no HAVING lance um erro de validação claro.
-    /// </summary>
-    [Fact]
-    [Trait("Category", "SqliteAggregation")]
-    public void Having_OrdinalOutOfRange_ShouldThrow()
-    {
-        const string sql = """
-                  SELECT userId, SUM(amount) AS sumAmount
-                  FROM orders
-                  GROUP BY userId
-                  HAVING 3 > 0
-                  """;
-
-        var ex = Assert.Throws<InvalidOperationException>(() => _cnn.Query<dynamic>(sql).ToList());
-        Assert.Contains("HAVING ordinal", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
     /// <summary>
     /// EN: Tests Distinct_Order_Limit_Offset_ShouldWork behavior.
     /// PT: Testa o comportamento de Distinct_Order_Limit_Offset_ShouldWork.
@@ -283,19 +39,8 @@ public sealed class SqliteAggregationTests : XUnitTestBase
                   LIMIT 1 OFFSET 1
                   """;
 
-        var rows = _cnn.Query<dynamic>(sql).ToList();
+        var rows = Query(sql);
         Assert.Single(rows);
         Assert.Equal(2, (int)rows[0].userId);
-    }
-
-    /// <summary>
-    /// EN: Disposes test resources.
-    /// PT: Descarta os recursos do teste.
-    /// </summary>
-    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
-    protected override void Dispose(bool disposing)
-    {
-        _cnn?.Dispose();
-        base.Dispose(disposing);
     }
 }

--- a/src/DbSqlLikeMem.Test/AggregationHavingOrdinalTestsBase.cs
+++ b/src/DbSqlLikeMem.Test/AggregationHavingOrdinalTestsBase.cs
@@ -1,0 +1,347 @@
+using System.Data.Common;
+
+namespace DbSqlLikeMem.Test;
+
+/// <summary>
+/// EN: Defines shared aggregation and HAVING ordinal scenarios across providers.
+/// PT: Define cenários compartilhados de agregação e ordinal em HAVING entre provedores.
+/// </summary>
+/// <typeparam name="TDbMock">EN: Provider database mock type. PT: Tipo do mock de banco do provedor.</typeparam>
+/// <typeparam name="TConnection">EN: Provider connection type. PT: Tipo de conexão do provedor.</typeparam>
+public abstract class AggregationHavingOrdinalTestsBase<TDbMock, TConnection> : XUnitTestBase
+    where TDbMock : DbMock
+    where TConnection : DbConnection
+{
+    private readonly TConnection _connection;
+
+    /// <summary>
+    /// EN: Gets the provider connection used by derived classes.
+    /// PT: Obtém a conexão do provedor usada pelas classes derivadas.
+    /// </summary>
+    protected DbConnection Connection => _connection;
+
+    /// <summary>
+    /// EN: Initializes shared aggregation/HAVING tests.
+    /// PT: Inicializa testes compartilhados de agregação/HAVING.
+    /// </summary>
+    /// <param name="helper">EN: Output helper. PT: Helper de saída.</param>
+    protected AggregationHavingOrdinalTestsBase(ITestOutputHelper helper) : base(helper)
+    {
+        var db = CreateDb();
+        SeedOrders(db);
+
+        _connection = CreateConnection(db);
+        if (_connection.State != System.Data.ConnectionState.Open)
+        {
+            _connection.Open();
+        }
+    }
+
+    /// <summary>
+    /// EN: Creates the provider-specific database mock used by shared tests.
+    /// PT: Cria o mock de banco específico do provedor usado pelos testes compartilhados.
+    /// </summary>
+    /// <returns>EN: Provider-specific database mock. PT: Mock de banco específico do provedor.</returns>
+    protected abstract TDbMock CreateDb();
+
+    /// <summary>
+    /// EN: Creates the provider-specific connection used by shared tests.
+    /// PT: Cria a conexão específica do provedor usada pelos testes compartilhados.
+    /// </summary>
+    /// <param name="db">EN: Provider database mock. PT: Mock de banco do provedor.</param>
+    /// <returns>EN: Provider-specific connection. PT: Conexão específica do provedor.</returns>
+    protected abstract TConnection CreateConnection(TDbMock db);
+
+    /// <summary>
+    /// EN: Executes SQL and returns dynamic rows.
+    /// PT: Executa SQL e retorna linhas dinâmicas.
+    /// </summary>
+    /// <param name="sql">EN: SQL to execute. PT: SQL para executar.</param>
+    /// <returns>EN: Materialized result rows. PT: Linhas do resultado materializadas.</returns>
+    protected abstract List<dynamic> Query(string sql);
+
+    private static void SeedOrders(TDbMock db)
+    {
+        var orders = db.AddTable("orders");
+        orders.AddColumn("id", DbType.Int32, false);
+        orders.AddColumn("userId", DbType.Int32, false);
+        orders.AddColumn("amount", DbType.Decimal, false, decimalPlaces: 2);
+
+        orders.Add(new Dictionary<int, object?> { [0] = 1, [1] = 1, [2] = 10m });
+        orders.Add(new Dictionary<int, object?> { [0] = 2, [1] = 1, [2] = 30m });
+        orders.Add(new Dictionary<int, object?> { [0] = 3, [1] = 2, [2] = 5m });
+    }
+
+    /// <summary>
+    /// EN: Tests GroupBy_WithCountAndSum_ShouldWork behavior.
+    /// PT: Testa o comportamento de GroupBy_WithCountAndSum_ShouldWork.
+    /// </summary>
+    [Fact]
+    public void GroupBy_WithCountAndSum_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, COUNT(id) AS total, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        var rows = Query(sql);
+        Assert.Equal(2, rows.Count);
+
+        Assert.Equal(1, (int)rows[0].userId);
+        Assert.Equal(2, (int)rows[0].total);
+        Assert.Equal(40m, (decimal)rows[0].sumAmount);
+
+        Assert.Equal(2, (int)rows[1].userId);
+        Assert.Equal(1, (int)rows[1].total);
+        Assert.Equal(5m, (decimal)rows[1].sumAmount);
+    }
+
+    /// <summary>
+    /// EN: Tests Having_ShouldFilterAggregates behavior.
+    /// PT: Testa o comportamento de Having_ShouldFilterAggregates.
+    /// </summary>
+    [Fact]
+    public void Having_ShouldFilterAggregates()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING sumAmount >= 10
+                  """;
+
+        var rows = Query(sql);
+        Assert.Single(rows);
+        Assert.Equal(1, (int)rows[0].userId);
+    }
+
+    /// <summary>
+    /// EN: Ensures HAVING aggregate alias can be combined with ORDER BY ordinal in grouped execution.
+    /// PT: Garante que alias de agregação no HAVING possa ser combinado com ORDER BY ordinal na execução agrupada.
+    /// </summary>
+    [Fact]
+    public void Having_AggregateAlias_WithOrderByOrdinal_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING sumAmount > 0
+                  ORDER BY 2 DESC
+                  """;
+
+        var rows = Query(sql);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, (int)rows[0].userId);
+        Assert.Equal(40m, (decimal)rows[0].sumAmount);
+        Assert.Equal(2, (int)rows[1].userId);
+        Assert.Equal(5m, (decimal)rows[1].sumAmount);
+    }
+
+    /// <summary>
+    /// EN: Ensures invalid HAVING alias in grouped execution throws a clear validation error.
+    /// PT: Garante que alias inválido no HAVING em execução agrupada lance erro de validação claro.
+    /// </summary>
+    [Fact]
+    public void Having_InvalidAlias_ShouldThrow()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING missing_alias > 0
+                  """;
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Query(sql));
+        Assert.Contains("HAVING reference", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures HAVING ordinal expression resolves to the corresponding projected select item.
+    /// PT: Garante que expressão ordinal no HAVING resolva para o item projetado correspondente no SELECT.
+    /// </summary>
+    [Fact]
+    public void Having_OrdinalExpression_ShouldResolveSelectedColumn()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING 2 > 0
+                  ORDER BY userId
+                  """;
+
+        var rows = Query(sql);
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, (int)rows[0].userId);
+        Assert.Equal(2, (int)rows[1].userId);
+    }
+
+    /// <summary>
+    /// EN: Ensures HAVING mixed with ordinal and aggregate resolves ordinal to the select-item expression.
+    /// PT: Garante que HAVING misto com ordinal e agregação resolva o ordinal para a expressão do item do SELECT.
+    /// </summary>
+    [Fact]
+    public void Having_MixedOrdinalAndAggregate_ShouldResolveOrdinal()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING 2 > 10 AND SUM(amount) > 0
+                  ORDER BY userId
+                  """;
+
+        var rows = Query(sql);
+        Assert.Single(rows);
+        Assert.Equal(1, (int)rows[0].userId);
+    }
+
+    /// <summary>
+    /// EN: Ensures HAVING CASE expression resolves ordinal references correctly.
+    /// PT: Garante que expressão CASE no HAVING resolva corretamente referências ordinais.
+    /// </summary>
+    [Fact]
+    public void Having_CaseWithOrdinal_ShouldResolveOrdinal()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING CASE WHEN 2 > 10 THEN 1 ELSE 0 END = 1
+                  ORDER BY userId
+                  """;
+
+        var rows = Query(sql);
+        Assert.Single(rows);
+        Assert.Equal(1, (int)rows[0].userId);
+    }
+
+    /// <summary>
+    /// EN: Ensures HAVING BETWEEN expression resolves ordinal references correctly.
+    /// PT: Garante que expressão BETWEEN no HAVING resolva corretamente referências ordinais.
+    /// </summary>
+    [Fact]
+    public void Having_BetweenWithOrdinal_ShouldResolveOrdinal()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING 2 BETWEEN 35 AND 45
+                  ORDER BY userId
+                  """;
+
+        var rows = Query(sql);
+        Assert.Single(rows);
+        Assert.Equal(1, (int)rows[0].userId);
+    }
+
+    /// <summary>
+    /// EN: Ensures HAVING IN expression resolves ordinal references correctly.
+    /// PT: Garante que expressão IN no HAVING resolva corretamente referências ordinais.
+    /// </summary>
+    [Fact]
+    public void Having_InWithOrdinal_ShouldResolveOrdinal()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING 2 IN (40)
+                  ORDER BY userId
+                  """;
+
+        var rows = Query(sql);
+        Assert.Single(rows);
+        Assert.Equal(1, (int)rows[0].userId);
+    }
+
+    /// <summary>
+    /// EN: Ensures numeric thresholds in HAVING aggregate comparisons are treated as constants, not ordinals.
+    /// PT: Garante que limites numéricos em comparações de agregação no HAVING sejam tratados como constantes, não ordinais.
+    /// </summary>
+    [Fact]
+    public void Having_AggregateThresholdConstant_ShouldNotBeTreatedAsOrdinal()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING SUM(amount) > 10
+                  ORDER BY userId
+                  """;
+
+        var rows = Query(sql);
+        Assert.Single(rows);
+        Assert.Equal(1, (int)rows[0].userId);
+    }
+
+    /// <summary>
+    /// EN: Ensures HAVING ordinal out of range throws a clear validation error.
+    /// PT: Garante que ordinal fora do intervalo no HAVING lance um erro de validação claro.
+    /// </summary>
+    [Fact]
+    public void Having_OrdinalOutOfRange_ShouldThrow()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING 3 > 0
+                  """;
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Query(sql));
+        Assert.Contains("HAVING ordinal", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures non-positive ordinals in HAVING are rejected even when mixed with aggregate predicates.
+    /// PT: Garante que ordinais não positivos no HAVING sejam rejeitados mesmo quando combinados com predicados de agregação.
+    /// </summary>
+    [Fact]
+    public void Having_NonPositiveOrdinal_WithAggregate_ShouldThrow()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING 0 > 0 AND SUM(amount) > 0
+                  """;
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Query(sql));
+        Assert.Contains("HAVING ordinal", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures out-of-range ordinals in HAVING are rejected even when mixed with aggregate predicates.
+    /// PT: Garante que ordinais fora do intervalo no HAVING sejam rejeitados mesmo quando combinados com predicados de agregação.
+    /// </summary>
+    [Fact]
+    public void Having_OrdinalOutOfRange_WithAggregate_ShouldThrow()
+    {
+        const string sql = """
+                  SELECT userId, SUM(amount) AS sumAmount
+                  FROM orders
+                  GROUP BY userId
+                  HAVING 3 > 0 AND SUM(amount) > 0
+                  """;
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Query(sql));
+        Assert.Contains("HAVING ordinal", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Disposes test resources.
+    /// PT: Descarta os recursos do teste.
+    /// </summary>
+    /// <param name="disposing">EN: True to dispose managed resources. PT: True para descartar recursos gerenciados.</param>
+    protected override void Dispose(bool disposing)
+    {
+        _connection.Dispose();
+        base.Dispose(disposing);
+    }
+}

--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -563,6 +563,12 @@ internal abstract class AstQueryExecutorBase(
             ref outOfRangeOrdinal,
             ref nonPositiveOrdinal);
 
+        if (nonPositiveOrdinal.HasValue)
+            throw new InvalidOperationException("invalid: HAVING ordinal must be >= 1");
+
+        if (outOfRangeOrdinal.HasValue)
+            throw new InvalidOperationException($"invalid: HAVING ordinal {outOfRangeOrdinal.Value} out of range");
+
         if (usedOrdinal)
             return rewritten;
 
@@ -570,12 +576,6 @@ internal abstract class AstQueryExecutorBase(
         var hasIdentifier = EnumerateIdentifiers(rewritten).Any();
         if (hasAggregate || hasIdentifier)
             return rewritten;
-
-        if (nonPositiveOrdinal.HasValue)
-            throw new InvalidOperationException("invalid: HAVING ordinal must be >= 1");
-
-        if (outOfRangeOrdinal.HasValue)
-            throw new InvalidOperationException($"invalid: HAVING ordinal {outOfRangeOrdinal.Value} out of range");
 
         throw new InvalidOperationException(
             "invalid: HAVING must reference grouped columns, projected aliases, aggregates, or valid ordinals");


### PR DESCRIPTION
### Motivation

- Reduce duplicated aggregation/HAVING test code across providers by centralizing shared scenarios and provider-specific setup.
- Ensure HAVING ordinal validation is consistent and rejects non-positive or out-of-range ordinals even when mixed with aggregate predicates.

### Description

- Add `AggregationHavingOrdinalTestsBase<TDbMock,TConnection>` which seeds the `orders` table, implements shared aggregation and HAVING ordinal tests, and exposes abstract `CreateDb`, `CreateConnection` and `Query` members.
- Convert provider-specific test classes (`Db2`, `MySql`, `Npgsql`, `Oracle`, `SqlServer`, `Sqlite`) to inherit from the new base and implement `CreateDb`, `CreateConnection` and `Query`, removing duplicated setup/teardown and test implementations.
- Update calls to execute SQL to use the abstract `Query` method in the derived tests.
- Change `AstQueryExecutorBase.NormalizeHavingExpression` to throw on `nonPositiveOrdinal` and `outOfRangeOrdinal` earlier in the flow so invalid ordinals are rejected even when combined with aggregate expressions, and keep the final validation message for otherwise-invalid HAVING expressions.

### Testing

- Ran the xUnit test suite for aggregation/HAVING scenarios via `dotnet test` across the provider test projects. All aggregation/HAVING tests, including new cases `Having_NonPositiveOrdinal_WithAggregate_ShouldThrow` and `Having_OrdinalOutOfRange_WithAggregate_ShouldThrow`, succeeded.
- Verified provider-specific test classes compile and run using the shared base test class via their implemented `CreateDb`/`CreateConnection`/`Query` methods.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e7623c4c832caf4de14db1094cc4)