### PR TITLE
Keep SQL keywords global, translate plan labels, and add IndexRecommendations advisor

### DIFF
--- a/docs/p7-p10-implementation-plan.md
+++ b/docs/p7-p10-implementation-plan.md
@@ -104,3 +104,12 @@ Documento gerado por `scripts/generate_p7_p10_plan.py` para orientar implementa�
 - [ ] Smoke tests dos demais providers sem regressão.
 - [ ] Documentação de compatibilidade atualizada.
 
+
+
+## Melhorias práticas para o plano de execução (Index Advisor)
+
+- [ ] Incluir seção `IndexRecommendations` no plano para queries SELECT com alto `EstimatedRowsRead`.
+- [ ] Sugerir índice composto com colunas de `WHERE/JOIN` e complementar com `ORDER BY` quando aplicável.
+- [ ] Exibir `Confidence` por recomendação para facilitar priorização técnica.
+- [ ] Cobrir cenários com e sem índice nos testes `ExecutionPlanTests` dos providers.
+

--- a/src/DbSqlLikeMem.MySql.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/ExecutionPlanTests.cs
@@ -39,8 +39,8 @@ public sealed class ExecutionPlanTests(
         ids.Should().Equal(1, 3);
         cnn.LastExecutionPlan.Should().NotBeNullOrWhiteSpace();
         cnn.LastExecutionPlan.Should().Contain("QueryType: SELECT");
-        cnn.LastExecutionPlan.Should().Contain("From: users");
-        cnn.LastExecutionPlan.Should().Contain("Filter:");
+        cnn.LastExecutionPlan.Should().Contain("FROM: users");
+        cnn.LastExecutionPlan.Should().Contain("WHERE:");
         cnn.LastExecutionPlan.Should().Contain("EstimatedCost:");
         cnn.LastExecutionPlan.Should().Contain("ActualRows: 2");
         cnn.LastExecutionPlan.Should().Contain("InputTables: 1");
@@ -50,6 +50,222 @@ public sealed class ExecutionPlanTests(
         cnn.LastExecutionPlan.Should().Contain("ElapsedMs:");
 
         Console.WriteLine("[ExecutionPlan]\n" + cnn.LastExecutionPlan);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures execution plan suggests missing index for filter/sort columns.
+    /// PT: Garante que o plano de execução sugira índice ausente para colunas de filtro/ordenação.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldSuggestMissingIndex_WhenNoMatchingIndexExists()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("IndexRecommendations:");
+        cnn.LastExecutionPlan.Should().Contain("CREATE INDEX IX_users_Active_Id ON users (Active, Id);");
+    }
+
+
+    /// <summary>
+    /// EN: Ensures execution plan does not suggest index when a matching index already exists.
+    /// PT: Garante que o plano não sugira índice quando já existe índice aderente.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotSuggestMissingIndex_WhenMatchingIndexAlreadyExists()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.DefineTable("users").Index("ix_users_active_id", ["Active", "Id"]);
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("IndexRecommendations:");
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures execution plan does not suggest index when PK prefix already covers query columns.
+    /// PT: Garante que o plano não sugira índice quando o prefixo da PK já cobre as colunas da consulta.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotSuggestMissingIndex_WhenPrimaryKeyAlreadyCoversPrefix()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Active");
+        cnn.Column<int>("users", "Id");
+        cnn.DefineTable("users").AddPrimaryKeyIndexes("Active", "Id");
+        cnn.Seed("users", null,
+            [1, 1],
+            [0, 2],
+            [1, 3]);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("IndexRecommendations:");
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures index recommendations include estimated before/after and gain metrics.
+    /// PT: Garante que recomendações de índice incluam métricas estimadas de antes/depois e ganho.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldIncludeEstimatedGainMetrics_WhenRecommendingIndex()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("EstimatedRowsReadBefore:");
+        cnn.LastExecutionPlan.Should().Contain("EstimatedRowsReadAfter:");
+        cnn.LastExecutionPlan.Should().Contain("EstimatedGainPct:");
+    }
+
+    /// <summary>
+    /// EN: Ensures suggested index keeps filter column order from predicate traversal.
+    /// PT: Garante que o índice sugerido preserve a ordem das colunas de filtro na varredura do predicado.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldPreservePredicateColumnOrder_InSuggestedIndex()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Id = 1 AND Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("CREATE INDEX IX_users_Id_Active ON users (Id, Active);");
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures advisor skips recommendation for tiny scans to reduce noise.
+    /// PT: Garante que o advisor não recomende índice para scans muito pequenos, reduzindo ruído.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotSuggestMissingIndex_WhenEstimatedRowsReadIsTooLow()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0]);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("IndexRecommendations:");
+    }
+
+    /// <summary>
+    /// EN: Ensures recommendation reason includes filter/order-by column context.
+    /// PT: Garante que o motivo da recomendação inclua contexto de colunas de filtro/ordenação.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldIncludeDetailedReason_WithFilterAndOrderByColumns()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("WHERE/JOIN (Active) + ORDER BY (Id)");
     }
 
     /// <summary>

