### PR TITLE
Conditionally import DbBatch and qualify NHibernate types to fix build errors

### DIFF
--- a/src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs
+++ b/src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs
@@ -283,7 +283,7 @@ public abstract class NHibernateSupportTestsBase
             _ = session
                 .CreateSQLQuery("INSERT INTO typed_values (id, str_val, int_val, dt_val, dec_val) VALUES (:id, :str, :int, :dt, :dec)")
                 .SetParameter("id", 1)
-                .SetParameter("str", (string?)null, NHibernate.NHibernateUtil.String)
+                .SetParameter("str", (string?)null, global::NHibernate.NHibernateUtil.String)
                 .SetParameter("int", 42)
                 .SetParameter("dt", expectedDate)
                 .SetParameter("dec", expectedDecimal)
@@ -297,7 +297,7 @@ public abstract class NHibernateSupportTestsBase
         var nullMatchCount = Convert.ToInt32(
             verifySession
                 .CreateSQLQuery("SELECT COUNT(*) FROM typed_values WHERE (:str IS NULL AND str_val IS NULL)")
-                .SetParameter("str", (string?)null, NHibernate.NHibernateUtil.String)
+                .SetParameter("str", (string?)null, global::NHibernate.NHibernateUtil.String)
                 .UniqueResult());
 
         Assert.Equal(1, nullMatchCount);
@@ -305,9 +305,9 @@ public abstract class NHibernateSupportTestsBase
         var typeMatchCount = Convert.ToInt32(
             verifySession
                 .CreateSQLQuery("SELECT COUNT(*) FROM typed_values WHERE int_val = :int AND dt_val = :dt AND dec_val = :dec")
-                .SetParameter("int", 42, NHibernate.NHibernateUtil.Int32)
-                .SetParameter("dt", expectedDate, NHibernate.NHibernateUtil.DateTime)
-                .SetParameter("dec", expectedDecimal, NHibernate.NHibernateUtil.Decimal)
+                .SetParameter("int", 42, global::NHibernate.NHibernateUtil.Int32)
+                .SetParameter("dt", expectedDate, global::NHibernate.NHibernateUtil.DateTime)
+                .SetParameter("dec", expectedDecimal, global::NHibernate.NHibernateUtil.Decimal)
                 .UniqueResult());
 
         Assert.Equal(1, typeMatchCount);
@@ -484,7 +484,7 @@ public abstract class NHibernateSupportTestsBase
         tx1.Commit();
 
         user2!.Name = "Tx2";
-        _ = Assert.ThrowsAny<NHibernate.StaleStateException>(() =>
+        _ = Assert.ThrowsAny<global::NHibernate.StaleStateException>(() =>
         {
             session2.Flush();
             tx2.Commit();

--- a/src/DbSqlLikeMem.SqlServer/SqlServerConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerConnectorFactoryMock.cs
@@ -6,8 +6,10 @@ using DbConnection = System.Data.Common.DbConnection;
 using DbConnectionStringBuilder = System.Data.Common.DbConnectionStringBuilder;
 using DbParameter = System.Data.Common.DbParameter;
 using DbDataAdapter = System.Data.Common.DbDataAdapter;
+#if NET6_0_OR_GREATER
 using DbBatch = System.Data.Common.DbBatch;
 using DbBatchCommand = System.Data.Common.DbBatchCommand;
+#endif
 using Microsoft.Data.SqlClient;
 namespace DbSqlLikeMem.SqlServer;
 

--- a/src/DbSqlLikeMem.Sqlite/SqliteConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteConnectorFactoryMock.cs
@@ -6,8 +6,10 @@ using DbConnection = System.Data.Common.DbConnection;
 using DbConnectionStringBuilder = System.Data.Common.DbConnectionStringBuilder;
 using DbParameter = System.Data.Common.DbParameter;
 using DbDataAdapter = System.Data.Common.DbDataAdapter;
+#if NET6_0_OR_GREATER
 using DbBatch = System.Data.Common.DbBatch;
 using DbBatchCommand = System.Data.Common.DbBatchCommand;
+#endif
 using Microsoft.Data.Sqlite;
 namespace DbSqlLikeMem.Sqlite;
 


### PR DESCRIPTION
### Motivation
- Resolve CS0234 build errors caused by `DbBatch`/`DbBatchCommand` not being available on older target frameworks and by NHibernate types being shadowed by the test namespace.
- Make connector factories and NHibernate tests compile across the project's multi-target frameworks without changing runtime behavior.

### Description
- Wrapped the `DbBatch` and `DbBatchCommand` `using` aliases in `SqliteConnectorFactoryMock.cs` and `SqlServerConnectorFactoryMock.cs` with `#if NET6_0_OR_GREATER` so those aliases are only defined when the APIs exist.
- Replaced occurrences of `NHibernate.NHibernateUtil` with `global::NHibernate.NHibernateUtil` and `NHibernate.StaleStateException` with `global::NHibernate.StaleStateException` in `NHibernateSupportTestsBase.cs` to avoid namespace shadowing and ensure the references resolve to the external NHibernate types.
- Changes were applied across the affected files under `src/` and validated by code searches to ensure all relevant occurrences were updated.

### Testing
- Searched the codebase for occurrences of the affected symbols using `rg` and inspected the modified files with `nl`/`sed`, confirming the replacements succeeded.
- Attempted `dotnet build` for the SQLite project via `dotnet build src/DbSqlLikeMem.Sqlite/DbSqlLikeMem.Sqlite.csproj`, but the environment lacks the `dotnet` CLI, so the build could not be executed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998fc0c6278832c83132af64d47e3ee)