### PR TITLE
Fix NHibernate rollback count scalar mapping

### DIFF
--- a/src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs
+++ b/src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs
@@ -152,7 +152,8 @@ public abstract class NHibernateSupportTestsBase
         using var verifySession = sessionFactory.WithOptions().Connection(connection).OpenSession();
         var count = Convert.ToInt32(
             verifySession
-                .CreateSQLQuery("SELECT COUNT(*) FROM users WHERE id = :id")
+                .CreateSQLQuery("SELECT COUNT(*) AS cnt FROM users WHERE id = :id")
+                .AddScalar("cnt", global::NHibernate.NHibernateUtil.Int32)
                 .SetParameter("id", 3)
                 .UniqueResult());
 


### PR DESCRIPTION
### Motivation
- Prevent NHibernate from treating an untyped native SQL count projection as a multicolumn `AnyType`, which caused `System.NotSupportedException: object is a multicolumn type` during rollback verification across providers.

### Description
- Updated `src/DbSqlLikeMem.NHibernate.Test/NHibernateSupportTestsBase.cs` to alias `COUNT(*)` as `cnt` and register the projection with `.AddScalar("cnt", global::NHibernate.NHibernateUtil.Int32)` before calling `UniqueResult()` in `NHibernate_TransactionRollback_ShouldDiscardChanges`.

### Testing
- Attempted to run `dotnet test --filter "NHibernate_TransactionRollback_ShouldDiscardChanges"`, but `dotnet` is not installed in this environment so the automated test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999287b6164832cb55814f1e8ede2f7)