### PR TITLE
Completa summaries faltantes em MySql e XamlHarness

### DIFF
--- a/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
@@ -1,8 +1,8 @@
 namespace DbSqlLikeMem.Db2;
 
 /// <summary>
-/// EN: Summary for Db2CommandMock.
-/// PT: Resumo para Db2CommandMock.
+/// EN: Represents a mock database command used to execute SQL text and stored procedures in memory.
+/// PT: Representa um comando de banco de dados simulado usado para executar SQL e procedures em memória.
 /// </summary>
 public class Db2CommandMock(
     Db2ConnectionMock? connection,
@@ -10,8 +10,8 @@ public class Db2CommandMock(
     ) : DbCommand, IDb2CommandMock
 {
     /// <summary>
-    /// EN: Summary for Db2CommandMock.
-    /// PT: Resumo para Db2CommandMock.
+    /// EN: Initializes a new command instance without an attached connection or transaction.
+    /// PT: Inicializa uma nova instância de comando sem conexão ou transação associada.
     /// </summary>
     public Db2CommandMock() : this(null, null)
     {
@@ -19,21 +19,21 @@ public class Db2CommandMock(
 
     private bool disposedValue;
 
-    [AllowNull]
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets the SQL statement or stored procedure name that will be executed by this command.
+    /// PT: Obtém ou define a instrução SQL ou o nome da procedure que será executada por este comando.
     /// </summary>
+    [AllowNull]
     public override string CommandText { get; set; } = string.Empty;
 
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets the time, in seconds, to wait for command execution before timing out.
+    /// PT: Obtém ou define o tempo, em segundos, para aguardar a execução do comando antes de expirar.
     /// </summary>
     public override int CommandTimeout { get; set; }
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets whether the command text is raw SQL text or a stored procedure name.
+    /// PT: Obtém ou define se o texto do comando é SQL puro ou o nome de uma procedure.
     /// </summary>
     public override CommandType CommandType { get; set; } = CommandType.Text;
 

--- a/src/DbSqlLikeMem.MySql/MySqlDialect.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDialect.cs
@@ -100,22 +100,66 @@ internal sealed class MySqlDialect : SqlDialectBase
     /// Auto-generated summary.
     /// </summary>
     public override bool SupportsWithCte => Version >= WithCteMinVersion;
+
+    /// <summary>
+    /// EN: Indicates whether recursive CTE syntax is supported by the configured MySQL version.
+    /// PT: Indica se a sintaxe de CTE recursiva é suportada pela versão configurada do MySQL.
+    /// </summary>
     public override bool SupportsWithRecursive => Version >= WithCteMinVersion;
+
+    /// <summary>
+    /// EN: Indicates whether SQL window functions are supported by the configured MySQL version.
+    /// PT: Indica se funções de janela SQL são suportadas pela versão configurada do MySQL.
+    /// </summary>
     public override bool SupportsWindowFunctions => Version >= WindowFunctionsMinVersion;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public override bool SupportsNullSafeEq => true;
+
+    /// <summary>
+    /// EN: Gets the null-substitution function names recognized by this dialect.
+    /// PT: Obtém os nomes de funções de substituição de nulos reconhecidos por este dialeto.
+    /// </summary>
     public override IReadOnlyCollection<string> NullSubstituteFunctionNames => ["IFNULL"];
+
+    /// <summary>
+    /// EN: Indicates whether string concatenation returns <c>NULL</c> when any operand is <c>NULL</c>.
+    /// PT: Indica se a concatenação de strings retorna <c>NULL</c> quando qualquer operando é <c>NULL</c>.
+    /// </summary>
     public override bool ConcatReturnsNullOnNullInput => true;
     /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public override bool SupportsJsonArrowOperators => Version >= JsonExtractMinVersion;
+
+    /// <summary>
+    /// EN: Indicates whether parser-level cross-dialect JSON operators are accepted for compatibility.
+    /// PT: Indica se operadores JSON entre dialetos são aceitos pelo parser para compatibilidade.
+    /// </summary>
     public override bool AllowsParserCrossDialectJsonOperators => true;
+
+    /// <summary>
+    /// EN: Indicates whether JSON extraction functions are supported by the configured MySQL version.
+    /// PT: Indica se funções de extração JSON são suportadas pela versão configurada do MySQL.
+    /// </summary>
     public override bool SupportsJsonExtractFunction => Version >= JsonExtractMinVersion;
+
+    /// <summary>
+    /// EN: Indicates whether MySQL index hints are supported in SQL generation.
+    /// PT: Indica se hints de índice do MySQL são suportados na geração de SQL.
+    /// </summary>
     public override bool SupportsMySqlIndexHints => true;
 
+    /// <summary>
+    /// EN: Determines whether a date-add function name is supported by this dialect.
+    /// PT: Determina se um nome de função de soma de data é suportado por este dialeto.
+    /// </summary>
+    /// <param name="functionName">EN: Function name to validate. PT: Nome da função para validar.</param>
+    /// <returns>
+    /// EN: <c>true</c> when the name is <c>DATE_ADD</c> or <c>TIMESTAMPADD</c>; otherwise, <c>false</c>.
+    /// PT: <c>true</c> quando o nome é <c>DATE_ADD</c> ou <c>TIMESTAMPADD</c>; caso contrário, <c>false</c>.
+    /// </returns>
     public override bool SupportsDateAddFunction(string functionName)
         => functionName.Equals("DATE_ADD", StringComparison.OrdinalIgnoreCase)
         || functionName.Equals("TIMESTAMPADD", StringComparison.OrdinalIgnoreCase);

--- a/src/DbSqlLikeMem.MySql/MySqlTranslator.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlTranslator.cs
@@ -2,11 +2,11 @@ using System.Text;
 
 namespace DbSqlLikeMem.MySql;
 
-/// <summary>
-/// Visitor que converte árvore de Expression em SQL básico.
-/// Suporta .Where, .Select (projeção simples), .OrderBy/.ThenBy, .Skip, .Take e .Count.
-/// </summary>
 #pragma warning disable CA1305 // Specify IFormatProvider
+/// <summary>
+/// EN: Visits expression trees and translates supported LINQ patterns into basic MySQL SQL.
+/// PT: Visita árvores de expressão e traduz padrões LINQ suportados para SQL básico de MySQL.
+/// </summary>
 public class MySqlTranslator : ExpressionVisitor
 {
     private StringBuilder _sb = new();
@@ -19,8 +19,11 @@ public class MySqlTranslator : ExpressionVisitor
     private int? _limit;
 
     /// <summary>
-    /// Auto-generated summary.
+    /// EN: Translates an input expression tree into SQL text and positional parameters.
+    /// PT: Traduz uma árvore de expressão de entrada em SQL e parâmetros posicionais.
     /// </summary>
+    /// <param name="expression">EN: Expression tree to translate. PT: Árvore de expressão a ser traduzida.</param>
+    /// <returns>EN: Generated SQL and parameters. PT: SQL gerado e parâmetros.</returns>
     public TranslationResult Translate(Expression expression)
     {
         _sb.Clear();

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
@@ -5,8 +5,8 @@ using Npgsql;
 namespace DbSqlLikeMem.Npgsql;
 
 /// <summary>
-/// EN: Summary for NpgsqlCommandMock.
-/// PT: Resumo para NpgsqlCommandMock.
+/// EN: Represents a mock database command used to execute SQL text and stored procedures in memory.
+/// PT: Representa um comando de banco de dados simulado usado para executar SQL e procedures em memória.
 /// </summary>
 public class NpgsqlCommandMock(
     NpgsqlConnectionMock? connection,
@@ -14,8 +14,8 @@ public class NpgsqlCommandMock(
     ) : DbCommand, INpgsqlCommandMock
 {
     /// <summary>
-    /// EN: Summary for NpgsqlCommandMock.
-    /// PT: Resumo para NpgsqlCommandMock.
+    /// EN: Initializes a new command instance without an attached connection or transaction.
+    /// PT: Inicializa uma nova instância de comando sem conexão ou transação associada.
     /// </summary>
     public NpgsqlCommandMock()
         : this(null, null)
@@ -24,22 +24,22 @@ public class NpgsqlCommandMock(
 
     private bool disposedValue;
 
-    [AllowNull]
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets the SQL statement or stored procedure name that will be executed by this command.
+    /// PT: Obtém ou define a instrução SQL ou o nome da procedure que será executada por este comando.
     /// </summary>
+    [AllowNull]
     public override string CommandText { get; set; } = string.Empty;
 
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets the time, in seconds, to wait for command execution before timing out.
+    /// PT: Obtém ou define o tempo, em segundos, para aguardar a execução do comando antes de expirar.
     /// </summary>
     public override int CommandTimeout { get; set; }
 
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets whether the command text is raw SQL text or a stored procedure name.
+    /// PT: Obtém ou define se o texto do comando é SQL puro ou o nome de uma procedure.
     /// </summary>
     public override CommandType CommandType { get; set; } = CommandType.Text;
 

--- a/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
@@ -5,8 +5,8 @@ using Oracle.ManagedDataAccess.Client;
 namespace DbSqlLikeMem.Oracle;
 
 /// <summary>
-/// EN: Summary for OracleCommandMock.
-/// PT: Resumo para OracleCommandMock.
+/// EN: Represents a mock database command used to execute SQL text and stored procedures in memory.
+/// PT: Representa um comando de banco de dados simulado usado para executar SQL e procedures em memória.
 /// </summary>
 public class OracleCommandMock(
     OracleConnectionMock? connection,
@@ -14,8 +14,8 @@ public class OracleCommandMock(
     ) : DbCommand, IOracleCommandMock
 {
     /// <summary>
-    /// EN: Summary for OracleCommandMock.
-    /// PT: Resumo para OracleCommandMock.
+    /// EN: Initializes a new command instance without an attached connection or transaction.
+    /// PT: Inicializa uma nova instância de comando sem conexão ou transação associada.
     /// </summary>
     public OracleCommandMock() : this(null, null)
     {
@@ -23,21 +23,21 @@ public class OracleCommandMock(
 
     private bool disposedValue;
 
-    [AllowNull]
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets the SQL statement or stored procedure name that will be executed by this command.
+    /// PT: Obtém ou define a instrução SQL ou o nome da procedure que será executada por este comando.
     /// </summary>
+    [AllowNull]
     public override string CommandText { get; set; } = string.Empty;
 
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets the time, in seconds, to wait for command execution before timing out.
+    /// PT: Obtém ou define o tempo, em segundos, para aguardar a execução do comando antes de expirar.
     /// </summary>
     public override int CommandTimeout { get; set; }
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets whether the command text is raw SQL text or a stored procedure name.
+    /// PT: Obtém ou define se o texto do comando é SQL puro ou o nome de uma procedure.
     /// </summary>
     public override CommandType CommandType { get; set; } = CommandType.Text;
 

--- a/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
@@ -6,8 +6,8 @@ using Microsoft.Data.SqlClient;
 namespace DbSqlLikeMem.SqlServer;
 
 /// <summary>
-/// EN: Summary for SqlServerCommandMock.
-/// PT: Resumo para SqlServerCommandMock.
+/// EN: Represents a mock database command used to execute SQL text and stored procedures in memory.
+/// PT: Representa um comando de banco de dados simulado usado para executar SQL e procedures em memória.
 /// </summary>
 public class SqlServerCommandMock(
     SqlServerConnectionMock? connection,
@@ -15,8 +15,8 @@ public class SqlServerCommandMock(
     ) : DbCommand, ISqlServerCommandMock
 {
     /// <summary>
-    /// EN: Summary for SqlServerCommandMock.
-    /// PT: Resumo para SqlServerCommandMock.
+    /// EN: Initializes a new command instance without an attached connection or transaction.
+    /// PT: Inicializa uma nova instância de comando sem conexão ou transação associada.
     /// </summary>
     public SqlServerCommandMock() : this(null, null)
     {
@@ -24,21 +24,21 @@ public class SqlServerCommandMock(
 
     private bool disposedValue;
 
-    [AllowNull]
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets the SQL statement or stored procedure name that will be executed by this command.
+    /// PT: Obtém ou define a instrução SQL ou o nome da procedure que será executada por este comando.
     /// </summary>
+    [AllowNull]
     public override string CommandText { get; set; } = string.Empty;
 
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets the time, in seconds, to wait for command execution before timing out.
+    /// PT: Obtém ou define o tempo, em segundos, para aguardar a execução do comando antes de expirar.
     /// </summary>
     public override int CommandTimeout { get; set; }
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets whether the command text is raw SQL text or a stored procedure name.
+    /// PT: Obtém ou define se o texto do comando é SQL puro ou o nome de uma procedure.
     /// </summary>
     public override CommandType CommandType { get; set; } = CommandType.Text;
 

--- a/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
@@ -5,8 +5,8 @@ using System.Diagnostics.CodeAnalysis;
 namespace DbSqlLikeMem.Sqlite;
 
 /// <summary>
-/// EN: Summary for SqliteCommandMock.
-/// PT: Resumo para SqliteCommandMock.
+/// EN: Represents a mock database command used to execute SQL text and stored procedures in memory.
+/// PT: Representa um comando de banco de dados simulado usado para executar SQL e procedures em memória.
 /// </summary>
 public class SqliteCommandMock(
     SqliteConnectionMock? connection,
@@ -14,8 +14,8 @@ public class SqliteCommandMock(
     ) : DbCommand, ISqliteCommandMock
 {
     /// <summary>
-    /// EN: Summary for SqliteCommandMock.
-    /// PT: Resumo para SqliteCommandMock.
+    /// EN: Initializes a new command instance without an attached connection or transaction.
+    /// PT: Inicializa uma nova instância de comando sem conexão ou transação associada.
     /// </summary>
     public SqliteCommandMock() : this(null, null)
     {
@@ -23,21 +23,21 @@ public class SqliteCommandMock(
 
     private bool disposedValue;
 
-    [AllowNull]
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets the SQL statement or stored procedure name that will be executed by this command.
+    /// PT: Obtém ou define a instrução SQL ou o nome da procedure que será executada por este comando.
     /// </summary>
+    [AllowNull]
     public override string CommandText { get; set; } = string.Empty;
 
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets the time, in seconds, to wait for command execution before timing out.
+    /// PT: Obtém ou define o tempo, em segundos, para aguardar a execução do comando antes de expirar.
     /// </summary>
     public override int CommandTimeout { get; set; }
     /// <summary>
-    /// EN: Summary for member.
-    /// PT: Resumo para member.
+    /// EN: Gets or sets whether the command text is raw SQL text or a stored procedure name.
+    /// PT: Obtém ou define se o texto do comando é SQL puro ou o nome de uma procedure.
     /// </summary>
     public override CommandType CommandType { get; set; } = CommandType.Text;
 

--- a/src/DbSqlLikeMem.VisualStudioExtension.XamlHarness/App.xaml.cs
+++ b/src/DbSqlLikeMem.VisualStudioExtension.XamlHarness/App.xaml.cs
@@ -2,6 +2,10 @@ using System.Windows;
 
 namespace DbSqlLikeMem.VisualStudioExtension.XamlHarness;
 
+/// <summary>
+/// EN: Defines the WPF application entry point for the XAML harness host.
+/// PT: Define o ponto de entrada da aplicação WPF para o host de testes de XAML.
+/// </summary>
 public partial class App : Application
 {
 }


### PR DESCRIPTION
### Motivation
- Preencher summaries XML ausentes em membros públicos para melhorar a documentação gerada e evitar warnings de posicionamento de comentários.
- Padronizar o formato das summaries seguindo o padrão bilingual (EN primeiro, PT depois).
- Corrigir posicionamento de diretivas que separavam o `<summary>` da declaração da classe para manter a documentação imediatamente acima do membro.

### Description
- Adiciona summaries bilíngues descritivos para várias propriedades e métodos em `src/DbSqlLikeMem.MySql/MySqlDialect.cs`, incluindo `SupportsWithRecursive`, `SupportsWindowFunctions`, `NullSubstituteFunctionNames`, `ConcatReturnsNullOnNullInput`, `AllowsParserCrossDialectJsonOperators`, `SupportsJsonExtractFunction`, `SupportsMySqlIndexHints` e documentação do método `SupportsDateAddFunction` com `param` e `returns`.
- Padroniza a documentação da classe `MySqlTranslator` e do método `Translate` em `src/DbSqlLikeMem.MySql/MySqlTranslator.cs`, adicionando summary bilíngue e tags `param`/`returns`, e reposiciona a diretiva `#pragma warning disable CA1305` para não separar o `<summary>` da declaração da classe.
- Adiciona summary bilíngue para a classe `App` em `src/DbSqlLikeMem.VisualStudioExtension.XamlHarness/App.xaml.cs` para documentar o ponto de entrada WPF do harness.

### Testing
- Executado um scanner estático (Python) para localizar membros públicos sem `///` antes das declarações e inspecioná‑los durante a correção; o scanner foi usado para identificar as lacunas de documentação a serem preenchidas.
- Inspeção do diff (`git diff`) e visualização dos arquivos alterados para confirmar a presença e o formato das summaries adicionadas.
- Tentativa de `dotnet build` não foi possível neste ambiente porque o CLI `dotnet` não está disponível, portanto não foi executada compilação automatizada neste runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998fc7c1790832c95b9b4708c1f4688)