### PR TITLE
Fix DbDataSource mocks for NET7+ and older TFMs

### DIFF
--- a/src/DbSqlLikeMem.Db2/Db2ConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2ConnectorFactoryMock.cs
@@ -92,6 +92,9 @@ public sealed class Db2ConnectorFactoryMock : DbProviderFactory
     public
 #if NET7_0_OR_GREATER
     override
+    DbDataSource
+#else
+    Db2DataSourceMock
 #endif
-    DbDataSource CreateDataSource(string connectionString) => new Db2DataSourceMock(db);
+    CreateDataSource(string connectionString) => new Db2DataSourceMock(db);
 }

--- a/src/DbSqlLikeMem.Db2/Db2DataSourceMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2DataSourceMock.cs
@@ -5,7 +5,7 @@ namespace DbSqlLikeMem.Db2;
 /// PT: Resumo para Db2DataSourceMock.
 /// </summary>
 public sealed class Db2DataSourceMock(Db2DbMock? db = null)
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
     : DbDataSource
 #endif
 {
@@ -14,12 +14,12 @@ public sealed class Db2DataSourceMock(Db2DbMock? db = null)
     /// PT: Resumo para member.
     /// </summary>
     public
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
     override
 #endif
     string ConnectionString => string.Empty;
 
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
     /// <summary>
     /// EN: Summary for CreateDbConnection.
     /// PT: Resumo para CreateDbConnection.

--- a/src/DbSqlLikeMem.MySql/MySqlConnectorFactoryMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlConnectorFactoryMock.cs
@@ -123,8 +123,11 @@ public sealed class MySqlConnectorFactoryMock : DbProviderFactory
     public
 #if NET7_0_OR_GREATER
     override
+    DbDataSource
+#else
+    MySqlDataSourceMock
 #endif
-    DbDataSource CreateDataSource(string connectionString) => new MySqlDataSourceMock(Db);
+    CreateDataSource(string connectionString) => new MySqlDataSourceMock(Db);
 #pragma warning restore CA1822 // Mark members as static
 
     internal MySqlConnectorFactoryMock(

--- a/src/DbSqlLikeMem.MySql/MySqlDataSourceMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDataSourceMock.cs
@@ -7,7 +7,7 @@ namespace DbSqlLikeMem.MySql;
 /// <param name="db">Optional in-memory database backing instance.
 /// Instância opcional de banco em memória usada como base.</param>
 public sealed class MySqlDataSourceMock(MySqlDbMock? db = null)
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
     : DbDataSource
 #endif
 {
@@ -16,12 +16,12 @@ public sealed class MySqlDataSourceMock(MySqlDbMock? db = null)
     /// Obtém a string de conexão exposta por esta fonte de dados mock.
     /// </summary>
     public
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
     override
 #endif
         string ConnectionString => string.Empty;
 
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
     /// <summary>
     /// Creates a database connection bound to the configured mock database.
     /// Cria uma conexão de banco vinculada ao banco de dados mock configurado.

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs
@@ -8,23 +8,38 @@ namespace DbSqlLikeMem.Npgsql;
 /// PT: Resumo para NpgsqlDataSourceMock.
 /// </summary>
 public sealed class NpgsqlDataSourceMock(NpgsqlDbMock? db = null)
+#if NET7_0_OR_GREATER
+    : DbDataSource
+#endif
 {
     /// <summary>
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public string ConnectionString => string.Empty;
+    public
+#if NET7_0_OR_GREATER
+    override
+#endif
+    string ConnectionString => string.Empty;
 
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// EN: Summary for CreateDbConnection.
+    /// PT: Resumo para CreateDbConnection.
+    /// </summary>
+    protected override DbConnection CreateDbConnection() => new NpgsqlConnectionMock(db);
+#else
     /// <summary>
     /// EN: Summary for CreateDbConnection.
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
     public NpgsqlConnectionMock CreateDbConnection() => new NpgsqlConnectionMock(db);
+#endif
 
     /// <summary>
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public NpgsqlConnectionMock CreateConnection() => CreateDbConnection();
+    public NpgsqlConnectionMock CreateConnection() => new NpgsqlConnectionMock(db);
 
 }

--- a/src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs
@@ -7,23 +7,38 @@ namespace DbSqlLikeMem.Oracle;
 /// PT: Resumo para OracleDataSourceMock.
 /// </summary>
 public sealed class OracleDataSourceMock(OracleDbMock? db = null)
+#if NET7_0_OR_GREATER
+    : DbDataSource
+#endif
 {
     /// <summary>
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public string ConnectionString => string.Empty;
+    public
+#if NET7_0_OR_GREATER
+    override
+#endif
+    string ConnectionString => string.Empty;
 
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// EN: Summary for CreateDbConnection.
+    /// PT: Resumo para CreateDbConnection.
+    /// </summary>
+    protected override DbConnection CreateDbConnection() => new OracleConnectionMock(db);
+#else
     /// <summary>
     /// EN: Summary for CreateDbConnection.
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
     public OracleConnectionMock CreateDbConnection() => new OracleConnectionMock(db);
+#endif
 
     /// <summary>
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public OracleConnectionMock CreateConnection() => CreateDbConnection();
+    public OracleConnectionMock CreateConnection() => new OracleConnectionMock(db);
 
 }

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs
@@ -8,23 +8,38 @@ namespace DbSqlLikeMem.SqlServer;
 /// PT: Resumo para SqlServerDataSourceMock.
 /// </summary>
 public sealed class SqlServerDataSourceMock(SqlServerDbMock? db = null)
+#if NET7_0_OR_GREATER
+    : DbDataSource
+#endif
 {
     /// <summary>
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public string ConnectionString => string.Empty;
+    public
+#if NET7_0_OR_GREATER
+    override
+#endif
+    string ConnectionString => string.Empty;
 
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// EN: Summary for CreateDbConnection.
+    /// PT: Resumo para CreateDbConnection.
+    /// </summary>
+    protected override DbConnection CreateDbConnection() => new SqlServerConnectionMock(db);
+#else
     /// <summary>
     /// EN: Summary for CreateDbConnection.
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
     public SqlServerConnectionMock CreateDbConnection() => new SqlServerConnectionMock(db);
+#endif
 
     /// <summary>
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public SqlServerConnectionMock CreateConnection() => CreateDbConnection();
+    public SqlServerConnectionMock CreateConnection() => new SqlServerConnectionMock(db);
 
 }

--- a/src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs
@@ -8,23 +8,38 @@ namespace DbSqlLikeMem.Sqlite;
 /// PT: Resumo para SqliteDataSourceMock.
 /// </summary>
 public sealed class SqliteDataSourceMock(SqliteDbMock? db = null)
+#if NET7_0_OR_GREATER
+    : DbDataSource
+#endif
 {
     /// <summary>
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>
-    public string ConnectionString => string.Empty;
+    public
+#if NET7_0_OR_GREATER
+    override
+#endif
+    string ConnectionString => string.Empty;
 
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// EN: Summary for CreateDbConnection.
+    /// PT: Resumo para CreateDbConnection.
+    /// </summary>
+    protected override DbConnection CreateDbConnection() => new SqliteConnectionMock(db);
+#else
     /// <summary>
     /// EN: Summary for CreateDbConnection.
     /// PT: Resumo para CreateDbConnection.
     /// </summary>
     public SqliteConnectionMock CreateDbConnection() => new SqliteConnectionMock(db);
+#endif
 
     /// <summary>
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public SqliteConnectionMock CreateConnection() => CreateDbConnection();
+    public SqliteConnectionMock CreateConnection() => new SqliteConnectionMock(db);
 
 }


### PR DESCRIPTION
### Motivation
- Builds failed with `CS0246` and `CS0029` because `DbDataSource` is not available on older target frameworks and provider data-source mocks did not consistently inherit it on NET7+.
- Introduce conditional compilation so code uses `DbDataSource` only when the target framework exposes it and preserve provider-specific APIs for older TFMs.

### Description
- Adjusted `CreateDataSource` signatures in connector factories so they return `DbDataSource` only under `#if NET7_0_OR_GREATER` and return the provider-specific mock type on older targets (changes in `MySqlConnectorFactoryMock` and `Db2ConnectorFactoryMock`).
- Updated all provider `*DataSourceMock` implementations to conditionally inherit from `DbDataSource` under `#if NET7_0_OR_GREATER` and to mark `ConnectionString` and `CreateDbConnection` as `override` / `protected override` in that case.
- Kept non-NET7 targets using the original provider-specific `CreateDbConnection` signatures and return types to maintain backward compatibility.
- Reworked `CreateConnection` implementations to explicitly construct provider connection mocks where necessary to avoid relying on differing `CreateDbConnection` signatures across TFMs.

### Testing
- Attempted to run `dotnet build DbSqlLikeMem.sln -v minimal`, but the environment does not include the .NET SDK (`bash: command not found: dotnet`), so a full compile could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699902c3f9c4832ca832f4cb085059c2)