--- a/src/DbSqlLikeMem.SqlServer.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/ExecutionPlanTests.cs
@@ -56,4 +56,127 @@ public sealed class ExecutionPlanTests : XUnitTestBase
 
         Console.WriteLine("[ExecutionPlan][SqlServer]\n" + cnn.LastExecutionPlan);
     }
+
+    /// <summary>
+    /// EN: Ensures execution plan suggests missing index for filter/sort columns.
+    /// PT: Garante que o plano de execução sugira índice ausente para colunas de filtro/ordenação.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldSuggestMissingIndex_WhenNoMatchingIndexExists()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("IndexRecommendations:");
+        cnn.LastExecutionPlan.Should().Contain("CREATE INDEX IX_users_Active_Id ON users (Active, Id);");
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures index recommendations include estimated before/after and gain metrics.
+    /// PT: Garante que recomendações de índice incluam métricas estimadas de antes/depois e ganho.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldIncludeEstimatedGainMetrics_WhenRecommendingIndex()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("EstimatedRowsReadBefore:");
+        cnn.LastExecutionPlan.Should().Contain("EstimatedRowsReadAfter:");
+        cnn.LastExecutionPlan.Should().Contain("EstimatedGainPct:");
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures advisor skips recommendation for tiny scans to reduce noise.
+    /// PT: Garante que o advisor não recomende índice para scans muito pequenos, reduzindo ruído.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotSuggestMissingIndex_WhenEstimatedRowsReadIsTooLow()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0]);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("IndexRecommendations:");
+    }
+
+    /// <summary>
+    /// EN: Ensures execution plan does not suggest index when a matching index already exists.
+    /// PT: Garante que o plano não sugira índice quando já existe índice aderente.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotSuggestMissingIndex_WhenMatchingIndexAlreadyExists()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.DefineTable("users").Index("ix_users_active_id", ["Active", "Id"]);
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("IndexRecommendations:");
+    }
 }

--- a/src/DbSqlLikeMem.Sqlite.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/ExecutionPlanTests.cs
@@ -56,4 +56,127 @@ public sealed class ExecutionPlanTests : XUnitTestBase
 
         Console.WriteLine("[ExecutionPlan][Sqlite]\n" + cnn.LastExecutionPlan);
     }
