### PR TITLE
Docs: expand Getting Started, README index and Wiki links; add NuGet usage and provider examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Este diretório organiza o conteúdo por contexto para facilitar navegação, ma
   - instalação
   - setup de provider
   - exemplos de uso
+  - checklist de revisão da documentação pós-mudanças
 - [Provedores, versões e compatibilidade](providers-and-features.md)
   - matriz por banco
   - capacidades SQL por dialeto/versão
@@ -31,6 +32,18 @@ Este diretório organiza o conteúdo por contexto para facilitar navegação, ma
 - [Relatório de hardening/regressão](hardening-regression-report.md)
   - regressões corrigidas
   - próximos itens priorizados
+- [Backlog técnico de testes de gaps](gap-tests-technical-backlog.md)
+  - priorização de testes por feature SQL
+  - referência para cobertura incremental
+- [Relatório de readiness para NuGet](nuget-readiness-validation-report.md)
+  - checklist de empacotamento
+  - validações antes de publicar
+- [Revisão de performance (work branch)](performance-review-work-branch.md)
+  - achados de performance
+  - recomendações de otimização
+- [Testes por versão de dialeto](testes-por-versao-dialect.md)
+  - cobertura por versão simulada
+  - rastreabilidade de comportamento por provider
 - [Publicação](publishing.md)
   - NuGet
   - Visual Studio (VSIX)

--- a/docs/wiki/pages/Home.md
+++ b/docs/wiki/pages/Home.md
@@ -6,16 +6,16 @@ DbSqlLikeMem is an in-memory database engine for C# unit tests focused on simula
 
 ## Navigation
 
-- [Getting Started](Getting-Started)
-- [Providers and Compatibility](Providers-and-Compatibility)
-- [Publishing](Publishing)
+- [Getting Started](Getting-Started.md)
+- [Providers and Compatibility](Providers-and-Compatibility.md)
+- [Publishing](Publishing.md)
 
 ## Useful repository links
 
-- Main README
-- `docs/getting-started.md`
-- `docs/providers-and-features.md`
-- `docs/publishing.md`
+- [Main README](https://github.com/chrisulson/DbSqlLikeMem/blob/main/README.md)
+- [Getting started (repo docs)](https://github.com/chrisulson/DbSqlLikeMem/blob/main/docs/getting-started.md)
+- [Providers and features (repo docs)](https://github.com/chrisulson/DbSqlLikeMem/blob/main/docs/providers-and-features.md)
+- [Publishing guide (repo docs)](https://github.com/chrisulson/DbSqlLikeMem/blob/main/docs/publishing.md)
 
 ---
 


### PR DESCRIPTION
### Motivation
- Atualizar e ampliar a documentação para cobrir novos providers, distribuição por NuGet e orientações práticas de uso em times e CI.
- Corrigir referências de projeto para apontar para a árvore `src/` e centralizar exemplos de consumo e factory para múltiplos providers.
- Fornecer checklists e artefatos de apoio (readiness, backlog de testes, performance) para facilitar manutenção e publicação do pacote.

### Description
- Atualiza `docs/README.md` adicionando novas entradas ao índice como `gap-tests-technical-backlog.md`, `nuget-readiness-validation-report.md`, `performance-review-work-branch.md` e `testes-por-versao-dialect.md`.
- Modifica `docs/getting-started.md` para usar `ProjectReference` em `src/…`, adiciona a opção de instalação via NuGet com exemplos de pacotes e inclui dicas de escolha de provider em projetos de teste.
- Expande a seleção de providers e a factory em exemplos para incluir `Sqlite` e `Db2`, e adiciona um exemplo de schema/manual+seed para `Npgsql` e outros trechos de uso prático; também insere um checklist rápido de revisão de documentação.
- Ajusta `docs/wiki/pages/Home.md` para usar links com extensão `.md` e adiciona links absolutos para o repositório no GitHub.

### Testing
- Executed `dotnet test src/DbSqlLikeMem.slnx` as part of the documentation checklist and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f089dc4c832ca90ca88331f178ac)