### PR TITLE
Fix provider mock warnings and data source surface compatibility

### DIFF
--- a/src/DbSqlLikeMem.Db2/Db2BatchMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2BatchMock.cs
@@ -284,7 +284,7 @@ public sealed class Db2BatchCommandMock : DbBatchCommand, IDb2CommandMock
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    private int recordsAffected;
+    private int recordsAffected = 0;
 
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlBatchMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlBatchMock.cs
@@ -294,7 +294,7 @@ public sealed class NpgsqlBatchCommandMock : DbBatchCommand, INpgsqlCommandMock
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    private int recordsAffected;
+    private int recordsAffected = 0;
 
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlConnectorFactoryMock.cs
@@ -100,5 +100,9 @@ public sealed class NpgsqlConnectorFactoryMock : DbProviderFactory
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
+#if NET7_0_OR_GREATER
+    public override NpgsqlDataSourceMock CreateDataSource(string connectionString) => new(db);
+#else
     public NpgsqlDataSourceMock CreateDataSource(string connectionString) => new(db);
+#endif
 }

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs
@@ -20,4 +20,11 @@ public sealed class NpgsqlDataSourceMock(NpgsqlDbMock? db = null)
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
     public NpgsqlConnectionMock CreateDbConnection() => new NpgsqlConnectionMock(db);
+
+    /// <summary>
+    /// EN: Summary for CreateConnection.
+    /// PT: Resumo para CreateConnection.
+    /// </summary>
+    public NpgsqlConnectionMock CreateConnection() => CreateDbConnection();
+
 }