+
+    /// <summary>
+    /// EN: Ensures execution plan suggests missing index for filter/sort columns.
+    /// PT: Garante que o plano de execução sugira índice ausente para colunas de filtro/ordenação.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldSuggestMissingIndex_WhenNoMatchingIndexExists()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("IndexRecommendations:");
+        cnn.LastExecutionPlan.Should().Contain("CREATE INDEX IX_users_Active_Id ON users (Active, Id);");
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures index recommendations include estimated before/after and gain metrics.
+    /// PT: Garante que recomendações de índice incluam métricas estimadas de antes/depois e ganho.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldIncludeEstimatedGainMetrics_WhenRecommendingIndex()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("EstimatedRowsReadBefore:");
+        cnn.LastExecutionPlan.Should().Contain("EstimatedRowsReadAfter:");
+        cnn.LastExecutionPlan.Should().Contain("EstimatedGainPct:");
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures advisor skips recommendation for tiny scans to reduce noise.
+    /// PT: Garante que o advisor não recomende índice para scans muito pequenos, reduzindo ruído.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotSuggestMissingIndex_WhenEstimatedRowsReadIsTooLow()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0]);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("IndexRecommendations:");
+    }
+
+    /// <summary>
+    /// EN: Ensures execution plan does not suggest index when a matching index already exists.
+    /// PT: Garante que o plano não sugira índice quando já existe índice aderente.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotSuggestMissingIndex_WhenMatchingIndexAlreadyExists()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+        cnn.DefineTable("users").Index("ix_users_active_id", ["Active", "Id"]);
+        cnn.Seed("users", null,
+            [1, 1],
+            [2, 0],
+            [3, 1]);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("IndexRecommendations:");
+    }
 }

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.cs
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.cs
@@ -1,0 +1,59 @@
+using System.Resources;
+
+namespace DbSqlLikeMem.Resources;
+
+internal static class SqlExecutionPlanMessages
+{
+    private static readonly ResourceManager ResourceManager =
+        new("DbSqlLikeMem.Resources.SqlExecutionPlanMessages", typeof(SqlExecutionPlanMessages).Assembly);
+
+    public static string ExecutionPlanTitle() => Format(nameof(ExecutionPlanTitle));
+    public static string QueryTypeLabel() => Format(nameof(QueryTypeLabel));
+    public static string EstimatedCostLabel() => Format(nameof(EstimatedCostLabel));
+    public static string CtesLabel() => Format(nameof(CtesLabel));
+    public static string CteMaterializeLabel() => Format(nameof(CteMaterializeLabel));
+    public static string FromLabel() => Format(nameof(FromLabel));
+    public static string JoinLabel() => Format(nameof(JoinLabel));
+    public static string FilterLabel() => Format(nameof(FilterLabel));
+    public static string GroupByLabel() => Format(nameof(GroupByLabel));
+    public static string HavingLabel() => Format(nameof(HavingLabel));
+    public static string ProjectionLabel() => Format(nameof(ProjectionLabel));
+    public static string DistinctLabel() => Format(nameof(DistinctLabel));
+    public static string SortLabel() => Format(nameof(SortLabel));
+    public static string LimitLabel() => Format(nameof(LimitLabel));
+    public static string InputTablesLabel() => Format(nameof(InputTablesLabel));
+    public static string EstimatedRowsReadLabel() => Format(nameof(EstimatedRowsReadLabel));
+    public static string ActualRowsLabel() => Format(nameof(ActualRowsLabel));
+    public static string SelectivityPctLabel() => Format(nameof(SelectivityPctLabel));
+    public static string RowsPerMsLabel() => Format(nameof(RowsPerMsLabel));
+    public static string ElapsedMsLabel() => Format(nameof(ElapsedMsLabel));
+    public static string IndexRecommendationsLabel() => Format(nameof(IndexRecommendationsLabel));
+    public static string TableLabel() => Format(nameof(TableLabel));
+    public static string SuggestedIndexLabel() => Format(nameof(SuggestedIndexLabel));
+    public static string ReasonLabel() => Format(nameof(ReasonLabel));
+    public static string ConfidenceLabel() => Format(nameof(ConfidenceLabel));
+    public static string EstimatedRowsReadBeforeLabel() => Format(nameof(EstimatedRowsReadBeforeLabel));
+    public static string EstimatedRowsReadAfterLabel() => Format(nameof(EstimatedRowsReadAfterLabel));
+    public static string EstimatedGainPctLabel() => Format(nameof(EstimatedGainPctLabel));
+    public static string PartsLabel() => Format(nameof(PartsLabel));
+    public static string PartLabel() => Format(nameof(PartLabel));
+    public static string CombineLabel() => Format(nameof(CombineLabel));
+
+    public static string ReasonFilterAndOrder(string filters, string orders, string key)
+        => Format(nameof(ReasonFilterAndOrder), filters, orders, key);
+
+    public static string ReasonFilterOnly(string filters)
+        => Format(nameof(ReasonFilterOnly), filters);
+
+    public static string ReasonOrderOnly(string orders)
+        => Format(nameof(ReasonOrderOnly), orders);
+
+    private static string Format(string key, params object?[] args)
+    {
+        var template = ResourceManager.GetString(key, CultureInfo.CurrentUICulture)
+            ?? ResourceManager.GetString(key, CultureInfo.InvariantCulture)
+            ?? key;
+
+        return string.Format(CultureInfo.CurrentCulture, template, args);
+    }
+}

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.de.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.de.resx
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Ausführungsplan (mock)</value></data>
+  <data name="QueryTypeLabel" xml:space="preserve"><value>AbfrageTyp</value></data>
+  <data name="EstimatedCostLabel" xml:space="preserve"><value>GeschaetzteKosten</value></data>
+  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
+  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
+  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
+  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
+  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
+  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
+  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
+  <data name="ProjectionLabel" xml:space="preserve"><value>Projektion</value></data>
+  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
+  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
+  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
+  <data name="InputTablesLabel" xml:space="preserve"><value>EingabeTabellen</value></data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>GeschaetzteGeleseneZeilen</value></data>
+  <data name="ActualRowsLabel" xml:space="preserve"><value>TatsaechlicheZeilen</value></data>
+  <data name="SelectivityPctLabel" xml:space="preserve"><value>SelektivitaetPct</value></data>
+  <data name="RowsPerMsLabel" xml:space="preserve"><value>ZeilenProMs</value></data>
+  <data name="ElapsedMsLabel" xml:space="preserve"><value>VerstricheneMs</value></data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>IndexEmpfehlungen</value></data>
+  <data name="TableLabel" xml:space="preserve"><value>Tabelle</value></data>
+  <data name="SuggestedIndexLabel" xml:space="preserve"><value>VorgeschlagenerIndex</value></data>
+  <data name="ReasonLabel" xml:space="preserve"><value>Grund</value></data>
+  <data name="ConfidenceLabel" xml:space="preserve"><value>Konfidenz</value></data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>GeschaetzteGeleseneZeilenVorher</value></data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>GeschaetzteGeleseneZeilenNachher</value></data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>GeschaetzterGewinnPct</value></data>
+  <data name="PartsLabel" xml:space="preserve"><value>Teile</value></data>
+  <data name="PartLabel" xml:space="preserve"><value>Teil</value></data>
+  <data name="CombineLabel" xml:space="preserve"><value>Kombinieren</value></data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) ohne passenden Index. Vorgeschlagener Schlüssel: {2}.</value></data>
+  <data name="ReasonFilterOnly" xml:space="preserve"><value>WHERE/JOIN-Prädikate ({0}) ohne passenden Index.</value></data>
+  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) ohne passenden Index.</value></data>
+</root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.es.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.es.resx
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Plan de Ejecución (mock)</value></data>
+  <data name="QueryTypeLabel" xml:space="preserve"><value>TipoConsulta</value></data>
+  <data name="EstimatedCostLabel" xml:space="preserve"><value>CostoEstimado</value></data>
+  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
+  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
+  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
+  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
+  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
+  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
+  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
+  <data name="ProjectionLabel" xml:space="preserve"><value>Proyección</value></data>
+  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
+  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
+  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
+  <data name="InputTablesLabel" xml:space="preserve"><value>TablasEntrada</value></data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>FilasEstimadasLeidas</value></data>
+  <data name="ActualRowsLabel" xml:space="preserve"><value>FilasReales</value></data>
+  <data name="SelectivityPctLabel" xml:space="preserve"><value>SelectividadPct</value></data>
+  <data name="RowsPerMsLabel" xml:space="preserve"><value>FilasPorMs</value></data>
+  <data name="ElapsedMsLabel" xml:space="preserve"><value>TiempoTranscurridoMs</value></data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>RecomendacionesIndice</value></data>
+  <data name="TableLabel" xml:space="preserve"><value>Tabla</value></data>
+  <data name="SuggestedIndexLabel" xml:space="preserve"><value>IndiceSugerido</value></data>
+  <data name="ReasonLabel" xml:space="preserve"><value>Motivo</value></data>
+  <data name="ConfidenceLabel" xml:space="preserve"><value>Confianza</value></data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>FilasEstimadasLeidasAntes</value></data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>FilasEstimadasLeidasDespues</value></data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>GananciaEstimadaPct</value></data>
+  <data name="PartsLabel" xml:space="preserve"><value>Partes</value></data>
+  <data name="PartLabel" xml:space="preserve"><value>Parte</value></data>
+  <data name="CombineLabel" xml:space="preserve"><value>Combinar</value></data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) sin índice compatible. Clave sugerida: {2}.</value></data>
+  <data name="ReasonFilterOnly" xml:space="preserve"><value>Predicados WHERE/JOIN ({0}) sin índice compatible.</value></data>
+  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) sin índice compatible.</value></data>
+</root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.fr.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.fr.resx
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Plan d'exécution (mock)</value></data>
+  <data name="QueryTypeLabel" xml:space="preserve"><value>TypeRequete</value></data>
+  <data name="EstimatedCostLabel" xml:space="preserve"><value>CoutEstime</value></data>
+  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
+  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
+  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
+  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
+  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
+  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
+  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
+  <data name="ProjectionLabel" xml:space="preserve"><value>Projection</value></data>
+  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
+  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
+  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
+  <data name="InputTablesLabel" xml:space="preserve"><value>TablesEntree</value></data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>LignesEstimeesLues</value></data>
+  <data name="ActualRowsLabel" xml:space="preserve"><value>LignesReelles</value></data>
+  <data name="SelectivityPctLabel" xml:space="preserve"><value>SelectivitePct</value></data>
+  <data name="RowsPerMsLabel" xml:space="preserve"><value>LignesParMs</value></data>
+  <data name="ElapsedMsLabel" xml:space="preserve"><value>TempsEcouleMs</value></data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>RecommandationsIndex</value></data>
+  <data name="TableLabel" xml:space="preserve"><value>Table</value></data>
+  <data name="SuggestedIndexLabel" xml:space="preserve"><value>IndexSuggere</value></data>
+  <data name="ReasonLabel" xml:space="preserve"><value>Raison</value></data>
+  <data name="ConfidenceLabel" xml:space="preserve"><value>Confiance</value></data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>LignesEstimeesLuesAvant</value></data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>LignesEstimeesLuesApres</value></data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>GainEstimePct</value></data>
+  <data name="PartsLabel" xml:space="preserve"><value>Parties</value></data>
+  <data name="PartLabel" xml:space="preserve"><value>Partie</value></data>
+  <data name="CombineLabel" xml:space="preserve"><value>Combiner</value></data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) sans index compatible. Clé suggérée : {2}.</value></data>
+  <data name="ReasonFilterOnly" xml:space="preserve"><value>Prédicats WHERE/JOIN ({0}) sans index compatible.</value></data>
+  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) sans index compatible.</value></data>
+</root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.it.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.it.resx
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Piano di Esecuzione (mock)</value></data>
+  <data name="QueryTypeLabel" xml:space="preserve"><value>TipoQuery</value></data>
+  <data name="EstimatedCostLabel" xml:space="preserve"><value>CostoStimato</value></data>
+  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
+  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
+  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
+  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
+  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
+  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
+  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
+  <data name="ProjectionLabel" xml:space="preserve"><value>Proiezione</value></data>
+  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
+  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
+  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
+  <data name="InputTablesLabel" xml:space="preserve"><value>TabelleInput</value></data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>RigheStimateLette</value></data>
+  <data name="ActualRowsLabel" xml:space="preserve"><value>RigheReali</value></data>
+  <data name="SelectivityPctLabel" xml:space="preserve"><value>SelettivitaPct</value></data>
+  <data name="RowsPerMsLabel" xml:space="preserve"><value>RighePerMs</value></data>
+  <data name="ElapsedMsLabel" xml:space="preserve"><value>TempoTrascorsoMs</value></data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>RaccomandazioniIndice</value></data>
+  <data name="TableLabel" xml:space="preserve"><value>Tabella</value></data>
+  <data name="SuggestedIndexLabel" xml:space="preserve"><value>IndiceSuggerito</value></data>
+  <data name="ReasonLabel" xml:space="preserve"><value>Motivo</value></data>
+  <data name="ConfidenceLabel" xml:space="preserve"><value>Confidenza</value></data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>RigheStimateLettePrima</value></data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>RigheStimateLetteDopo</value></data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>GuadagnoStimatoPct</value></data>
+  <data name="PartsLabel" xml:space="preserve"><value>Parti</value></data>
+  <data name="PartLabel" xml:space="preserve"><value>Parte</value></data>
+  <data name="CombineLabel" xml:space="preserve"><value>Combina</value></data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) senza indice corrispondente. Chiave suggerita: {2}.</value></data>
+  <data name="ReasonFilterOnly" xml:space="preserve"><value>Predicati WHERE/JOIN ({0}) senza indice corrispondente.</value></data>
+  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) senza indice corrispondente.</value></data>
+</root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.pt.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.pt.resx
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Plano de Execução (mock)</value></data>
+  <data name="QueryTypeLabel" xml:space="preserve"><value>TipoConsulta</value></data>
+  <data name="EstimatedCostLabel" xml:space="preserve"><value>CustoEstimado</value></data>
+  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
+  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
+  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
+  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
+  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
+  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
+  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
+  <data name="ProjectionLabel" xml:space="preserve"><value>Projeção</value></data>
+  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
+  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
+  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
+  <data name="InputTablesLabel" xml:space="preserve"><value>TabelasEntrada</value></data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>LinhasEstimadasLidas</value></data>
+  <data name="ActualRowsLabel" xml:space="preserve"><value>LinhasReais</value></data>
+  <data name="SelectivityPctLabel" xml:space="preserve"><value>SeletividadePct</value></data>
+  <data name="RowsPerMsLabel" xml:space="preserve"><value>LinhasPorMs</value></data>
+  <data name="ElapsedMsLabel" xml:space="preserve"><value>TempoDecorridoMs</value></data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>RecomendacoesIndice</value></data>
+  <data name="TableLabel" xml:space="preserve"><value>Tabela</value></data>
+  <data name="SuggestedIndexLabel" xml:space="preserve"><value>IndiceSugerido</value></data>
+  <data name="ReasonLabel" xml:space="preserve"><value>Motivo</value></data>
+  <data name="ConfidenceLabel" xml:space="preserve"><value>Confianca</value></data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>LinhasEstimadasLidasAntes</value></data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>LinhasEstimadasLidasDepois</value></data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>GanhoEstimadoPct</value></data>
+  <data name="PartsLabel" xml:space="preserve"><value>Partes</value></data>
+  <data name="PartLabel" xml:space="preserve"><value>Parte</value></data>
+  <data name="CombineLabel" xml:space="preserve"><value>Combinar</value></data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) sem índice aderente. Chave sugerida: {2}.</value></data>
+  <data name="ReasonFilterOnly" xml:space="preserve"><value>Predicados WHERE/JOIN ({0}) sem índice aderente.</value></data>
+  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) sem índice aderente.</value></data>
+</root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.resx
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Execution Plan (mock)</value></data>
+  <data name="QueryTypeLabel" xml:space="preserve"><value>QueryType</value></data>
+  <data name="EstimatedCostLabel" xml:space="preserve"><value>EstimatedCost</value></data>
+  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
+  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
+  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
+  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
+  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
+  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
+  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
+  <data name="ProjectionLabel" xml:space="preserve"><value>Projection</value></data>
+  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
+  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
+  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
+  <data name="InputTablesLabel" xml:space="preserve"><value>InputTables</value></data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>EstimatedRowsRead</value></data>
+  <data name="ActualRowsLabel" xml:space="preserve"><value>ActualRows</value></data>
+  <data name="SelectivityPctLabel" xml:space="preserve"><value>SelectivityPct</value></data>
+  <data name="RowsPerMsLabel" xml:space="preserve"><value>RowsPerMs</value></data>
+  <data name="ElapsedMsLabel" xml:space="preserve"><value>ElapsedMs</value></data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>IndexRecommendations</value></data>
+  <data name="TableLabel" xml:space="preserve"><value>Table</value></data>
+  <data name="SuggestedIndexLabel" xml:space="preserve"><value>SuggestedIndex</value></data>
+  <data name="ReasonLabel" xml:space="preserve"><value>Reason</value></data>
+  <data name="ConfidenceLabel" xml:space="preserve"><value>Confidence</value></data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>EstimatedRowsReadBefore</value></data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>EstimatedRowsReadAfter</value></data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>EstimatedGainPct</value></data>
+  <data name="PartsLabel" xml:space="preserve"><value>Parts</value></data>
+  <data name="PartLabel" xml:space="preserve"><value>Part</value></data>
+  <data name="CombineLabel" xml:space="preserve"><value>Combine</value></data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) without a matching index. Suggested key: {2}.</value></data>
+  <data name="ReasonFilterOnly" xml:space="preserve"><value>WHERE/JOIN predicates ({0}) without a matching index.</value></data>
+  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) without a matching index.</value></data>
+</root>


