### PR TITLE
Make ADO.NET types explicit and stabilize provider mocks (aliases, batch async, adapter/data source decoupling)

### DIFF
--- a/src/DbSqlLikeMem.Db2/Db2BatchMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2BatchMock.cs
@@ -217,6 +217,37 @@ public sealed class Db2BatchMock : DbBatch
     }
 
     /// <summary>
+    /// EN: Summary for ExecuteNonQueryAsync.
+    /// PT: Resumo para ExecuteNonQueryAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task<int> ExecuteNonQueryAsync(System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(ExecuteNonQuery());
+
+    /// <summary>
+    /// EN: Summary for ExecuteDbDataReaderAsync.
+    /// PT: Resumo para ExecuteDbDataReaderAsync.
+    /// </summary>
+    protected override System.Threading.Tasks.Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult<DbDataReader>(ExecuteDbDataReader(behavior));
+
+    /// <summary>
+    /// EN: Summary for ExecuteScalarAsync.
+    /// PT: Resumo para ExecuteScalarAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task<object?> ExecuteScalarAsync(System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(ExecuteScalar());
+
+    /// <summary>
+    /// EN: Summary for PrepareAsync.
+    /// PT: Resumo para PrepareAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task PrepareAsync(System.Threading.CancellationToken cancellationToken = default)
+    {
+        Prepare();
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    /// <summary>
     /// EN: Summary for Prepare.
     /// PT: Resumo para Prepare.
     /// </summary>
@@ -253,7 +284,13 @@ public sealed class Db2BatchCommandMock : DbBatchCommand, IDb2CommandMock
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public override int RecordsAffected { get; set; }
+    private int recordsAffected;
+
+    /// <summary>
+    /// EN: Summary for member.
+    /// PT: Resumo para member.
+    /// </summary>
+    public override int RecordsAffected => recordsAffected;
 
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.Db2/Db2DataAdapterMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2DataAdapterMock.cs
@@ -1,10 +1,12 @@
+using System.Data.Common;
+
 namespace DbSqlLikeMem.Db2;
 
 /// <summary>
 /// EN: Summary for Db2DataAdapterMock.
 /// PT: Resumo para Db2DataAdapterMock.
 /// </summary>
-public sealed class Db2DataAdapterMock : DbDataAdapter, IDbDataAdapter
+public sealed class Db2DataAdapterMock : DbDataAdapter
 {
     /// <summary>
     /// EN: Summary for DeleteCommand.

--- a/src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj
+++ b/src/DbSqlLikeMem.Npgsql/DbSqlLikeMem.Npgsql.csproj
@@ -36,6 +36,7 @@
 	<ItemGroup>
 		<Using Include="DbSqlLikeMem.Resources" />
 		<Using Include="System.Data" />
+		<Using Include="System.Data.Common" />
 		<Using Include="System.Globalization" />
 		<Using Include="System.Text.RegularExpressions" />
 	</ItemGroup>

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlBatchMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlBatchMock.cs
@@ -1,3 +1,13 @@
+using System.Data.Common;
+
+using DbBatch = System.Data.Common.DbBatch;
+using DbConnection = System.Data.Common.DbConnection;
+using DbTransaction = System.Data.Common.DbTransaction;
+using DbBatchCommandCollection = System.Data.Common.DbBatchCommandCollection;
+using DbDataReader = System.Data.Common.DbDataReader;
+using DbBatchCommand = System.Data.Common.DbBatchCommand;
+using DbParameterCollection = System.Data.Common.DbParameterCollection;
+using DbParameter = System.Data.Common.DbParameter;
 namespace DbSqlLikeMem.Npgsql;
 
 #if NET6_0_OR_GREATER
@@ -217,6 +227,37 @@ public sealed class NpgsqlBatchMock : DbBatch
     }
 
     /// <summary>
+    /// EN: Summary for ExecuteNonQueryAsync.
+    /// PT: Resumo para ExecuteNonQueryAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task<int> ExecuteNonQueryAsync(System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(ExecuteNonQuery());
+
+    /// <summary>
+    /// EN: Summary for ExecuteDbDataReaderAsync.
+    /// PT: Resumo para ExecuteDbDataReaderAsync.
+    /// </summary>
+    protected override System.Threading.Tasks.Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult<DbDataReader>(ExecuteDbDataReader(behavior));
+
+    /// <summary>
+    /// EN: Summary for ExecuteScalarAsync.
+    /// PT: Resumo para ExecuteScalarAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task<object?> ExecuteScalarAsync(System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(ExecuteScalar());
+
+    /// <summary>
+    /// EN: Summary for PrepareAsync.
+    /// PT: Resumo para PrepareAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task PrepareAsync(System.Threading.CancellationToken cancellationToken = default)
+    {
+        Prepare();
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    /// <summary>
     /// EN: Summary for Prepare.
     /// PT: Resumo para Prepare.
     /// </summary>
@@ -253,7 +294,13 @@ public sealed class NpgsqlBatchCommandMock : DbBatchCommand, INpgsqlCommandMock
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public override int RecordsAffected { get; set; }
+    private int recordsAffected;
+
+    /// <summary>
+    /// EN: Summary for member.
+    /// PT: Resumo para member.
+    /// </summary>
+    public override int RecordsAffected => recordsAffected;
 
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlConnectorFactoryMock.cs
@@ -1,3 +1,13 @@
+using System.Data.Common;
+
+using DbProviderFactory = System.Data.Common.DbProviderFactory;
+using DbCommand = System.Data.Common.DbCommand;
+using DbConnection = System.Data.Common.DbConnection;
+using DbConnectionStringBuilder = System.Data.Common.DbConnectionStringBuilder;
+using DbParameter = System.Data.Common.DbParameter;
+using DbDataAdapter = System.Data.Common.DbDataAdapter;
+using DbBatch = System.Data.Common.DbBatch;
+using DbBatchCommand = System.Data.Common.DbBatchCommand;
 namespace DbSqlLikeMem.Npgsql;
 
 /// <summary>
@@ -89,9 +99,5 @@ public sealed class NpgsqlConnectorFactoryMock : DbProviderFactory
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public
-#if NET7_0_OR_GREATER
-    override
-#endif
-    NpgsqlDataSourceMock CreateDataSource(string connectionString) => new(db);
+    public NpgsqlDataSourceMock CreateDataSource(string connectionString) => new(db);
 }

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDataAdapterMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDataAdapterMock.cs
@@ -1,10 +1,13 @@
+using System.Data.Common;
+
+using DbDataAdapter = System.Data.Common.DbDataAdapter;
 namespace DbSqlLikeMem.Npgsql;
 
 /// <summary>
 /// EN: Summary for NpgsqlDataAdapterMock.
 /// PT: Resumo para NpgsqlDataAdapterMock.
 /// </summary>
-public sealed class NpgsqlDataAdapterMock : DbDataAdapter, IDbDataAdapter
+public sealed class NpgsqlDataAdapterMock : DbDataAdapter
 {
     /// <summary>
     /// EN: Summary for DeleteCommand.

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs
@@ -1,3 +1,6 @@
+using System.Data.Common;
+
+using DbConnection = System.Data.Common.DbConnection;
 namespace DbSqlLikeMem.Npgsql;
 
 /// <summary>
@@ -5,31 +8,16 @@ namespace DbSqlLikeMem.Npgsql;
 /// PT: Resumo para NpgsqlDataSourceMock.
 /// </summary>
 public sealed class NpgsqlDataSourceMock(NpgsqlDbMock? db = null)
-#if NET8_0_OR_GREATER
-    : DbDataSource
-#endif
 {
     /// <summary>
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public
-#if NET8_0_OR_GREATER
-    override
-#endif
-    string ConnectionString => string.Empty;
+    public string ConnectionString => string.Empty;
 
-#if NET8_0_OR_GREATER
     /// <summary>
     /// EN: Summary for CreateDbConnection.
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
-    protected override DbConnection CreateDbConnection() => new NpgsqlConnectionMock(db);
-#else
-    /// <summary>
-    /// EN: Summary for CreateDbConnection.
-    /// PT: Resumo para CreateDbConnection.
-    /// </summary>
-    public DbConnection CreateDbConnection() => new NpgsqlConnectionMock(db);
-#endif
+    public NpgsqlConnectionMock CreateDbConnection() => new NpgsqlConnectionMock(db);
 }

--- a/src/DbSqlLikeMem.Oracle/DbSqlLikeMem.Oracle.csproj
+++ b/src/DbSqlLikeMem.Oracle/DbSqlLikeMem.Oracle.csproj
@@ -23,6 +23,7 @@
 	<ItemGroup>
 		<Using Include="DbSqlLikeMem.Resources" />
 		<Using Include="System.Data" />
+		<Using Include="System.Data.Common" />
 		<Using Include="System.Globalization" />
 		<Using Include="System.Text.RegularExpressions" />
 	</ItemGroup>

--- a/src/DbSqlLikeMem.Oracle/OracleBatchMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleBatchMock.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 namespace DbSqlLikeMem.Oracle;
 
 #if NET6_0_OR_GREATER
@@ -217,6 +219,37 @@ public sealed class OracleBatchMock : DbBatch
     }
 
     /// <summary>
+    /// EN: Summary for ExecuteNonQueryAsync.
+    /// PT: Resumo para ExecuteNonQueryAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task<int> ExecuteNonQueryAsync(System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(ExecuteNonQuery());
+
+    /// <summary>
+    /// EN: Summary for ExecuteDbDataReaderAsync.
+    /// PT: Resumo para ExecuteDbDataReaderAsync.
+    /// </summary>
+    protected override System.Threading.Tasks.Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult<DbDataReader>(ExecuteDbDataReader(behavior));
+
+    /// <summary>
+    /// EN: Summary for ExecuteScalarAsync.
+    /// PT: Resumo para ExecuteScalarAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task<object?> ExecuteScalarAsync(System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(ExecuteScalar());
+
+    /// <summary>
+    /// EN: Summary for PrepareAsync.
+    /// PT: Resumo para PrepareAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task PrepareAsync(System.Threading.CancellationToken cancellationToken = default)
+    {
+        Prepare();
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    /// <summary>
     /// EN: Summary for Prepare.
     /// PT: Resumo para Prepare.
     /// </summary>
@@ -253,7 +286,13 @@ public sealed class OracleBatchCommandMock : DbBatchCommand, IOracleCommandMock
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public override int RecordsAffected { get; set; }
+    private int recordsAffected;
+
+    /// <summary>
+    /// EN: Summary for member.
+    /// PT: Resumo para member.
+    /// </summary>
+    public override int RecordsAffected => recordsAffected;
 
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.Oracle/OracleConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleConnectorFactoryMock.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 namespace DbSqlLikeMem.Oracle;
 
 /// <summary>
@@ -89,9 +91,5 @@ public sealed class OracleConnectorFactoryMock : DbProviderFactory
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public
-#if NET7_0_OR_GREATER
-    override
-#endif
-    OracleDataSourceMock CreateDataSource(string connectionString) => new(db);
+    public OracleDataSourceMock CreateDataSource(string connectionString) => new(db);
 }

--- a/src/DbSqlLikeMem.Oracle/OracleDataAdapterMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDataAdapterMock.cs
@@ -1,10 +1,12 @@
+using System.Data.Common;
+
 namespace DbSqlLikeMem.Oracle;
 
 /// <summary>
 /// EN: Summary for OracleDataAdapterMock.
 /// PT: Resumo para OracleDataAdapterMock.
 /// </summary>
-public sealed class OracleDataAdapterMock : DbDataAdapter, IDbDataAdapter
+public sealed class OracleDataAdapterMock : DbDataAdapter
 {
     /// <summary>
     /// EN: Summary for DeleteCommand.

--- a/src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 namespace DbSqlLikeMem.Oracle;
 
 /// <summary>
@@ -5,31 +7,16 @@ namespace DbSqlLikeMem.Oracle;
 /// PT: Resumo para OracleDataSourceMock.
 /// </summary>
 public sealed class OracleDataSourceMock(OracleDbMock? db = null)
-#if NET8_0_OR_GREATER
-    : DbDataSource
-#endif
 {
     /// <summary>
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public
-#if NET8_0_OR_GREATER
-    override
-#endif
-    string ConnectionString => string.Empty;
+    public string ConnectionString => string.Empty;
 
-#if NET8_0_OR_GREATER
     /// <summary>
     /// EN: Summary for CreateDbConnection.
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
-    protected override DbConnection CreateDbConnection() => new OracleConnectionMock(db);
-#else
-    /// <summary>
-    /// EN: Summary for CreateDbConnection.
-    /// PT: Resumo para CreateDbConnection.
-    /// </summary>
-    public DbConnection CreateDbConnection() => new OracleConnectionMock(db);
-#endif
+    public OracleConnectionMock CreateDbConnection() => new OracleConnectionMock(db);
 }

--- a/src/DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj
+++ b/src/DbSqlLikeMem.SqlServer/DbSqlLikeMem.SqlServer.csproj
@@ -27,6 +27,7 @@
 	<ItemGroup>
 		<Using Include="DbSqlLikeMem.Resources" />
 		<Using Include="System.Data" />
+		<Using Include="System.Data.Common" />
 		<Using Include="System.Globalization" />
 		<Using Include="System.Text.RegularExpressions" />
 	</ItemGroup>

--- a/src/DbSqlLikeMem.SqlServer/SqlServerBatchMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerBatchMock.cs
@@ -1,3 +1,13 @@
+using System.Data.Common;
+
+using DbBatch = System.Data.Common.DbBatch;
+using DbConnection = System.Data.Common.DbConnection;
+using DbTransaction = System.Data.Common.DbTransaction;
+using DbBatchCommandCollection = System.Data.Common.DbBatchCommandCollection;
+using DbDataReader = System.Data.Common.DbDataReader;
+using DbBatchCommand = System.Data.Common.DbBatchCommand;
+using DbParameterCollection = System.Data.Common.DbParameterCollection;
+using DbParameter = System.Data.Common.DbParameter;
 namespace DbSqlLikeMem.SqlServer;
 
 #if NET6_0_OR_GREATER
@@ -217,6 +227,37 @@ public sealed class SqlServerBatchMock : DbBatch
     }
 
     /// <summary>
+    /// EN: Summary for ExecuteNonQueryAsync.
+    /// PT: Resumo para ExecuteNonQueryAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task<int> ExecuteNonQueryAsync(System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(ExecuteNonQuery());
+
+    /// <summary>
+    /// EN: Summary for ExecuteDbDataReaderAsync.
+    /// PT: Resumo para ExecuteDbDataReaderAsync.
+    /// </summary>
+    protected override System.Threading.Tasks.Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult<DbDataReader>(ExecuteDbDataReader(behavior));
+
+    /// <summary>
+    /// EN: Summary for ExecuteScalarAsync.
+    /// PT: Resumo para ExecuteScalarAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task<object?> ExecuteScalarAsync(System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(ExecuteScalar());
+
+    /// <summary>
+    /// EN: Summary for PrepareAsync.
+    /// PT: Resumo para PrepareAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task PrepareAsync(System.Threading.CancellationToken cancellationToken = default)
+    {
+        Prepare();
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    /// <summary>
     /// EN: Summary for Prepare.
     /// PT: Resumo para Prepare.
     /// </summary>
@@ -253,7 +294,13 @@ public sealed class SqlServerBatchCommandMock : DbBatchCommand, ISqlServerComman
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public override int RecordsAffected { get; set; }
+    private int recordsAffected;
+
+    /// <summary>
+    /// EN: Summary for member.
+    /// PT: Resumo para member.
+    /// </summary>
+    public override int RecordsAffected => recordsAffected;
 
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.SqlServer/SqlServerConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerConnectorFactoryMock.cs
@@ -1,3 +1,13 @@
+using System.Data.Common;
+
+using DbProviderFactory = System.Data.Common.DbProviderFactory;
+using DbCommand = System.Data.Common.DbCommand;
+using DbConnection = System.Data.Common.DbConnection;
+using DbConnectionStringBuilder = System.Data.Common.DbConnectionStringBuilder;
+using DbParameter = System.Data.Common.DbParameter;
+using DbDataAdapter = System.Data.Common.DbDataAdapter;
+using DbBatch = System.Data.Common.DbBatch;
+using DbBatchCommand = System.Data.Common.DbBatchCommand;
 namespace DbSqlLikeMem.SqlServer;
 
 /// <summary>
@@ -89,9 +99,5 @@ public sealed class SqlServerConnectorFactoryMock : DbProviderFactory
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public
-#if NET7_0_OR_GREATER
-    override
-#endif
-    SqlServerDataSourceMock CreateDataSource(string connectionString) => new(db);
+    public SqlServerDataSourceMock CreateDataSource(string connectionString) => new(db);
 }

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDataAdapterMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDataAdapterMock.cs
@@ -1,10 +1,13 @@
+using System.Data.Common;
+
+using DbDataAdapter = System.Data.Common.DbDataAdapter;
 namespace DbSqlLikeMem.SqlServer;
 
 /// <summary>
 /// EN: Summary for SqlServerDataAdapterMock.
 /// PT: Resumo para SqlServerDataAdapterMock.
 /// </summary>
-public sealed class SqlServerDataAdapterMock : DbDataAdapter, IDbDataAdapter
+public sealed class SqlServerDataAdapterMock : DbDataAdapter
 {
     /// <summary>
     /// EN: Summary for DeleteCommand.

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs
@@ -1,3 +1,6 @@
+using System.Data.Common;
+
+using DbConnection = System.Data.Common.DbConnection;
 namespace DbSqlLikeMem.SqlServer;
 
 /// <summary>
@@ -5,31 +8,16 @@ namespace DbSqlLikeMem.SqlServer;
 /// PT: Resumo para SqlServerDataSourceMock.
 /// </summary>
 public sealed class SqlServerDataSourceMock(SqlServerDbMock? db = null)
-#if NET8_0_OR_GREATER
-    : DbDataSource
-#endif
 {
     /// <summary>
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public
-#if NET8_0_OR_GREATER
-    override
-#endif
-    string ConnectionString => string.Empty;
+    public string ConnectionString => string.Empty;
 
-#if NET8_0_OR_GREATER
     /// <summary>
     /// EN: Summary for CreateDbConnection.
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
-    protected override DbConnection CreateDbConnection() => new SqlServerConnectionMock(db);
-#else
-    /// <summary>
-    /// EN: Summary for CreateDbConnection.
-    /// PT: Resumo para CreateDbConnection.
-    /// </summary>
-    public DbConnection CreateDbConnection() => new SqlServerConnectionMock(db);
-#endif
+    public SqlServerConnectionMock CreateDbConnection() => new SqlServerConnectionMock(db);
 }

--- a/src/DbSqlLikeMem.Sqlite/DbSqlLikeMem.Sqlite.csproj
+++ b/src/DbSqlLikeMem.Sqlite/DbSqlLikeMem.Sqlite.csproj
@@ -27,6 +27,7 @@
 	<ItemGroup>
 		<Using Include="DbSqlLikeMem.Resources" />
 		<Using Include="System.Data" />
+		<Using Include="System.Data.Common" />
 		<Using Include="System.Globalization" />
 		<Using Include="System.Text.RegularExpressions" />
 	</ItemGroup>

--- a/src/DbSqlLikeMem.Sqlite/SqliteBatchMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteBatchMock.cs
@@ -1,3 +1,13 @@
+using System.Data.Common;
+
+using DbBatch = System.Data.Common.DbBatch;
+using DbConnection = System.Data.Common.DbConnection;
+using DbTransaction = System.Data.Common.DbTransaction;
+using DbBatchCommandCollection = System.Data.Common.DbBatchCommandCollection;
+using DbDataReader = System.Data.Common.DbDataReader;
+using DbBatchCommand = System.Data.Common.DbBatchCommand;
+using DbParameterCollection = System.Data.Common.DbParameterCollection;
+using DbParameter = System.Data.Common.DbParameter;
 namespace DbSqlLikeMem.Sqlite;
 
 #if NET6_0_OR_GREATER
@@ -217,6 +227,37 @@ public sealed class SqliteBatchMock : DbBatch
     }
 
     /// <summary>
+    /// EN: Summary for ExecuteNonQueryAsync.
+    /// PT: Resumo para ExecuteNonQueryAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task<int> ExecuteNonQueryAsync(System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(ExecuteNonQuery());
+
+    /// <summary>
+    /// EN: Summary for ExecuteDbDataReaderAsync.
+    /// PT: Resumo para ExecuteDbDataReaderAsync.
+    /// </summary>
+    protected override System.Threading.Tasks.Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult<DbDataReader>(ExecuteDbDataReader(behavior));
+
+    /// <summary>
+    /// EN: Summary for ExecuteScalarAsync.
+    /// PT: Resumo para ExecuteScalarAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task<object?> ExecuteScalarAsync(System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(ExecuteScalar());
+
+    /// <summary>
+    /// EN: Summary for PrepareAsync.
+    /// PT: Resumo para PrepareAsync.
+    /// </summary>
+    public override System.Threading.Tasks.Task PrepareAsync(System.Threading.CancellationToken cancellationToken = default)
+    {
+        Prepare();
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    /// <summary>
     /// EN: Summary for Prepare.
     /// PT: Resumo para Prepare.
     /// </summary>
@@ -253,7 +294,13 @@ public sealed class SqliteBatchCommandMock : DbBatchCommand, ISqliteCommandMock
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public override int RecordsAffected { get; set; }
+    private int recordsAffected;
+
+    /// <summary>
+    /// EN: Summary for member.
+    /// PT: Resumo para member.
+    /// </summary>
+    public override int RecordsAffected => recordsAffected;
 
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.Sqlite/SqliteConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteConnectorFactoryMock.cs
@@ -1,3 +1,13 @@
+using System.Data.Common;
+
+using DbProviderFactory = System.Data.Common.DbProviderFactory;
+using DbCommand = System.Data.Common.DbCommand;
+using DbConnection = System.Data.Common.DbConnection;
+using DbConnectionStringBuilder = System.Data.Common.DbConnectionStringBuilder;
+using DbParameter = System.Data.Common.DbParameter;
+using DbDataAdapter = System.Data.Common.DbDataAdapter;
+using DbBatch = System.Data.Common.DbBatch;
+using DbBatchCommand = System.Data.Common.DbBatchCommand;
 namespace DbSqlLikeMem.Sqlite;
 
 /// <summary>
@@ -89,9 +99,5 @@ public sealed class SqliteConnectorFactoryMock : DbProviderFactory
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public
-#if NET7_0_OR_GREATER
-    override
-#endif
-    SqliteDataSourceMock CreateDataSource(string connectionString) => new(db);
+    public SqliteDataSourceMock CreateDataSource(string connectionString) => new(db);
 }

--- a/src/DbSqlLikeMem.Sqlite/SqliteDataAdapterMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDataAdapterMock.cs
@@ -1,10 +1,13 @@
+using System.Data.Common;
+
+using DbDataAdapter = System.Data.Common.DbDataAdapter;
 namespace DbSqlLikeMem.Sqlite;
 
 /// <summary>
 /// EN: Summary for SqliteDataAdapterMock.
 /// PT: Resumo para SqliteDataAdapterMock.
 /// </summary>
-public sealed class SqliteDataAdapterMock : DbDataAdapter, IDbDataAdapter
+public sealed class SqliteDataAdapterMock : DbDataAdapter
 {
     /// <summary>
     /// EN: Summary for DeleteCommand.

--- a/src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs
@@ -1,3 +1,6 @@
+using System.Data.Common;
+
+using DbConnection = System.Data.Common.DbConnection;
 namespace DbSqlLikeMem.Sqlite;
 
 /// <summary>
@@ -5,31 +8,16 @@ namespace DbSqlLikeMem.Sqlite;
 /// PT: Resumo para SqliteDataSourceMock.
 /// </summary>
 public sealed class SqliteDataSourceMock(SqliteDbMock? db = null)
-#if NET8_0_OR_GREATER
-    : DbDataSource
-#endif
 {
     /// <summary>
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public
-#if NET8_0_OR_GREATER
-    override
-#endif
-    string ConnectionString => string.Empty;
+    public string ConnectionString => string.Empty;
 
-#if NET8_0_OR_GREATER
     /// <summary>
     /// EN: Summary for CreateDbConnection.
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
-    protected override DbConnection CreateDbConnection() => new SqliteConnectionMock(db);
-#else
-    /// <summary>
-    /// EN: Summary for CreateDbConnection.
-    /// PT: Resumo para CreateDbConnection.
-    /// </summary>
-    public DbConnection CreateDbConnection() => new SqliteConnectionMock(db);
-#endif
+    public SqliteConnectionMock CreateDbConnection() => new SqliteConnectionMock(db);
 }


### PR DESCRIPTION
### Motivation
- Fix numerous compile errors where core ADO.NET types like `Db*` and `DbBatch` were not resolved (CS0246) and where mock classes exposed signatures incompatible with the evolving ADO.NET APIs. 
- Remove fragile conditional inheritance/overrides and tight coupling to `DbDataSource` that caused cross-target-framework build issues. 
- Adapt provider mocks to the newer `DbBatch`/`DbBatchCommand` API surface (async members and getter-only `RecordsAffected`) and avoid `IDbDataAdapter`-interface return-type conflicts. 

### Description
- Added explicit `System.Data.Common` usages to provider projects and source files by inserting `<Using Include="System.Data.Common" />` and `using System.Data.Common;`, and added local `using` aliases (for example `using DbProviderFactory = System.Data.Common.DbProviderFactory;`) in provider mock files so core ADO.NET symbols bind reliably per-file. 
- Implemented the newer `DbBatch` contract on all provider `*BatchMock` classes by adding async overrides (`ExecuteNonQueryAsync`, `ExecuteDbDataReaderAsync`, `ExecuteScalarAsync`, `PrepareAsync`) and updating batch-command types so they compile against the new API. 
- Converted `DbBatchCommand.RecordsAffected` implementations to a private backing field with a getter-only `public override int RecordsAffected => recordsAffected;`. 
- Decoupled `*DataSourceMock` types from inheriting `DbDataSource` and removed conditional `override` usage by providing concrete `CreateDbConnection()`/`CreateDataSource()` methods that return provider-specific connection/data-source mock types. 
- Removed explicit `IDbDataAdapter` implementation from provider `*DataAdapterMock` classes so they inherit only from `DbDataAdapter` and keep strongly-typed `new` command properties to avoid interface return-type conflicts. 

### Testing
- Ran `rg -n "IDbDataAdapter|: DbDataSource" src/DbSqlLikeMem.{Npgsql,Sqlite,SqlServer} -g '*.cs'` to confirm the old problematic patterns are no longer present and the search returned no matches. 
- Inspected modified files with `nl`/`sed` to verify `using System.Data.Common;` and the new type aliases and async overrides were added as intended. 
- Attempted a repository build with `dotnet build -v minimal`, but the `dotnet` CLI is not available in this environment so a full compile could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f4594a98832c8954dab1116f52fe)