### PR TITLE
docs: refresh implementation plan to P7–P14 and include NHibernate tests in discovery

### DIFF
--- a/docs/p7-p10-implementation-plan.md
+++ b/docs/p7-p10-implementation-plan.md
@@ -1,56 +1,100 @@
-# Plano executável — P7 a P10
+# Plano executável — P7 a P14
 
-Documento gerado por `scripts/generate_p7_p10_plan.py` para orientar implementação técnica dos itens P7, P8, P9 e P10 com base nos testes existentes por provider.
+Documento gerado por `scripts/generate_p7_p10_plan.py` para orientar implementação técnica dos itens P7 a P14 com base nos testes existentes por provider.
 
 ## Como usar
 
-1. Escolha um pilar (P7–P10).
+1. Escolha um pilar (P7–P14).
 2. Implemente provider por provider, priorizando os arquivos mapeados abaixo.
 3. Rode os testes por provider e atualize o status.
 
 ## P7 (DML avançado)
 
-| Provider | Arquivos de teste-alvo | Status |
-| --- | --- | --- |
-| MySQL | `src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/Strategy/MySqlDeleteStrategyTests.cs` | ⬜ Pending |
-| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs` | ⬜ Pending |
-| Oracle | `src/DbSqlLikeMem.Oracle.Test/Strategy/OracleInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/Strategy/OracleDeleteStrategyTests.cs` | ⬜ Pending |
-| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs` | ⬜ Pending |
-| SQLite | `src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteDeleteStrategyTests.cs` | ⬜ Pending |
-| DB2 | `src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/Strategy/Db2UpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/Strategy/Db2DeleteStrategyTests.cs` | ⬜ Pending |
+| Provider | Arquivos de teste-alvo | Cobertura | Status sugerido |
+| --- | --- | --- | --- |
+| MySQL | `src/DbSqlLikeMem.MySql.Test/Strategy/MySqlInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/Strategy/MySqlUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/Strategy/MySqlDeleteStrategyTests.cs` | 3 arquivos | 🟨 Em evolução |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Dapper.Test/Strategy/SqlServerInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerDeleteStrategyTests.cs` | 3 arquivos | 🟨 Em evolução |
+| Oracle | `src/DbSqlLikeMem.Oracle.Dapper.Test/Strategy/OracleInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/Strategy/OracleUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/Strategy/OracleDeleteStrategyTests.cs` | 3 arquivos | 🟨 Em evolução |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Dapper.Test/Strategy/PostgreSqlInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlDeleteStrategyTests.cs` | 3 arquivos | 🟨 Em evolução |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteInsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteUpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteDeleteStrategyTests.cs` | 3 arquivos | 🟨 Em evolução |
+| DB2 | `src/DbSqlLikeMem.Db2.Test/Strategy/Db2InsertOnDuplicateTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/Strategy/Db2UpdateStrategyTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/Strategy/Db2DeleteStrategyTests.cs` | 3 arquivos | 🟨 Em evolução |
 
 ## P8 (Paginação/ordenação)
 
-| Provider | Arquivos de teste-alvo | Status |
-| --- | --- | --- |
-| MySQL | `src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
-| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
-| Oracle | `src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
-| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
-| SQLite | `src/DbSqlLikeMem.Sqlite.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
-| DB2 | `src/DbSqlLikeMem.Db2.Test/Db2UnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| Provider | Arquivos de teste-alvo | Cobertura | Status sugerido |
+| --- | --- | --- | --- |
+| MySQL | `src/DbSqlLikeMem.MySql.Dapper.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
+| Oracle | `src/DbSqlLikeMem.Oracle.Dapper.Test/OracleUnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
+| DB2 | `src/DbSqlLikeMem.Db2.Dapper.Test/Db2UnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
 
 ## P9 (JSON)
 