### PR DESCRIPTION
### Motivation
- Externalize execution-plan text so non-SQL labels and headings can be localized while preserving canonical SQL syntax tokens across locales.
- Introduce an index-advisor to surface `IndexRecommendations` in execution plans for queries with significant estimated scans to help diagnose and prioritize indexing opportunities.
- Align tests and resource files to ensure localized labels and advisor output are covered by provider-specific `ExecutionPlanTests`.

### Description
- Added a resource gateway `SqlExecutionPlanMessages` (`src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.cs`) and created `.resx` files for base and locales (`.resx`, `pt`, `es`, `de`, `fr`, `it`) with translated non-SQL labels and reason templates.
- Updated `SqlExecutionPlanFormatter` (`src/DbSqlLikeMem/Query/SqlExecutionPlanFormatter.cs`) to print SQL reserved keywords explicitly (`FROM`, `JOIN`, `WHERE`, `GROUP BY`, `HAVING`, `ORDER BY`, `DISTINCT`, `LIMIT/TOP/FETCH`) while using resource lookups for non-SQL labels and metrics, and added `AppendIndexRecommendations` to render advisor output.
- Added `SqlIndexRecommendation` record and index-advisor implementation in `AstQueryExecutorBase` (`BuildIndexRecommendations` and helpers) to collect predicate/order columns, propose composite keys, skip when existing indexes/PKs cover the keys, estimate post-index rows, and compute a confidence score.
- Updated provider tests (`ExecutionPlanTests.cs` in MySql/SqlServer/Sqlite) to expect canonical SQL keywords and added multiple new test cases validating presence/absence and metrics of `IndexRecommendations` and suggested DDL strings.

### Testing
- Attempted to run unit tests with `dotnet test ... --filter ExecutionPlanTests` but the environment lacks the .NET SDK/CLI, so automated tests could not be executed (`bash: command not found: dotnet`).
- Performed static verification and file inspections of modified files including `SqlExecutionPlanFormatter`, `AstQueryExecutorBase`, `SqlExecutionPlanMessages` and the updated `ExecutionPlanTests` to ensure assertions and resource keys align.
- Ran repository checks such as `git status` and reviewed diffs to confirm the expected files and test updates were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b73ca8358832c8fa9454303c1d1dc)