### PR TITLE
Fix MySQL split-statements test assertions for SqlInsertQuery AST

### DIFF
--- a/src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserSplitStatementsTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserSplitStatementsTests.cs
@@ -37,20 +37,17 @@ public sealed class SqlQueryParserSplitStatementsTests(
     public void ParseInsertSelectWithOnDuplicate_ShouldRemainSingleStatement(int version)
     {
         var dialect = new MySqlDialect(version);
-        var sql = """
-                  INSERT INTO users (Id, Name)
-                  SELECT Id, Name FROM users_archive
-                  ON DUPLICATE KEY UPDATE Name = VALUES(Name);
-                  SELECT COUNT(*) FROM users;
-                  """;
+        var sql = "INSERT INTO users (Id, Name)\n"
+                + "SELECT Id, Name FROM users_archive\n"
+                + "ON DUPLICATE KEY UPDATE Name = VALUES(Name);\n"
+                + "SELECT COUNT(*) FROM users;";
 
         var parts = SqlQueryParser.SplitStatementsTopLevel(sql, dialect);
 
         Assert.Equal(2, parts.Count);
-        var insertAst = SqlQueryParser.Parse(parts[0], dialect);
+        var insertAst = Assert.IsType<SqlInsertQuery>(SqlQueryParser.Parse(parts[0], dialect));
 
-        Assert.NotNull(insertAst.Insert);
-        Assert.NotNull(insertAst.Insert!.Select);
-        Assert.NotNull(insertAst.Insert.OnDuplicate);
+        Assert.NotNull(insertAst.InsertSelect);
+        Assert.True(insertAst.HasOnDuplicateKeyUpdate);
     }
 }


### PR DESCRIPTION
### Motivation
- The test was accessing insert-specific members on `SqlQueryBase` (e.g. `Insert`, `Select`, `OnDuplicate`) which does not expose those properties, causing `CS1061` compile errors.
- The test previously used a C# 11 raw string literal which may not be supported by older target frameworks, so it was made compatible.

### Description
- Updated `ParseInsertSelectWithOnDuplicate_ShouldRemainSingleStatement` in `src/DbSqlLikeMem.MySql.Test/Parser/SqlQueryParserSplitStatementsTests.cs` to assert the actual parsed type via `Assert.IsType<SqlInsertQuery>(SqlQueryParser.Parse(...))`.
- Replaced invalid property accesses with `Assert.NotNull(insertAst.InsertSelect)` and `Assert.True(insertAst.HasOnDuplicateKeyUpdate)` to use the actual `SqlInsertQuery` members.
- Rewrote the SQL test string to use concatenated string lines with `\n` instead of a C# 11 raw string literal for broader framework compatibility.

### Testing
- Attempted to run the relevant test via `dotnet test` but the environment lacks the .NET SDK, so automated tests could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b96a441fc832c8af0dfc16d2f97c7)