--- a/src/DbSqlLikeMem.Oracle.Test/OracleConnectorFactoryMockTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleConnectorFactoryMockTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.Oracle.Test;
 /// </summary>
 public sealed class OracleConnectorFactoryMockTests
 {
-    [Fact]
     /// <summary>
     /// EN: Summary for CreateCoreMembers_ShouldReturnProviderMocks.
     /// PT: Resumo para CreateCoreMembers_ShouldReturnProviderMocks.
     /// </summary>
+    [Fact]
     public void CreateCoreMembers_ShouldReturnProviderMocks()
     {
         var factory = OracleConnectorFactoryMock.GetInstance(new OracleDbMock());
@@ -23,11 +23,11 @@ public sealed class OracleConnectorFactoryMockTests
     }
 
 #if NET6_0_OR_GREATER
-    [Fact]
     /// <summary>
     /// EN: Summary for CreateBatchMembers_ShouldReturnProviderMocks.
     /// PT: Resumo para CreateBatchMembers_ShouldReturnProviderMocks.
     /// </summary>
+    [Fact]
     public void CreateBatchMembers_ShouldReturnProviderMocks()
     {
         var factory = OracleConnectorFactoryMock.GetInstance(new OracleDbMock());
@@ -39,11 +39,11 @@ public sealed class OracleConnectorFactoryMockTests
 #endif
 
 #if NET7_0_OR_GREATER
-    [Fact]
     /// <summary>
     /// EN: Summary for CreateDataSource_ShouldReturnProviderDataSourceMock.
     /// PT: Resumo para CreateDataSource_ShouldReturnProviderDataSourceMock.
     /// </summary>
+    [Fact]
     public void CreateDataSource_ShouldReturnProviderDataSourceMock()
     {
         var factory = OracleConnectorFactoryMock.GetInstance(new OracleDbMock());

--- a/src/DbSqlLikeMem.Oracle.Test/OracleProviderSurfaceMocksTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleProviderSurfaceMocksTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.Oracle.Test;
 /// </summary>
 public sealed class OracleProviderSurfaceMocksTests
 {
-    [Fact]
     /// <summary>
     /// EN: Summary for DataAdapter_ShouldKeepTypedSelectCommand.
     /// PT: Resumo para DataAdapter_ShouldKeepTypedSelectCommand.
     /// </summary>
+    [Fact]
     public void DataAdapter_ShouldKeepTypedSelectCommand()
     {
         using var connection = new OracleConnectionMock(new OracleDbMock());
@@ -20,11 +20,11 @@ public sealed class OracleProviderSurfaceMocksTests
         Assert.Equal("SELECT 1 FROM DUAL", adapter.SelectCommand!.CommandText);
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for DataSource_ShouldCreateOracleConnection.
     /// PT: Resumo para DataSource_ShouldCreateOracleConnection.
     /// </summary>
+    [Fact]
     public void DataSource_ShouldCreateOracleConnection()
     {
         var source = new OracleDataSourceMock(new OracleDbMock());
@@ -37,11 +37,11 @@ public sealed class OracleProviderSurfaceMocksTests
     }
 
 #if NET6_0_OR_GREATER
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ShouldExecuteAllCommands.
     /// PT: Resumo para Batch_ShouldExecuteAllCommands.
     /// </summary>
+    [Fact]
     public void Batch_ShouldExecuteAllCommands()
     {
         var db = new OracleDbMock();
@@ -63,11 +63,11 @@ public sealed class OracleProviderSurfaceMocksTests
         Assert.Equal(2, connection.GetTable("Users").Count);
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ExecuteScalar_ShouldUseFirstCommandResult.
     /// PT: Resumo para Batch_ExecuteScalar_ShouldUseFirstCommandResult.
     /// </summary>
+    [Fact]
     public void Batch_ExecuteScalar_ShouldUseFirstCommandResult()
     {
         var db = new OracleDbMock();
@@ -94,11 +94,11 @@ public sealed class OracleProviderSurfaceMocksTests
         Assert.Equal("Ana", result);
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ExecuteReader_ShouldReturnResultsFromMultipleCommands.
     /// PT: Resumo para Batch_ExecuteReader_ShouldReturnResultsFromMultipleCommands.
     /// </summary>
+    [Fact]
     public void Batch_ExecuteReader_ShouldReturnResultsFromMultipleCommands()
     {
         var db = new OracleDbMock();
@@ -129,11 +129,11 @@ public sealed class OracleProviderSurfaceMocksTests
         Assert.Equal(1, reader.GetInt32(0));
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ExecuteReader_ShouldAllowNonQueryBeforeSelect.
     /// PT: Resumo para Batch_ExecuteReader_ShouldAllowNonQueryBeforeSelect.
     /// </summary>
+    [Fact]
     public void Batch_ExecuteReader_ShouldAllowNonQueryBeforeSelect()
     {
         var db = new OracleDbMock();

--- a/src/DbSqlLikeMem.Oracle/OracleBatchMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleBatchMock.cs
@@ -286,7 +286,7 @@ public sealed class OracleBatchCommandMock : DbBatchCommand, IOracleCommandMock
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    private int recordsAffected;
+    private int recordsAffected = 0;
 
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.Oracle/OracleConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleConnectorFactoryMock.cs
@@ -92,5 +92,9 @@ public sealed class OracleConnectorFactoryMock : DbProviderFactory
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
+#if NET7_0_OR_GREATER
+    public override OracleDataSourceMock CreateDataSource(string connectionString) => new(db);
+#else
     public OracleDataSourceMock CreateDataSource(string connectionString) => new(db);
+#endif
 }

--- a/src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs
@@ -19,4 +19,11 @@ public sealed class OracleDataSourceMock(OracleDbMock? db = null)
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
     public OracleConnectionMock CreateDbConnection() => new OracleConnectionMock(db);
+
+    /// <summary>
+    /// EN: Summary for CreateConnection.
+    /// PT: Resumo para CreateConnection.
+    /// </summary>
+    public OracleConnectionMock CreateConnection() => CreateDbConnection();
+
 }

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerConnectorFactoryMockTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerConnectorFactoryMockTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.SqlServer.Test;
 /// </summary>
 public sealed class SqlServerConnectorFactoryMockTests
 {
-    [Fact]
     /// <summary>
     /// EN: Summary for CreateCoreMembers_ShouldReturnProviderMocks.
     /// PT: Resumo para CreateCoreMembers_ShouldReturnProviderMocks.
     /// </summary>
+    [Fact]
     public void CreateCoreMembers_ShouldReturnProviderMocks()
     {
         var factory = SqlServerConnectorFactoryMock.GetInstance(new SqlServerDbMock());
@@ -23,11 +23,11 @@ public sealed class SqlServerConnectorFactoryMockTests
     }
 
 #if NET6_0_OR_GREATER
-    [Fact]
     /// <summary>
     /// EN: Summary for CreateBatchMembers_ShouldReturnProviderMocks.
     /// PT: Resumo para CreateBatchMembers_ShouldReturnProviderMocks.
     /// </summary>
+    [Fact]
     public void CreateBatchMembers_ShouldReturnProviderMocks()
     {
         var factory = SqlServerConnectorFactoryMock.GetInstance(new SqlServerDbMock());
@@ -39,11 +39,11 @@ public sealed class SqlServerConnectorFactoryMockTests
 #endif
 
 #if NET7_0_OR_GREATER
-    [Fact]
     /// <summary>
     /// EN: Summary for CreateDataSource_ShouldReturnProviderDataSourceMock.
     /// PT: Resumo para CreateDataSource_ShouldReturnProviderDataSourceMock.
     /// </summary>
+    [Fact]
     public void CreateDataSource_ShouldReturnProviderDataSourceMock()
     {
         var factory = SqlServerConnectorFactoryMock.GetInstance(new SqlServerDbMock());

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerProviderSurfaceMocksTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerProviderSurfaceMocksTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.SqlServer.Test;
 /// </summary>
 public sealed class SqlServerProviderSurfaceMocksTests
 {
-    [Fact]
     /// <summary>
     /// EN: Summary for DataAdapter_ShouldKeepTypedSelectCommand.
     /// PT: Resumo para DataAdapter_ShouldKeepTypedSelectCommand.
     /// </summary>
+    [Fact]
     public void DataAdapter_ShouldKeepTypedSelectCommand()
     {
         using var connection = new SqlServerConnectionMock(new SqlServerDbMock());
@@ -20,11 +20,11 @@ public sealed class SqlServerProviderSurfaceMocksTests
         Assert.Equal("SELECT 1", adapter.SelectCommand!.CommandText);
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for DataSource_ShouldCreateSqlServerConnection.
     /// PT: Resumo para DataSource_ShouldCreateSqlServerConnection.
     /// </summary>
+    [Fact]
     public void DataSource_ShouldCreateSqlServerConnection()
     {
         var source = new SqlServerDataSourceMock(new SqlServerDbMock());
@@ -37,11 +37,11 @@ public sealed class SqlServerProviderSurfaceMocksTests
     }
 
 #if NET6_0_OR_GREATER
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ShouldExecuteAllCommands.
     /// PT: Resumo para Batch_ShouldExecuteAllCommands.
     /// </summary>
+    [Fact]
     public void Batch_ShouldExecuteAllCommands()
     {
         var db = new SqlServerDbMock();
@@ -63,11 +63,11 @@ public sealed class SqlServerProviderSurfaceMocksTests
         Assert.Equal(2, connection.GetTable("Users").Count);
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ExecuteScalar_ShouldUseFirstCommandResult.
     /// PT: Resumo para Batch_ExecuteScalar_ShouldUseFirstCommandResult.
     /// </summary>
+    [Fact]
     public void Batch_ExecuteScalar_ShouldUseFirstCommandResult()
     {
         var db = new SqlServerDbMock();
@@ -94,11 +94,11 @@ public sealed class SqlServerProviderSurfaceMocksTests
         Assert.Equal("Ana", result);
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ExecuteReader_ShouldReturnResultsFromMultipleCommands.
     /// PT: Resumo para Batch_ExecuteReader_ShouldReturnResultsFromMultipleCommands.
     /// </summary>
+    [Fact]
     public void Batch_ExecuteReader_ShouldReturnResultsFromMultipleCommands()
     {
         var db = new SqlServerDbMock();
@@ -129,11 +129,11 @@ public sealed class SqlServerProviderSurfaceMocksTests
         Assert.Equal(1, reader.GetInt32(0));
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ExecuteReader_ShouldAllowNonQueryBeforeSelect.
     /// PT: Resumo para Batch_ExecuteReader_ShouldAllowNonQueryBeforeSelect.
     /// </summary>
+    [Fact]
     public void Batch_ExecuteReader_ShouldAllowNonQueryBeforeSelect()
     {
         var db = new SqlServerDbMock();

--- a/src/DbSqlLikeMem.SqlServer/SqlServerBatchMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerBatchMock.cs
@@ -296,7 +296,7 @@ public sealed class SqlServerBatchCommandMock : DbBatchCommand, ISqlServerComman
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    private int recordsAffected;
+    private int recordsAffected = 0;
 
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.SqlServer/SqlServerConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerConnectorFactoryMock.cs
@@ -102,5 +102,9 @@ public sealed class SqlServerConnectorFactoryMock : DbProviderFactory
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
+#if NET7_0_OR_GREATER
+    public override SqlServerDataSourceMock CreateDataSource(string connectionString) => new(db);
+#else
     public SqlServerDataSourceMock CreateDataSource(string connectionString) => new(db);
+#endif
 }

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs
@@ -20,4 +20,11 @@ public sealed class SqlServerDataSourceMock(SqlServerDbMock? db = null)
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
     public SqlServerConnectionMock CreateDbConnection() => new SqlServerConnectionMock(db);
+
+    /// <summary>
+    /// EN: Summary for CreateConnection.
+    /// PT: Resumo para CreateConnection.
+    /// </summary>
+    public SqlServerConnectionMock CreateConnection() => CreateDbConnection();
+
 }

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteConnectorFactoryMockTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteConnectorFactoryMockTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.Sqlite.Test;
 /// </summary>
 public sealed class SqliteConnectorFactoryMockTests
 {
-    [Fact]
     /// <summary>
     /// EN: Summary for CreateCoreMembers_ShouldReturnProviderMocks.
     /// PT: Resumo para CreateCoreMembers_ShouldReturnProviderMocks.
     /// </summary>
+    [Fact]
     public void CreateCoreMembers_ShouldReturnProviderMocks()
     {
         var factory = SqliteConnectorFactoryMock.GetInstance(new SqliteDbMock());
@@ -23,11 +23,11 @@ public sealed class SqliteConnectorFactoryMockTests
     }
 
 #if NET6_0_OR_GREATER
-    [Fact]
     /// <summary>
     /// EN: Summary for CreateBatchMembers_ShouldReturnProviderMocks.
     /// PT: Resumo para CreateBatchMembers_ShouldReturnProviderMocks.
     /// </summary>
+    [Fact]
     public void CreateBatchMembers_ShouldReturnProviderMocks()
     {
         var factory = SqliteConnectorFactoryMock.GetInstance(new SqliteDbMock());
@@ -39,11 +39,11 @@ public sealed class SqliteConnectorFactoryMockTests
 #endif
 
 #if NET7_0_OR_GREATER
-    [Fact]
     /// <summary>
     /// EN: Summary for CreateDataSource_ShouldReturnProviderDataSourceMock.
     /// PT: Resumo para CreateDataSource_ShouldReturnProviderDataSourceMock.
     /// </summary>
+    [Fact]
     public void CreateDataSource_ShouldReturnProviderDataSourceMock()
     {
         var factory = SqliteConnectorFactoryMock.GetInstance(new SqliteDbMock());

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteProviderSurfaceMocksTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteProviderSurfaceMocksTests.cs
@@ -6,11 +6,11 @@ namespace DbSqlLikeMem.Sqlite.Test;
 /// </summary>
 public sealed class SqliteProviderSurfaceMocksTests
 {
-    [Fact]
     /// <summary>
     /// EN: Summary for DataAdapter_ShouldKeepTypedSelectCommand.
     /// PT: Resumo para DataAdapter_ShouldKeepTypedSelectCommand.
     /// </summary>
+    [Fact]
     public void DataAdapter_ShouldKeepTypedSelectCommand()
     {
         using var connection = new SqliteConnectionMock(new SqliteDbMock());
@@ -20,11 +20,11 @@ public sealed class SqliteProviderSurfaceMocksTests
         Assert.Equal("SELECT 1", adapter.SelectCommand!.CommandText);
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for DataSource_ShouldCreateSqliteConnection.
     /// PT: Resumo para DataSource_ShouldCreateSqliteConnection.
     /// </summary>
+    [Fact]
     public void DataSource_ShouldCreateSqliteConnection()
     {
         var source = new SqliteDataSourceMock(new SqliteDbMock());
@@ -37,11 +37,11 @@ public sealed class SqliteProviderSurfaceMocksTests
     }
 
 #if NET6_0_OR_GREATER
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ShouldExecuteAllCommands.
     /// PT: Resumo para Batch_ShouldExecuteAllCommands.
     /// </summary>
+    [Fact]
     public void Batch_ShouldExecuteAllCommands()
     {
         var db = new SqliteDbMock();
@@ -63,11 +63,11 @@ public sealed class SqliteProviderSurfaceMocksTests
         Assert.Equal(2, connection.GetTable("users").Count);
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ExecuteScalar_ShouldUseFirstCommandResult.
     /// PT: Resumo para Batch_ExecuteScalar_ShouldUseFirstCommandResult.
     /// </summary>
+    [Fact]
     public void Batch_ExecuteScalar_ShouldUseFirstCommandResult()
     {
         var db = new SqliteDbMock();
@@ -94,11 +94,11 @@ public sealed class SqliteProviderSurfaceMocksTests
         Assert.Equal("Ana", result);
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ExecuteReader_ShouldReturnResultsFromMultipleCommands.
     /// PT: Resumo para Batch_ExecuteReader_ShouldReturnResultsFromMultipleCommands.
     /// </summary>
+    [Fact]
     public void Batch_ExecuteReader_ShouldReturnResultsFromMultipleCommands()
     {
         var db = new SqliteDbMock();
@@ -129,11 +129,11 @@ public sealed class SqliteProviderSurfaceMocksTests
         Assert.Equal(1, reader.GetInt32(0));
     }
 
-    [Fact]
     /// <summary>
     /// EN: Summary for Batch_ExecuteReader_ShouldAllowNonQueryBeforeSelect.
     /// PT: Resumo para Batch_ExecuteReader_ShouldAllowNonQueryBeforeSelect.
     /// </summary>
+    [Fact]
     public void Batch_ExecuteReader_ShouldAllowNonQueryBeforeSelect()
     {
         var db = new SqliteDbMock();

--- a/src/DbSqlLikeMem.Sqlite/SqliteBatchMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteBatchMock.cs
@@ -296,7 +296,7 @@ public sealed class SqliteBatchCommandMock : DbBatchCommand, ISqliteCommandMock
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    private int recordsAffected;
+    private int recordsAffected = 0;
 
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.Sqlite/SqliteConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteConnectorFactoryMock.cs
@@ -102,5 +102,9 @@ public sealed class SqliteConnectorFactoryMock : DbProviderFactory
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
+#if NET7_0_OR_GREATER
+    public override SqliteDataSourceMock CreateDataSource(string connectionString) => new(db);
+#else
     public SqliteDataSourceMock CreateDataSource(string connectionString) => new(db);
+#endif
 }

--- a/src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs
@@ -20,4 +20,11 @@ public sealed class SqliteDataSourceMock(SqliteDbMock? db = null)
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
     public SqliteConnectionMock CreateDbConnection() => new SqliteConnectionMock(db);
+
+    /// <summary>
+    /// EN: Summary for CreateConnection.
+    /// PT: Resumo para CreateConnection.
+    /// </summary>
+    public SqliteConnectionMock CreateConnection() => CreateDbConnection();
+
 }


### PR DESCRIPTION
### Motivation
- Remove compile-time warnings about member hiding (`CS0114`) and unassigned fields (`CS0649`) and satisfy newer provider surface tests that expect a `CreateConnection()` method on data source mocks.
- Make tests that assert `CreateDataSource`/`CreateConnection` behavior pass consistently across target frameworks.

### Description
- Conditionally mark `CreateDataSource(string)` as `override` when building for `NET7_0_OR_GREATER` in the Oracle, Npgsql, Sqlite and SqlServer connector factory mocks to avoid member-hiding warnings while keeping compatibility with older targets (`src/.../ConnectorFactoryMock.cs`).
- Add `CreateConnection()` wrappers on provider `DataSourceMock` classes that delegate to existing `CreateDbConnection()` to expose the newer surface expected by tests (`src/.../DataSourceMock.cs`).
- Initialize `recordsAffected` fields to `0` in batch command mocks for Db2, Oracle, Npgsql, SqlServer and Sqlite to remove unassigned-field warnings (`src/.../BatchMock.cs`).
- Reposition or add minimal XML doc comments before `[Fact]` attributes in affected test files so XML comments are on valid language elements and reduce `CS1587`/`CS1591` noise in tests (`src/*/*.Test/*.cs`).

### Testing
- Attempted to run `dotnet build DbSqlLikeMem.sln`, but the `dotnet` SDK is not available in the execution environment, so a full build could not be performed (`bash: command not found: dotnet`).
- Verified repository changes with `git status` and committed the fixes with `git commit -m "Fix provider mock warnings and data source surface tests"` successfully.
- Confirmed edits by inspecting the updated files and diff; no automated build/test run was possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ffbdaa60832cbb01b54fda25be95)