### PR TITLE
Fix NHibernate mapped entity naming, rollback idempotency, and inferred-column metadata

### DIFF
--- a/src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs
+++ b/src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs
@@ -550,6 +550,7 @@ public abstract class NHibernateSupportTestsBase
     {
         public NhTestUserMap()
         {
+            EntityName(nameof(NhTestUser));
             Table("users");
 
             Id(x => x.Id, map =>
@@ -588,6 +589,7 @@ public abstract class NHibernateSupportTestsBase
     {
         public NhUserGroupMap()
         {
+            EntityName(nameof(NhUserGroup));
             Table("user_groups");
 
             Id(x => x.Id, map =>
@@ -617,6 +619,7 @@ public abstract class NHibernateSupportTestsBase
     {
         public NhRelUserMap()
         {
+            EntityName(nameof(NhRelUser));
             Table("users_rel");
 
             Id(x => x.Id, map =>
@@ -643,6 +646,7 @@ public abstract class NHibernateSupportTestsBase
     {
         public NhVersionedUserMap()
         {
+            EntityName(nameof(NhVersionedUser));
             Table("users_versioned");
 
             Id(x => x.Id, map =>

--- a/src/DbSqlLikeMem/Base/DbConnectionMockBase.cs
+++ b/src/DbSqlLikeMem/Base/DbConnectionMockBase.cs
@@ -530,6 +530,9 @@ public abstract class DbConnectionMockBase(
 
     private void RollbackCore()
     {
+        if (CurrentTransaction == null)
+            return;
+
         Debug.WriteLine("Transaction Rolled Back");
         RollbackToSavepointCore("__tx_begin__");
         ClearTransactionStateCore();

--- a/src/DbSqlLikeMem/Strategies/DbSelectIntoAndInsertSelectStrategies.cs
+++ b/src/DbSqlLikeMem/Strategies/DbSelectIntoAndInsertSelectStrategies.cs
@@ -96,7 +96,7 @@ internal static class DbSelectIntoAndInsertSelectStrategies
             {
                 var colName = res.Columns[i].ColumnName;
                 var dbType = InferDbType(res, i);
-                newTable.AddColumn(colName, dbType, nullable: true);
+                AddInferredColumn(newTable, colName, dbType);
             }
 
             foreach (var row in res)
@@ -284,7 +284,7 @@ internal static class DbSelectIntoAndInsertSelectStrategies
         {
             var colName = names[i];
             var dbType = (i < res.Columns.Count) ? InferDbType(res, i) : DbType.String;
-            newTable.AddColumn(colName, dbType, nullable: true);
+            AddInferredColumn(newTable, colName, dbType);
         }
 
         foreach (var row in res)
@@ -422,5 +422,22 @@ internal static class DbSelectIntoAndInsertSelectStrategies
             };
         }
         return DbType.Object;
+    }
+
+    private static void AddInferredColumn(ITableMock table, string columnName, DbType dbType)
+    {
+        if (dbType == DbType.String)
+        {
+            table.AddColumn(columnName, dbType, nullable: true, size: 255);
+            return;
+        }
+
+        if (dbType == DbType.Decimal || dbType == DbType.Double || dbType == DbType.Currency)
+        {
+            table.AddColumn(columnName, dbType, nullable: true, decimalPlaces: 2);
+            return;
+        }
+
+        table.AddColumn(columnName, dbType, nullable: true);
     }
 }


### PR DESCRIPTION
### Motivation
- NHibernate HQL was failing with "<Entity> is not mapped" when tests reference nested/private test classes by name, indicating mappings lacked explicit entity names.
- Some rollback paths raised "No active transaction for savepoint operation" during optimistic-concurrency tests, showing rollback logic must tolerate missing active transactions.
- `CREATE TABLE ... AS SELECT` and temp-table creation inferred columns without required metadata (string size, decimal precision), causing failures when strict column validation is enforced.

### Description
- Set explicit NHibernate `EntityName` on test mappings for `NhTestUser`, `NhUserGroup`, `NhRelUser`, and `NhVersionedUser` so HQL class references resolve (file: `src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs`).
- Make rollback idempotent by returning early from `RollbackCore()` when there is no active transaction to avoid savepoint/rollback errors (file: `src/DbSqlLikeMem/Base/DbConnectionMockBase.cs`).
- Centralize inferred-column creation in `AddInferredColumn` and use it when creating tables from SELECT results or temporary-table selects, supplying `size: 255` for strings and `decimalPlaces: 2` for decimal/double/currency types to satisfy `ColumnDef` requirements (file: `src/DbSqlLikeMem/Strategies/DbSelectIntoAndInsertSelectStrategies.cs`).

### Testing
- Attempted to run targeted NHibernate tests via `dotnet test ... --filter "NHibernate_MappedQuery_Pagination_ShouldReturnWindow|NHibernate_Hql_AndCriteria_ShouldFilterMappedEntity|NHibernate_Hql_RelationshipAggregation_ShouldReturnExpectedCounts|NHibernate_MappedRelationship_ManyToOne_ShouldPersistAndQuery|NHibernate_NativeSql_NullAndTypedParameters_ShouldRoundTrip|NHibernate_MappedEntity_OptimisticConcurrency_ShouldDetectStaleUpdate"`, but the environment lacks `dotnet` and the command failed with `bash: command not found: dotnet`.
- Verified changes with local code inspection and grep/sed checks to confirm the intended edits were applied to the three modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990a22192c832cb9bb922b798d87db)