### PR TITLE
Fix pagination regressions and aggregate empty-set handling

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
@@ -142,6 +142,22 @@ public sealed class Db2DialectFeatureParserTests
 
 
 
+
+    /// <summary>
+    /// EN: Ensures OFFSET/FETCH pagination is accepted by DB2 parser.
+    /// PT: Garante que paginação OFFSET/FETCH seja aceita pelo parser DB2.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseSelect_WithOffsetFetch_ShouldParse(int version)
+    {
+        var sql = "SELECT id FROM users ORDER BY id OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY";
+
+        var parsed = SqlQueryParser.Parse(sql, new Db2Dialect(version));
+        Assert.IsType<SqlSelectQuery>(parsed);
+    }
+
     /// <summary>
     /// EN: Ensures PIVOT clause is rejected when the dialect capability flag is disabled.
     /// PT: Garante que a cláusula PIVOT seja rejeitada quando a flag de capacidade do dialeto está desabilitada.

--- a/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
@@ -218,7 +218,7 @@ public class Db2CommandMock(
         var executor = AstQueryExecutorFactory.Create(connection.Db.Dialect, connection, Parameters);
 
         // Parse Multiplo (ex: "SELECT 1; SELECT 2;" ou "CREATE TEMPORARY TABLE ...; SELECT ...")
-        var queries = SqlQueryParser.ParseMulti(sql, connection.Db.Dialect).ToList();
+        var queries = SqlQueryParser.ParseMulti(sql, connection.Db.Dialect, Parameters).ToList();
 
         var tables = new List<TableResultMock>();
 

--- a/src/DbSqlLikeMem.Db2/Db2Dialect.cs
+++ b/src/DbSqlLikeMem.Db2/Db2Dialect.cs
@@ -55,6 +55,12 @@ internal sealed class Db2Dialect : SqlDialectBase
     /// PT: Resumo para member.
     /// </summary>
     public override bool SupportsFetchFirst => true;
+
+    /// <summary>
+    /// EN: Summary for member.
+    /// PT: Resumo para member.
+    /// </summary>
+    public override bool SupportsOffsetFetch => true;
     
     /// <summary>
     /// EN: Summary for member.

--- a/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
@@ -182,6 +182,22 @@ public sealed class MySqlDialectFeatureParserTests
     }
 
     /// <summary>
+    /// EN: Ensures OFFSET/FETCH compatibility syntax is accepted for MySQL parser.
+    /// PT: Garante que a sintaxe de compatibilidade OFFSET/FETCH seja aceita pelo parser MySQL.
+    /// </summary>
+    /// <param name="version">EN: MySQL dialect version under test. PT: Versão do dialeto MySQL em teste.</param>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseSelect_WithOffsetFetch_ShouldParse(int version)
+    {
+        var sql = "SELECT id FROM users ORDER BY id OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY";
+
+        var parsed = SqlQueryParser.Parse(sql, new MySqlDialect(version));
+        Assert.IsType<SqlSelectQuery>(parsed);
+    }
+
+    /// <summary>
     /// EN: Ensures PIVOT clause is rejected when the dialect capability flag is disabled.
     /// PT: Garante que a cláusula PIVOT seja rejeitada quando a flag de capacidade do dialeto está desabilitada.
     /// </summary>

