### PR TITLE
Refatorar avaliação de funções para reduzir hotspots e adicionar testes de funções (SQL Server)

### DIFF
--- a/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerFunctionHotspotCoverageTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerFunctionHotspotCoverageTests.cs
@@ -1,0 +1,62 @@
+namespace DbSqlLikeMem.SqlServer.Dapper.Test;
+
+public sealed class SqlServerFunctionHotspotCoverageTests : XUnitTestBase
+{
+    private readonly SqlServerConnectionMock _cnn;
+
+    public SqlServerFunctionHotspotCoverageTests(ITestOutputHelper helper) : base(helper)
+    {
+        var db = new SqlServerDbMock();
+        var t = db.AddTable("fn_data");
+        t.AddColumn("id", DbType.Int32, false);
+        t.AddColumn("name", DbType.String, false);
+        t.AddColumn("email", DbType.String, true);
+        t.AddColumn("payload", DbType.String, true);
+        t.AddColumn("created", DbType.DateTime, false);
+
+        t.Add(new Dictionary<int, object?>
+        {
+            [0] = 1,
+            [1] = "John",
+            [2] = null,
+            [3] = "{\"a\":{\"b\":42}}",
+            [4] = new DateTime(2020, 1, 1)
+        });
+
+        _cnn = new SqlServerConnectionMock(db);
+        _cnn.Open();
+    }
+
+    [Fact]
+    [Trait("Category", "SqlServerFunctionCoverage")]
+    public void Cast_And_TryCast_ShouldFollowExpectedFallbacks()
+    {
+        var row = _cnn.QuerySingle<dynamic>("SELECT CAST('abc' AS INT) AS cast_value, TRY_CAST('abc' AS INT) AS try_cast_value");
+
+        Assert.Equal(0, (int)row.cast_value);
+        Assert.Null((object?)row.try_cast_value);
+    }
+
+    [Fact]
+    [Trait("Category", "SqlServerFunctionCoverage")]
+    public void OpenJson_ConcatWs_And_DateAdd_ShouldBeEvaluated()
+    {
+        var row = _cnn.QuerySingle<dynamic>(@"
+SELECT
+    OPENJSON(payload) AS json_text,
+    CONCAT_WS('-', name, email, 'end') AS joined,
+    DATEADD(DAY, 2, created) AS plus_two_days
+FROM fn_data
+WHERE id = 1");
+
+        Assert.Equal("{\"a\":{\"b\":42}}", (string)row.json_text);
+        Assert.Equal("John-end", (string)row.joined);
+        Assert.Equal(new DateTime(2020, 1, 3), (DateTime)row.plus_two_days);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        _cnn?.Dispose();
+        base.Dispose(disposing);
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduzir a concentração de complexidade no método de avaliação de funções (`EvalFunction`) para mitigar hotspots apontados pelo relatório de cobertura/analise de hotspots.
- Aumentar cobertura de caminhos de função importantes (CAST/TRY_CAST, JSON, CONCAT_WS, DATEADD) adicionando testes automatizados para cenários comuns.

### Description
- Extraído o código de `TRY_CAST` para o helper `EvalTryCast(FunctionCallExpr, Func<int, object?>)`. (arquivo: `src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs`).
- Extraído o código de `CAST` para o helper `EvalCast(FunctionCallExpr, Func<int, object?>)` e o fluxo principal agora delega a esses helpers quando apropriado.
- Centralizada a lógica das funções de adição de data (`DATE_ADD`, `TIMESTAMPADD`, `DATEADD`) em `TryEvalDateAddFunction(...)` para reduzir branching no hotspot principal.
- Adicionado novo conjunto de testes `SqlServerFunctionHotspotCoverageTests` (arquivo: `src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerFunctionHotspotCoverageTests.cs`) que cobre: `CAST` vs `TRY_CAST`, `OPENJSON`, `CONCAT_WS` (com comportamento de NULL) e `DATEADD`.

### Testing
- Tentativa de executar os novos testes com `dotnet test src/DbSqlLikeMem.SqlServer.Dapper.Test/DbSqlLikeMem.SqlServer.Dapper.Test.csproj --filter SqlServerFunctionHotspotCoverageTests` falhou no ambiente de execução porque o comando `dotnet` não está disponível (erro: `command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699920af8548832cb90560615dfcf8db)