### PR TITLE
Remove unnecessary `new` from provider `CreateConnection` methods

### DIFF
--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs
@@ -40,6 +40,6 @@ public sealed class NpgsqlDataSourceMock(NpgsqlDbMock? db = null)
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public new NpgsqlConnectionMock CreateConnection() => new NpgsqlConnectionMock(db);
+    public NpgsqlConnectionMock CreateConnection() => new NpgsqlConnectionMock(db);
 
 }

--- a/src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs
@@ -39,6 +39,6 @@ public sealed class OracleDataSourceMock(OracleDbMock? db = null)
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public new OracleConnectionMock CreateConnection() => new OracleConnectionMock(db);
+    public OracleConnectionMock CreateConnection() => new OracleConnectionMock(db);
 
 }

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs
@@ -40,6 +40,6 @@ public sealed class SqlServerDataSourceMock(SqlServerDbMock? db = null)
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public new SqlServerConnectionMock CreateConnection() => new SqlServerConnectionMock(db);
+    public SqlServerConnectionMock CreateConnection() => new SqlServerConnectionMock(db);
 
 }

--- a/src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs
@@ -40,6 +40,6 @@ public sealed class SqliteDataSourceMock(SqliteDbMock? db = null)
     /// EN: Summary for CreateConnection.
     /// PT: Resumo para CreateConnection.
     /// </summary>
-    public new SqliteConnectionMock CreateConnection() => new SqliteConnectionMock(db);
+    public SqliteConnectionMock CreateConnection() => new SqliteConnectionMock(db);
 
 }


### PR DESCRIPTION
### Motivation
- The `CreateConnection()` methods in several provider data source mocks used the `new` modifier while not hiding any accessible base members, causing CS0109 warnings.
- The change aims to remove those unnecessary modifiers to clean up warnings without altering runtime behavior.

### Description
- Removed the `new` keyword from `CreateConnection()` in `src/DbSqlLikeMem.Npgsql/NpgsqlDataSourceMock.cs`.
- Removed the `new` keyword from `CreateConnection()` in `src/DbSqlLikeMem.Oracle/OracleDataSourceMock.cs`.
- Removed the `new` keyword from `CreateConnection()` in `src/DbSqlLikeMem.SqlServer/SqlServerDataSourceMock.cs`.
- Removed the `new` keyword from `CreateConnection()` in `src/DbSqlLikeMem.Sqlite/SqliteDataSourceMock.cs`.

### Testing
- Ran `rg "public new .*CreateConnection\(" src -n` to confirm there are no remaining occurrences, which succeeded.
- Attempted `dotnet build DbSqlLikeMem.sln -v minimal` to build the solution, which failed in this environment because the `dotnet` CLI is not installed.
- Ran `git status --short` to verify staged changes and then committed the modifications, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699906b9c140832c8afdecf3acd45e58)