### PR TITLE
Fix NuGet metadata validation for namespace-free nuspec files

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -38,6 +38,14 @@ jobs:
           import zipfile
           import xml.etree.ElementTree as ET
 
+          def get_child(parent, local_name):
+              for child in parent:
+                  tag = child.tag.split('}', 1)[-1] if '}' in child.tag else child.tag
+                  if tag == local_name:
+                      return child
+
+              return None
+
           packages = glob.glob('./artifacts/*.nupkg')
           packages = [p for p in packages if 'DbSqlLikeMem.VisualStudioExtension.' not in os.path.basename(p)]
 
@@ -53,12 +61,11 @@ jobs:
                   with zf.open(nuspec_name) as nuspec:
                       root = ET.parse(nuspec).getroot()
 
-              ns = {'n': 'http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd'}
-              metadata = root.find('n:metadata', ns)
+              metadata = get_child(root, 'metadata')
               if metadata is None:
                   raise SystemExit(f'::error::{os.path.basename(package)} has no metadata section in nuspec.')
 
-              repository = metadata.find('n:repository', ns)
+              repository = get_child(metadata, 'repository')
               repo_url = repository.attrib.get('url') if repository is not None else None
               if not repo_url or 'github.com/christianulson/DbSqlLikeMem' not in repo_url:
                   raise SystemExit(f'::error::{os.path.basename(package)} is missing expected repository URL metadata.')


### PR DESCRIPTION
### Motivation
- The `Validate package repository metadata` step in the NuGet publish workflow failed for a package whose `.nuspec` did not expose `<metadata>` under the hard-coded 2013 nuspec XML namespace, causing CI package validation to error.
- Make the validation robust to both namespaced and namespace-free nuspec layouts while preserving the existing repository URL requirement.

### Description
- Added a small namespace-agnostic helper function `get_child(parent, local_name)` to the Python validation script in `.github/workflows/nuget-publish.yml` to match child elements by local tag name.
- Replaced the namespace-based lookups for the `metadata` and `repository` elements with calls to `get_child` so the script works whether the nuspec uses the `http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd` namespace or no namespace at all.
- Kept the existing repository URL assertion (checks for `github.com/christianulson/DbSqlLikeMem`) and preserved all other validation logic.

### Testing
- The previous automated validation run failed with the error `has no metadata section in nuspec` for `DbSqlLikeMem.EfCore.1.4.0.nupkg`, demonstrating the namespace-sensitivity problem (CI failure).
- Ran a local Python sanity check that parses both a namespaced and a namespace-free nuspec sample and confirmed `get_child` successfully locates `metadata` and `repository` and extracts the expected repository URL (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69992bd29040832c8adcaaa73357d9df)