--- a/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
@@ -387,7 +387,7 @@ public class MySqlCommandMock(
         var tables = new List<TableResultMock>();
         var hasAnyQuery = false;
 
-        foreach (var q in SqlQueryParser.ParseMulti(sql, connection.Db.Dialect))
+        foreach (var q in SqlQueryParser.ParseMulti(sql, connection.Db.Dialect, Parameters))
         {
             hasAnyQuery = true;
 

--- a/src/DbSqlLikeMem.MySql/MySqlDialect.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDialect.cs
@@ -87,6 +87,11 @@ internal sealed class MySqlDialect : SqlDialectBase
     /// </summary>
     public override bool SupportsLimitOffset => true;
     /// <summary>
+    /// EN: Enables SQL Server-style OFFSET/FETCH syntax as parser compatibility mode.
+    /// PT: Habilita sintaxe OFFSET/FETCH estilo SQL Server como modo de compatibilidade do parser.
+    /// </summary>
+    public override bool SupportsOffsetFetch => true;
+    /// <summary>
     /// Auto-generated summary.
     /// </summary>
     public override bool SupportsOnDuplicateKeyUpdate => true;

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
@@ -161,7 +161,7 @@ public class NpgsqlCommandMock(
 
         var executor = new NpgsqlAstQueryExecutor(connection!, Parameters);
 
-        var queries = SqlQueryParser.ParseMulti(sql, connection!.Db.Dialect).ToList();
+        var queries = SqlQueryParser.ParseMulti(sql, connection!.Db.Dialect, Parameters).ToList();
         var tables = new List<TableResultMock>();
 
         foreach (var query in queries)

--- a/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
@@ -158,7 +158,7 @@ public class OracleCommandMock(
 
         var executor = new OracleAstQueryExecutor(connection!, Parameters);
 
-        var queries = SqlQueryParser.ParseMulti(sql, connection!.Db.Dialect).ToList();
+        var queries = SqlQueryParser.ParseMulti(sql, connection!.Db.Dialect, Parameters).ToList();
         var tables = new List<TableResultMock>();
 
         foreach (var query in queries)

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
@@ -27,6 +27,31 @@ public sealed class SqlServerDialectFeatureParserTests
         Assert.Throws<InvalidOperationException>(() => SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
     }
 
+
+
+    /// <summary>
+    /// EN: Ensures OFFSET/FETCH accepts command parameters in parser execution mode.
+    /// PT: Garante que OFFSET/FETCH aceite parâmetros de comando no modo de execução do parser.
+    /// </summary>
+    /// <param name="version">EN: SQL Server dialect version under test. PT: Versão do dialeto SQL Server em teste.</param>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseSelect_WithOffsetFetchParameters_ShouldParse(int version)
+    {
+        if (version < SqlServerDialect.OffsetFetchMinVersion)
+            return;
+
+        var sql = "SELECT id FROM users ORDER BY id OFFSET @p0 ROWS FETCH FIRST @p1 ROWS ONLY";
+        var pars = new SqlServerDataParameterCollectionMock
+        {
+            new Microsoft.Data.SqlClient.SqlParameter("@p0", 1),
+            new Microsoft.Data.SqlClient.SqlParameter("@p1", 2)
+        };
+
+        var parsed = SqlQueryParser.Parse(sql, new SqlServerDialect(version), pars);
+        Assert.IsType<SqlSelectQuery>(parsed);
+    }
     /// <summary>
     /// EN: Ensures WITH RECURSIVE syntax is rejected.
     /// PT: Garante que a sintaxe WITH RECURSIVE seja rejeitada.

--- a/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
@@ -159,7 +159,7 @@ public class SqlServerCommandMock(
 
         var executor = new SqlServerAstQueryExecutor(connection!, Parameters);
 
-        var queries = SqlQueryParser.ParseMulti(sql, connection!.Db.Dialect).ToList();
+        var queries = SqlQueryParser.ParseMulti(sql, connection!.Db.Dialect, Parameters).ToList();
         var tables = new List<TableResultMock>();
 
         foreach (var query in queries)

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
@@ -106,6 +106,22 @@ public sealed class SqliteDialectFeatureParserTests
     }
 
 
+    /// <summary>
+    /// EN: Ensures OFFSET/FETCH compatibility syntax is accepted for SQLite parser.
+    /// PT: Garante que a sintaxe de compatibilidade OFFSET/FETCH seja aceita pelo parser SQLite.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseSelect_WithOffsetFetch_ShouldParse(int version)
+    {
+        var sql = "SELECT id FROM users ORDER BY id OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY";
+
+        var parsed = SqlQueryParser.Parse(sql, new SqliteDialect(version));
+        Assert.IsType<SqlSelectQuery>(parsed);
+    }
+
+
 
 
     /// <summary>

--- a/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
@@ -186,7 +186,7 @@ public class SqliteCommandMock(
         var executor = AstQueryExecutorFactory.Create(connection!.Db.Dialect, connection, Parameters);
 
         // Parse Multiplo (ex: "SELECT 1; SELECT 2;" ou "CREATE TEMPORARY TABLE ...; SELECT ...")
-        var queries = SqlQueryParser.ParseMulti(sql, connection.Db.Dialect).ToList();
+        var queries = SqlQueryParser.ParseMulti(sql, connection.Db.Dialect, Parameters).ToList();
 
         var tables = new List<TableResultMock>();
 

--- a/src/DbSqlLikeMem.Sqlite/SqliteDialect.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDialect.cs
@@ -71,6 +71,11 @@ internal sealed class SqliteDialect : SqlDialectBase
     /// </summary>
     public override bool SupportsLimitOffset => true;
     /// <summary>
+    /// EN: Enables OFFSET/FETCH compatibility syntax for shared smoke tests.
+    /// PT: Habilita sintaxe de compatibilidade OFFSET/FETCH para testes smoke compartilhados.
+    /// </summary>
+    public override bool SupportsOffsetFetch => true;
+    /// <summary>
     /// EN: Summary for member.
     /// PT: Resumo para member.
     /// </summary>


### PR DESCRIPTION
### Motivation
- Fix NHibernate/EF/LinqToDB pagination regressions where parameterized `OFFSET/FETCH` or `LIMIT/OFFSET` produced `FormatException` or `NotSupportedException` for several dialects.
- Accept SQL Server-style `OFFSET ... FETCH` compatibility syntax for dialects used in smoke tests to avoid parser rejections.
- Preserve aggregate semantics for aggregate-only queries so `COUNT(*)` and similar aggregates return a single row on empty inputs instead of producing an empty result.

### Description
- Added optional `IDataParameterCollection` support to `SqlQueryParser` and new overloads for `Parse`/`ParseMulti`, and implemented runtime parsing mode that bypasses the AST cache when parameters are supplied to avoid AST poisoning; `ExpectNumberInt` now resolves numeric parameters via `ResolveParameterInt` when the token is a parameter.
- Propagated command `Parameters` into parser calls from provider command mocks (`Sqlite`, `SqlServer`, `Oracle`, `MySql`, `Npgsql`, `Db2`) by calling `SqlQueryParser.ParseMulti(..., Parameters)` so parameterized pagination tokens like `@p0` are resolved during parse-time.
- Enabled parser compatibility flags for `OFFSET/FETCH` by setting `SupportsOffsetFetch` where appropriate (SQLite/MySQL/DB2) and added parser regression tests covering `OFFSET/FETCH` acceptance and parameterized `OFFSET/FETCH` parsing (`ParseSelect_WithOffsetFetch_ShouldParse`, `ParseSelect_WithOffsetFetchParameters_ShouldParse` and equivalents).
- Hardened aggregate detection and empty-input evaluation in the executor by adding `LooksLikeAggregateExpression` (regex fallback) inside `ContainsAggregate`, adding `EvalRow.Empty()`, and adjusting `ProjectGrouped` to synthesize a single empty-group row for aggregate-only queries so aggregate evaluators (e.g. `COUNT`) return correct results on empty input.

### Testing
- Ran repository static checks via `git diff --check` which reported no whitespace/errors.
- Added parser regression tests (examples: `ParseSelect_WithOffsetFetch_ShouldParse` in SQLite/MySQL/DB2 tests and `ParseSelect_WithOffsetFetchParameters_ShouldParse` in SQL Server parser tests) which are present in the test suite but were not executed in this environment.
- Attempted to run targeted `dotnet test` for smoke tests but the environment lacks the `dotnet` runtime so automated test execution could not be performed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69991db70ec4832cbe1cd20da01a56b6)