-| Provider | Arquivos de teste-alvo | Status |
-| --- | --- | --- |
-| MySQL | `src/DbSqlLikeMem.MySql.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
-| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
-| Oracle | `src/DbSqlLikeMem.Oracle.Test/OracleUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
-| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
-| SQLite | `src/DbSqlLikeMem.Sqlite.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
-| DB2 | `src/DbSqlLikeMem.Db2.Test/Db2UnionLimitAndJsonCompatibilityTests.cs` | ⬜ Pending |
+| Provider | Arquivos de teste-alvo | Cobertura | Status sugerido |
+| --- | --- | --- | --- |
+| MySQL | `src/DbSqlLikeMem.MySql.Dapper.Test/MySqlUnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerUnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
+| Oracle | `src/DbSqlLikeMem.Oracle.Dapper.Test/OracleUnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlUnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteUnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
+| DB2 | `src/DbSqlLikeMem.Db2.Dapper.Test/Db2UnionLimitAndJsonCompatibilityTests.cs` | 1 arquivo | 🟨 Em evolução |
 
 ## P10 (Procedures/OUT params)
 
-| Provider | Arquivos de teste-alvo | Status |
-| --- | --- | --- |
-| MySQL | `src/DbSqlLikeMem.MySql.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
-| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
-| Oracle | `src/DbSqlLikeMem.Oracle.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
-| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
-| SQLite | `src/DbSqlLikeMem.Sqlite.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
-| DB2 | `src/DbSqlLikeMem.Db2.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/StoredProcedureSignatureTests.cs` | ⬜ Pending |
+| Provider | Arquivos de teste-alvo | Cobertura | Status sugerido |
+| --- | --- | --- | --- |
+| MySQL | `src/DbSqlLikeMem.MySql.Dapper.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/StoredProcedureSignatureTests.cs` | 2 arquivos | 🟨 Em evolução |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Dapper.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/StoredProcedureSignatureTests.cs` | 2 arquivos | 🟨 Em evolução |
+| Oracle | `src/DbSqlLikeMem.Oracle.Dapper.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/StoredProcedureSignatureTests.cs` | 2 arquivos | 🟨 Em evolução |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Dapper.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/StoredProcedureSignatureTests.cs` | 2 arquivos | 🟨 Em evolução |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Dapper.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/StoredProcedureSignatureTests.cs` | 2 arquivos | 🟨 Em evolução |
+| DB2 | `src/DbSqlLikeMem.Db2.Dapper.Test/StoredProcedureExecutionTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/StoredProcedureSignatureTests.cs` | 2 arquivos | 🟨 Em evolução |
+
+## P11 (Confiabilidade transacional e concorrência)
+
+| Provider | Arquivos de teste-alvo | Cobertura | Status sugerido |
+| --- | --- | --- | --- |
+| MySQL | `src/DbSqlLikeMem.MySql.Test/Strategy/MySqlTransactionTests.cs`<br>`src/DbSqlLikeMem.MySql.Dapper.Test/MySqlTransactionTests.cs`<br>`src/DbSqlLikeMem.MySql.Dapper.Test/MySqlTransactionReliabilityTests.cs` | 3 arquivos | 🟨 Em evolução |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/Strategy/SqlServerTransactionTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerTransactionTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerTransactionReliabilityTests.cs` | 3 arquivos | 🟨 Em evolução |
+| Oracle | `src/DbSqlLikeMem.Oracle.Test/Strategy/OracleTransactionTests.cs`<br>`src/DbSqlLikeMem.Oracle.Dapper.Test/OracleTransactionTests.cs`<br>`src/DbSqlLikeMem.Oracle.Dapper.Test/OracleTransactionReliabilityTests.cs` | 3 arquivos | 🟨 Em evolução |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/Strategy/PostgreSqlTransactionTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlTransactionTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlTransactionReliabilityTests.cs` | 3 arquivos | 🟨 Em evolução |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Test/Strategy/SqliteTransactionTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteTransactionTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteTransactionReliabilityTests.cs` | 3 arquivos | 🟨 Em evolução |
+| DB2 | `src/DbSqlLikeMem.Db2.Test/Strategy/Db2TransactionTests.cs`<br>`src/DbSqlLikeMem.Db2.Dapper.Test/Db2TransactionTests.cs`<br>`src/DbSqlLikeMem.Db2.Dapper.Test/Db2TransactionReliabilityTests.cs` | 3 arquivos | 🟨 Em evolução |
+
+## P12 (Observabilidade, diagnóstico e ergonomia de erro)
+
+| Provider | Arquivos de teste-alvo | Cobertura | Status sugerido |
+| --- | --- | --- | --- |
+| MySQL | `src/DbSqlLikeMem.MySql.Dapper.Test/MySqlAdditionalBehaviorCoverageTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/ExecutionPlanTests.cs`<br>`src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserCorpusTests.cs` | 3 arquivos | 🟨 Em evolução |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAdditionalBehaviorCoverageTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/ExecutionPlanTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/Parser/SqlQueryParserCorpusTests.cs` | 3 arquivos | 🟨 Em evolução |
+| Oracle | `src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAdditionalBehaviorCoverageTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/ExecutionPlanTests.cs`<br>`src/DbSqlLikeMem.Oracle.Test/Parser/SqlQueryParserCorpusTests.cs` | 3 arquivos | 🟨 Em evolução |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlAdditionalBehaviorCoverageTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/ExecutionPlanTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/Parser/SqlQueryParserCorpusTests.cs` | 3 arquivos | 🟨 Em evolução |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAdditionalBehaviorCoverageTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/ExecutionPlanTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/Parser/SqlQueryParserCorpusTests.cs` | 3 arquivos | 🟨 Em evolução |
+| DB2 | `src/DbSqlLikeMem.Db2.Dapper.Test/Db2AdditionalBehaviorCoverageTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/ExecutionPlanTests.cs`<br>`src/DbSqlLikeMem.Db2.Test/Parser/SqlQueryParserCorpusTests.cs` | 3 arquivos | 🟨 Em evolução |
+
+## P13 (Performance e escala do engine em memória)
+
+| Provider | Arquivos de teste-alvo | Cobertura | Status sugerido |
+| --- | --- | --- | --- |
+| MySQL | `src/DbSqlLikeMem.MySql.Test/Performance/MySqlPerformanceTests.cs` | 1 arquivo | 🟨 Em evolução |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.Test/Performance/SqlServerPerformanceTests.cs` | 1 arquivo | 🟨 Em evolução |
+| Oracle | `src/DbSqlLikeMem.Oracle.Test/Performance/OraclePerformanceTests.cs` | 1 arquivo | 🟨 Em evolução |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.Test/Performance/PostgreSqlPerformanceTests.cs` | 1 arquivo | 🟨 Em evolução |
+| SQLite | `src/DbSqlLikeMem.Sqlite.Test/Performance/SqlitePerformanceTests.cs` | 1 arquivo | 🟨 Em evolução |
+| DB2 | `src/DbSqlLikeMem.Db2.Test/Performance/Db2PerformanceTests.cs` | 1 arquivo | 🟨 Em evolução |
+
+## P14 (Conformidade de ecossistema .NET/ORM/tooling)
+
+| Provider | Arquivos de teste-alvo | Cobertura | Status sugerido |
+| --- | --- | --- | --- |
+| MySQL | `src/DbSqlLikeMem.MySql.NHibernate.Test/NHibernateSmokeTests.cs`<br>`src/DbSqlLikeMem.MySql.Dapper.Test/DapperTests.cs`<br>`src/DbSqlLikeMem.MySql.Dapper.Test/FluentTest.cs`<br>`src/DbSqlLikeMem.MySql.Test/MySqlLinqProviderTest.cs` | 4 arquivos | 🟨 Em evolução |
+| SQL Server | `src/DbSqlLikeMem.SqlServer.NHibernate.Test/NHibernateSmokeTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Dapper.Test/DapperTests.cs`<br>`src/DbSqlLikeMem.SqlServer.Dapper.Test/FluentTest.cs`<br>`src/DbSqlLikeMem.SqlServer.Test/SqlServerLinqProviderTest.cs` | 4 arquivos | 🟨 Em evolução |
+| Oracle | `src/DbSqlLikeMem.Oracle.NHibernate.Test/NHibernateSmokeTests.cs`<br>`src/DbSqlLikeMem.Oracle.Dapper.Test/DapperTests.cs`<br>`src/DbSqlLikeMem.Oracle.Dapper.Test/FluentTest.cs`<br>`src/DbSqlLikeMem.Oracle.Test/OracleLinqProviderTest.cs` | 4 arquivos | 🟨 Em evolução |
+| PostgreSQL (Npgsql) | `src/DbSqlLikeMem.Npgsql.NHibernate.Test/NHibernateSmokeTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Dapper.Test/DapperTests.cs`<br>`src/DbSqlLikeMem.Npgsql.Dapper.Test/FluentTest.cs`<br>`src/DbSqlLikeMem.Npgsql.Test/PostgreSqlLinqProviderTest.cs` | 4 arquivos | 🟨 Em evolução |
+| SQLite | `src/DbSqlLikeMem.Sqlite.NHibernate.Test/NHibernateSmokeTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Dapper.Test/DapperTests.cs`<br>`src/DbSqlLikeMem.Sqlite.Dapper.Test/FluentTest.cs`<br>`src/DbSqlLikeMem.Sqlite.Test/SqliteLinqProviderTest.cs` | 4 arquivos | 🟨 Em evolução |
+| DB2 | `src/DbSqlLikeMem.Db2.NHibernate.Test/NHibernateSmokeTests.cs`<br>`src/DbSqlLikeMem.Db2.Dapper.Test/DapperTests.cs`<br>`src/DbSqlLikeMem.Db2.Dapper.Test/FluentTest.cs`<br>`src/DbSqlLikeMem.Db2.Test/Db2LinqProviderTest.cs` | 4 arquivos | 🟨 Em evolução |
 
 ## Checklist de saída por PR
 


### PR DESCRIPTION
### Motivation

- O plano existente (P7–P10) estava desalinhado com o estado atual do repositório porque testes e trabalho foram adicionados além de P10. 
- É necessário que o documento de planejamento reflita a matriz real de testes para priorização e progresso. 
- A descoberta de testes precisava incluir projetos `NHibernate.Test` e `Dapper.Test` para evitar lacunas no mapeamento por provider.

### Description

- Atualizei `scripts/generate_p7_p10_plan.py` para ampliar o conjunto de pilares de implementação de `P7–P10` para `P7–P14` e adicionar os tokens de busca correspondentes a P11–P14. 
- Ampliei a função de descoberta de testes `find_test_paths` para procurar em `DbSqlLikeMem.<Provider>.Test`, `DbSqlLikeMem.<Provider>.Dapper.Test` e `DbSqlLikeMem.<Provider>.NHibernate.Test`, mantendo desduplicação e ordem. 
- Melhorei a saída do gerador para incluir as colunas `Cobertura` (pluralização correta `arquivo`/`arquivos`) e `Status sugerido` (`🟨 Em evolução` / `⬜ Gap`) para facilitar priorização. 
- Regenerado o documento `docs/p7-p10-implementation-plan.md` com inventário atualizado por provider cobrindo `P7–P14` (arquivo de saída preservado para compatibilidade).

### Testing

- Executei `python3 -m py_compile scripts/generate_p7_p10_plan.py` com sucesso para validar sintaxe Python. 
- Executei `python3 scripts/generate_p7_p10_plan.py` que atualizou `docs/p7-p10-implementation-plan.md` corretamente sem erros.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f0d5d7b8832cbfa828deeb13ff33)