### PR TITLE
Fix CS0108 CreateConnection hiding warnings in datasource mocks

### DIFF
--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs
@@ -40,6 +40,6 @@ public sealed class NpgsqlDataSourceMock(NpgsqlDbMock? db = null)
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public NpgsqlConnectionMock CreateConnection() => new NpgsqlConnectionMock(db);
+    public new NpgsqlConnectionMock CreateConnection() => new NpgsqlConnectionMock(db);
 
 }

--- a/src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs
@@ -39,6 +39,6 @@ public sealed class OracleDataSourceMock(OracleDbMock? db = null)
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public OracleConnectionMock CreateConnection() => new OracleConnectionMock(db);
+    public new OracleConnectionMock CreateConnection() => new OracleConnectionMock(db);
 
 }

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs
@@ -40,6 +40,6 @@ public sealed class SqlServerDataSourceMock(SqlServerDbMock? db = null)
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public SqlServerConnectionMock CreateConnection() => new SqlServerConnectionMock(db);
+    public new SqlServerConnectionMock CreateConnection() => new SqlServerConnectionMock(db);
 
 }

--- a/src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs
@@ -40,6 +40,6 @@ public sealed class SqliteDataSourceMock(SqliteDbMock? db = null)
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public SqliteConnectionMock CreateConnection() => new SqliteConnectionMock(db);
+    public new SqliteConnectionMock CreateConnection() => new SqliteConnectionMock(db);
 
 }


### PR DESCRIPTION
### Motivation
- Provider-specific datasource mock classes were triggering CS0108 warnings because `CreateConnection()` hides `DbDataSource.CreateConnection()` without an explicit modifier, so the change makes the hiding intentional and explicit.

### Description
- Added the `new` modifier to `CreateConnection()` in the Npgsql datasource mock at `src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs`.
- Added the `new` modifier to `CreateConnection()` in the Oracle datasource mock at `src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs`.
- Added the `new` modifier to `CreateConnection()` in the SqlServer datasource mock at `src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs`.
- Added the `new` modifier to `CreateConnection()` in the Sqlite datasource mock at `src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs`.

### Testing
- Searched the codebase for `CreateConnection()` occurrences with `rg` and verified the four provider-specific files were updated to include `new`.
- Inspected the modified files with `nl` to confirm the `public new ... CreateConnection()` lines are present in each file.
- Attempted to run `dotnet build` to validate compilation, but the .NET SDK is not available in this environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999056725e4832cb08a049c69660142)