### PR TITLE
feat: localize PlanWarnings severity values and add PlanWarnings advisor

### DIFF
--- a/docs/p7-p10-implementation-plan.md
+++ b/docs/p7-p10-implementation-plan.md
@@ -106,10 +106,21 @@ Documento gerado por `scripts/generate_p7_p10_plan.py` para orientar implementa�
 
 
 
-## Melhorias práticas para o plano de execução (Index Advisor)
+## Melhorias práticas para o plano de execução (Execution Plan Advisor)
 
-- [ ] Incluir seção `IndexRecommendations` no plano para queries SELECT com alto `EstimatedRowsRead`.
-- [ ] Sugerir índice composto com colunas de `WHERE/JOIN` e complementar com `ORDER BY` quando aplicável.
-- [ ] Exibir `Confidence` por recomendação para facilitar priorização técnica.
-- [ ] Cobrir cenários com e sem índice nos testes `ExecutionPlanTests` dos providers.
+### Index Advisor
+- [x] Incluir seção `IndexRecommendations` no plano para queries SELECT com alto `EstimatedRowsRead`.
+- [x] Sugerir índice composto com colunas de `WHERE/JOIN` e complementar com `ORDER BY` quando aplicável.
+- [x] Exibir `Confidence` por recomendação para facilitar priorização técnica.
+- [x] Cobrir cenários com e sem índice nos testes `ExecutionPlanTests` dos providers.
+
+### PlanWarnings (MVP)
+- [x] Incluir seção `PlanWarnings` no plano de execução para recomendações práticas ao desenvolvedor.
+- [x] Implementar alerta para `ORDER BY` sem `LIMIT/TOP/FETCH` em consultas com alto `EstimatedRowsRead`.
+- [x] Implementar alerta para baixa seletividade com `EstimatedRowsRead` alto.
+- [x] Implementar alerta opcional para `SELECT *` em leitura estimada alta.
+- [x] Exibir para cada alerta: `Code`, `Message`, `Reason`, `SuggestedAction`, `Severity`.
+- [x] Internacionalizar labels/mensagens do advisor mantendo keywords SQL canônicas (ex.: `WHERE`, `ORDER BY`, `LIMIT/TOP/FETCH`).
+- [x] Cobrir cenários positivos e negativos por regra em `ExecutionPlanTests` (MySQL, SQL Server, SQLite).
+- [x] Aplicar gate de alto volume de leitura para warnings (`EstimatedRowsRead` alto), evitando ruído em consultas pequenas.
 

--- a/src/DbSqlLikeMem.SqlServer.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/ExecutionPlanTests.cs
@@ -179,4 +179,164 @@ public sealed class ExecutionPlanTests : XUnitTestBase
 
         cnn.LastExecutionPlan.Should().NotContain("IndexRecommendations:");
     }
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW001_WhenOrderByHasNoLimitAndHighRead()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("PlanWarnings:");
+        cnn.LastExecutionPlan.Should().Contain("Code: PW001");
+        cnn.LastExecutionPlan.Should().Contain("Message:");
+        cnn.LastExecutionPlan.Should().Contain("Reason:");
+        cnn.LastExecutionPlan.Should().Contain("SuggestedAction:");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarningPW001_WhenLimitIsPresent()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users ORDER BY Id LIMIT 3"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW001");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW002_WhenSelectivityIsLowAndHighRead()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarningPW002_WhenSelectivityIsHigh()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, i => i == 1 ? 1 : 0);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW002");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW003_WhenSelectStarHasHighRead()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW003");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarningPW003_WhenProjectionIsExplicit()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW003");
+    }
+
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarnings_WhenEstimatedRowsReadIsNotHigh()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 8, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("PlanWarnings:");
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW001");
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW002");
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW003");
+    }
+
+
+
+    private static void SeedUsers(SqlServerConnectionMock cnn, int totalRows, Func<int, int> activeSelector)
+    {
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+
+        var rows = new object?[totalRows][];
+        for (var i = 1; i <= totalRows; i++)
+            rows[i - 1] = [i, activeSelector(i)];
+
+        cnn.Seed("users", null, rows);
+    }
+
 }

--- a/src/DbSqlLikeMem.Sqlite.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/ExecutionPlanTests.cs
@@ -179,4 +179,164 @@ public sealed class ExecutionPlanTests : XUnitTestBase
 
         cnn.LastExecutionPlan.Should().NotContain("IndexRecommendations:");
     }
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW001_WhenOrderByHasNoLimitAndHighRead()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("PlanWarnings:");
+        cnn.LastExecutionPlan.Should().Contain("Code: PW001");
+        cnn.LastExecutionPlan.Should().Contain("Message:");
+        cnn.LastExecutionPlan.Should().Contain("Reason:");
+        cnn.LastExecutionPlan.Should().Contain("SuggestedAction:");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarningPW001_WhenLimitIsPresent()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users ORDER BY Id LIMIT 3"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW001");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW002_WhenSelectivityIsLowAndHighRead()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarningPW002_WhenSelectivityIsHigh()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        SeedUsers(cnn, 120, i => i == 1 ? 1 : 0);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW002");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW003_WhenSelectStarHasHighRead()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW003");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarningPW003_WhenProjectionIsExplicit()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW003");
+    }
+
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarnings_WhenEstimatedRowsReadIsNotHigh()
+    {
+        using var cnn = new SqliteConnectionMock();
+
+        SeedUsers(cnn, 8, _ => 1);
+
+        using var cmd = new SqliteCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("PlanWarnings:");
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW001");
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW002");
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW003");
+    }
+
+
+
+    private static void SeedUsers(SqliteConnectionMock cnn, int totalRows, Func<int, int> activeSelector)
+    {
+        cnn.Define("users");
+        cnn.Column<int>("users", "Id");
+        cnn.Column<int>("users", "Active");
+
+        var rows = new object?[totalRows][];
+        for (var i = 1; i <= totalRows; i++)
+            rows[i - 1] = [i, activeSelector(i)];
+
+        cnn.Seed("users", null, rows);
+    }
+
 }

--- a/src/DbSqlLikeMem/Query/SqlExecutionPlanFormatter.cs
+++ b/src/DbSqlLikeMem/Query/SqlExecutionPlanFormatter.cs
@@ -27,12 +27,27 @@ internal sealed record SqlIndexRecommendation(
             : (double)(EstimatedRowsReadBefore - EstimatedRowsReadAfter) / EstimatedRowsReadBefore * 100d;
 }
 
+internal enum SqlPlanWarningSeverity
+{
+    Info,
+    Warning,
+    High
+}
+
+internal sealed record SqlPlanWarning(
+    string Code,
+    string Message,
+    string Reason,
+    string SuggestedAction,
+    SqlPlanWarningSeverity Severity);
+
 internal static class SqlExecutionPlanFormatter
 {
     public static string FormatSelect(
         SqlSelectQuery query,
         SqlPlanRuntimeMetrics metrics,
-        IReadOnlyList<SqlIndexRecommendation>? indexRecommendations = null)
+        IReadOnlyList<SqlIndexRecommendation>? indexRecommendations = null,
+        IReadOnlyList<SqlPlanWarning>? planWarnings = null)
     {
         var sb = new StringBuilder();
         sb.AppendLine(SqlExecutionPlanMessages.ExecutionPlanTitle());
@@ -88,9 +103,37 @@ internal static class SqlExecutionPlanFormatter
         sb.AppendLine($"- {SqlExecutionPlanMessages.ElapsedMsLabel()}: {metrics.ElapsedMs}");
 
         AppendIndexRecommendations(sb, indexRecommendations);
+        AppendPlanWarnings(sb, planWarnings);
 
         return sb.ToString().TrimEnd();
     }
+
+    private static void AppendPlanWarnings(
+        StringBuilder sb,
+        IReadOnlyList<SqlPlanWarning>? planWarnings)
+    {
+        if (planWarnings is null || planWarnings.Count == 0)
+            return;
+
+        sb.AppendLine($"- {SqlExecutionPlanMessages.PlanWarningsLabel()}:");
+        foreach (var warning in planWarnings)
+        {
+            sb.AppendLine($"  - {SqlExecutionPlanMessages.CodeLabel()}: {warning.Code}");
+            sb.AppendLine($"    {SqlExecutionPlanMessages.MessageLabel()}: {warning.Message}");
+            sb.AppendLine($"    {SqlExecutionPlanMessages.ReasonLabel()}: {warning.Reason}");
+            sb.AppendLine($"    {SqlExecutionPlanMessages.SuggestedActionLabel()}: {warning.SuggestedAction}");
+            sb.AppendLine($"    {SqlExecutionPlanMessages.SeverityLabel()}: {FormatWarningSeverity(warning.Severity)}");
+        }
+    }
+
+    private static string FormatWarningSeverity(SqlPlanWarningSeverity severity)
+        => severity switch
+        {
+            SqlPlanWarningSeverity.Info => SqlExecutionPlanMessages.SeverityInfoValue(),
+            SqlPlanWarningSeverity.Warning => SqlExecutionPlanMessages.SeverityWarningValue(),
+            SqlPlanWarningSeverity.High => SqlExecutionPlanMessages.SeverityHighValue(),
+            _ => severity.ToString()
+        };
 
     public static string FormatUnion(
         IReadOnlyList<SqlSelectQuery> parts,

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.cs
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.cs
@@ -38,6 +38,11 @@ internal static class SqlExecutionPlanMessages
     public static string PartsLabel() => Format(nameof(PartsLabel));
     public static string PartLabel() => Format(nameof(PartLabel));
     public static string CombineLabel() => Format(nameof(CombineLabel));
+    public static string PlanWarningsLabel() => Format(nameof(PlanWarningsLabel));
+    public static string CodeLabel() => Format(nameof(CodeLabel));
+    public static string MessageLabel() => Format(nameof(MessageLabel));
+    public static string SuggestedActionLabel() => Format(nameof(SuggestedActionLabel));
+    public static string SeverityLabel() => Format(nameof(SeverityLabel));
 
     public static string ReasonFilterAndOrder(string filters, string orders, string key)
         => Format(nameof(ReasonFilterAndOrder), filters, orders, key);
@@ -47,6 +52,38 @@ internal static class SqlExecutionPlanMessages
 
     public static string ReasonOrderOnly(string orders)
         => Format(nameof(ReasonOrderOnly), orders);
+
+    public static string WarningOrderByWithoutLimitMessage()
+        => Format(nameof(WarningOrderByWithoutLimitMessage));
+
+
+    public static string SeverityInfoValue() => Format(nameof(SeverityInfoValue));
+    public static string SeverityWarningValue() => Format(nameof(SeverityWarningValue));
+    public static string SeverityHighValue() => Format(nameof(SeverityHighValue));
+
+    public static string WarningOrderByWithoutLimitReason(long estimatedRowsRead)
+        => Format(nameof(WarningOrderByWithoutLimitReason), estimatedRowsRead);
+
+    public static string WarningOrderByWithoutLimitAction()
+        => Format(nameof(WarningOrderByWithoutLimitAction));
+
+    public static string WarningLowSelectivityMessage()
+        => Format(nameof(WarningLowSelectivityMessage));
+
+    public static string WarningLowSelectivityReason(double selectivityPct, long estimatedRowsRead)
+        => Format(nameof(WarningLowSelectivityReason), selectivityPct, estimatedRowsRead);
+
+    public static string WarningLowSelectivityAction()
+        => Format(nameof(WarningLowSelectivityAction));
+
+    public static string WarningSelectStarMessage()
+        => Format(nameof(WarningSelectStarMessage));
+
+    public static string WarningSelectStarReason(long estimatedRowsRead)
+        => Format(nameof(WarningSelectStarReason), estimatedRowsRead);
+
+    public static string WarningSelectStarAction()
+        => Format(nameof(WarningSelectStarAction));
 
     private static string Format(string key, params object?[] args)
     {

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.de.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.de.resx
@@ -1,41 +1,168 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Ausführungsplan (mock)</value></data>
-  <data name="QueryTypeLabel" xml:space="preserve"><value>AbfrageTyp</value></data>
-  <data name="EstimatedCostLabel" xml:space="preserve"><value>GeschaetzteKosten</value></data>
-  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
-  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
-  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
-  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
-  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
-  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
-  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
-  <data name="ProjectionLabel" xml:space="preserve"><value>Projektion</value></data>
-  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
-  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
-  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
-  <data name="InputTablesLabel" xml:space="preserve"><value>EingabeTabellen</value></data>
-  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>GeschaetzteGeleseneZeilen</value></data>
-  <data name="ActualRowsLabel" xml:space="preserve"><value>TatsaechlicheZeilen</value></data>
-  <data name="SelectivityPctLabel" xml:space="preserve"><value>SelektivitaetPct</value></data>
-  <data name="RowsPerMsLabel" xml:space="preserve"><value>ZeilenProMs</value></data>
-  <data name="ElapsedMsLabel" xml:space="preserve"><value>VerstricheneMs</value></data>
-  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>IndexEmpfehlungen</value></data>
-  <data name="TableLabel" xml:space="preserve"><value>Tabelle</value></data>
-  <data name="SuggestedIndexLabel" xml:space="preserve"><value>VorgeschlagenerIndex</value></data>
-  <data name="ReasonLabel" xml:space="preserve"><value>Grund</value></data>
-  <data name="ConfidenceLabel" xml:space="preserve"><value>Konfidenz</value></data>
-  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>GeschaetzteGeleseneZeilenVorher</value></data>
-  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>GeschaetzteGeleseneZeilenNachher</value></data>
-  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>GeschaetzterGewinnPct</value></data>
-  <data name="PartsLabel" xml:space="preserve"><value>Teile</value></data>
-  <data name="PartLabel" xml:space="preserve"><value>Teil</value></data>
-  <data name="CombineLabel" xml:space="preserve"><value>Kombinieren</value></data>
-  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) ohne passenden Index. Vorgeschlagener Schlüssel: {2}.</value></data>
-  <data name="ReasonFilterOnly" xml:space="preserve"><value>WHERE/JOIN-Prädikate ({0}) ohne passenden Index.</value></data>
-  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) ohne passenden Index.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve">
+    <value>Ausführungsplan (mock)</value>
+  </data>
+  <data name="QueryTypeLabel" xml:space="preserve">
+    <value>AbfrageTyp</value>
+  </data>
+  <data name="EstimatedCostLabel" xml:space="preserve">
+    <value>GeschaetzteKosten</value>
+  </data>
+  <data name="CtesLabel" xml:space="preserve">
+    <value>CTEs</value>
+  </data>
+  <data name="CteMaterializeLabel" xml:space="preserve">
+    <value>CTE Materialize</value>
+  </data>
+  <data name="FromLabel" xml:space="preserve">
+    <value>From</value>
+  </data>
+  <data name="JoinLabel" xml:space="preserve">
+    <value>Join</value>
+  </data>
+  <data name="FilterLabel" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="GroupByLabel" xml:space="preserve">
+    <value>GroupBy</value>
+  </data>
+  <data name="HavingLabel" xml:space="preserve">
+    <value>Having</value>
+  </data>
+  <data name="ProjectionLabel" xml:space="preserve">
+    <value>Projektion</value>
+  </data>
+  <data name="DistinctLabel" xml:space="preserve">
+    <value>Distinct</value>
+  </data>
+  <data name="SortLabel" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="LimitLabel" xml:space="preserve">
+    <value>Limit</value>
+  </data>
+  <data name="InputTablesLabel" xml:space="preserve">
+    <value>EingabeTabellen</value>
+  </data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve">
+    <value>GeschaetzteGeleseneZeilen</value>
+  </data>
+  <data name="ActualRowsLabel" xml:space="preserve">
+    <value>TatsaechlicheZeilen</value>
+  </data>
+  <data name="SelectivityPctLabel" xml:space="preserve">
+    <value>SelektivitaetPct</value>
+  </data>
+  <data name="RowsPerMsLabel" xml:space="preserve">
+    <value>ZeilenProMs</value>
+  </data>
+  <data name="ElapsedMsLabel" xml:space="preserve">
+    <value>VerstricheneMs</value>
+  </data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve">
+    <value>IndexEmpfehlungen</value>
+  </data>
+  <data name="TableLabel" xml:space="preserve">
+    <value>Tabelle</value>
+  </data>
+  <data name="SuggestedIndexLabel" xml:space="preserve">
+    <value>VorgeschlagenerIndex</value>
+  </data>
+  <data name="ReasonLabel" xml:space="preserve">
+    <value>Grund</value>
+  </data>
+  <data name="ConfidenceLabel" xml:space="preserve">
+    <value>Konfidenz</value>
+  </data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve">
+    <value>GeschaetzteGeleseneZeilenVorher</value>
+  </data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve">
+    <value>GeschaetzteGeleseneZeilenNachher</value>
+  </data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve">
+    <value>GeschaetzterGewinnPct</value>
+  </data>
+  <data name="PartsLabel" xml:space="preserve">
+    <value>Teile</value>
+  </data>
+  <data name="PartLabel" xml:space="preserve">
+    <value>Teil</value>
+  </data>
+  <data name="CombineLabel" xml:space="preserve">
+    <value>Kombinieren</value>
+  </data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve">
+    <value>WHERE/JOIN ({0}) + ORDER BY ({1}) ohne passenden Index. Vorgeschlagener Schlüssel: {2}.</value>
+  </data>
+  <data name="ReasonFilterOnly" xml:space="preserve">
+    <value>WHERE/JOIN-Prädikate ({0}) ohne passenden Index.</value>
+  </data>
+  <data name="ReasonOrderOnly" xml:space="preserve">
+    <value>ORDER BY ({0}) ohne passenden Index.</value>
+  </data>
+  <data name="PlanWarningsLabel" xml:space="preserve">
+    <value>PlanWarnungen</value>
+  </data>
+  <data name="CodeLabel" xml:space="preserve">
+    <value>Code</value>
+  </data>
+  <data name="MessageLabel" xml:space="preserve">
+    <value>Meldung</value>
+  </data>
+  <data name="SuggestedActionLabel" xml:space="preserve">
+    <value>EmpfohleneAktion</value>
+  </data>
+  <data name="SeverityLabel" xml:space="preserve">
+    <value>Schweregrad</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitMessage" xml:space="preserve">
+    <value>ORDER BY kann ohne LIMIT/TOP/FETCH teuer sein.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitReason" xml:space="preserve">
+    <value>ORDER BY sortiert geschätzt {0} Zeilen ohne LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitAction" xml:space="preserve">
+    <value>Verwenden Sie nach Möglichkeit LIMIT/TOP/FETCH oder erstellen/pflegen Sie einen auf ORDER BY ausgerichteten Index.</value>
+  </data>
+  <data name="WarningLowSelectivityMessage" xml:space="preserve">
+    <value>Niedrige Selektivität bei hohem Lesevolumen erkannt.</value>
+  </data>
+  <data name="WarningLowSelectivityReason" xml:space="preserve">
+    <value>Die Abfrage gab einen hohen Prozentsatz gescannter Zeilen zurück (SelectivityPct={0:F2}) bei EstimatedRowsRead={1}.</value>
+  </data>
+  <data name="WarningLowSelectivityAction" xml:space="preserve">
+    <value>Verfeinern Sie WHERE-Prädikate und prüfen Sie, ob zusätzliche selektive Prädikate oder Indizes nötig sind.</value>
+  </data>
+  <data name="WarningSelectStarMessage" xml:space="preserve">
+    <value>SELECT * bei hoher Leselast kann I/O- und Speichernutzung erhöhen.</value>
+  </data>
+  <data name="WarningSelectStarReason" xml:space="preserve">
+    <value>SELECT * wurde verwendet, während EstimatedRowsRead bei {0} liegt.</value>
+  </data>
+  <data name="WarningSelectStarAction" xml:space="preserve">
+    <value>Projizieren Sie nur benötigte Spalten statt SELECT *.</value>
+  </data>
+  <data name="SeverityInfoValue" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="SeverityWarningValue" xml:space="preserve">
+    <value>Warnung</value>
+  </data>
+  <data name="SeverityHighValue" xml:space="preserve">
+    <value>Hoch</value>
+  </data>
 </root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.es.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.es.resx
@@ -1,41 +1,168 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Plan de Ejecución (mock)</value></data>
-  <data name="QueryTypeLabel" xml:space="preserve"><value>TipoConsulta</value></data>
-  <data name="EstimatedCostLabel" xml:space="preserve"><value>CostoEstimado</value></data>
-  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
-  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
-  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
-  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
-  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
-  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
-  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
-  <data name="ProjectionLabel" xml:space="preserve"><value>Proyección</value></data>
-  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
-  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
-  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
-  <data name="InputTablesLabel" xml:space="preserve"><value>TablasEntrada</value></data>
-  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>FilasEstimadasLeidas</value></data>
-  <data name="ActualRowsLabel" xml:space="preserve"><value>FilasReales</value></data>
-  <data name="SelectivityPctLabel" xml:space="preserve"><value>SelectividadPct</value></data>
-  <data name="RowsPerMsLabel" xml:space="preserve"><value>FilasPorMs</value></data>
-  <data name="ElapsedMsLabel" xml:space="preserve"><value>TiempoTranscurridoMs</value></data>
-  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>RecomendacionesIndice</value></data>
-  <data name="TableLabel" xml:space="preserve"><value>Tabla</value></data>
-  <data name="SuggestedIndexLabel" xml:space="preserve"><value>IndiceSugerido</value></data>
-  <data name="ReasonLabel" xml:space="preserve"><value>Motivo</value></data>
-  <data name="ConfidenceLabel" xml:space="preserve"><value>Confianza</value></data>
-  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>FilasEstimadasLeidasAntes</value></data>
-  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>FilasEstimadasLeidasDespues</value></data>
-  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>GananciaEstimadaPct</value></data>
-  <data name="PartsLabel" xml:space="preserve"><value>Partes</value></data>
-  <data name="PartLabel" xml:space="preserve"><value>Parte</value></data>
-  <data name="CombineLabel" xml:space="preserve"><value>Combinar</value></data>
-  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) sin índice compatible. Clave sugerida: {2}.</value></data>
-  <data name="ReasonFilterOnly" xml:space="preserve"><value>Predicados WHERE/JOIN ({0}) sin índice compatible.</value></data>
-  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) sin índice compatible.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve">
+    <value>Plan de Ejecución (mock)</value>
+  </data>
+  <data name="QueryTypeLabel" xml:space="preserve">
+    <value>TipoConsulta</value>
+  </data>
+  <data name="EstimatedCostLabel" xml:space="preserve">
+    <value>CostoEstimado</value>
+  </data>
+  <data name="CtesLabel" xml:space="preserve">
+    <value>CTEs</value>
+  </data>
+  <data name="CteMaterializeLabel" xml:space="preserve">
+    <value>CTE Materialize</value>
+  </data>
+  <data name="FromLabel" xml:space="preserve">
+    <value>From</value>
+  </data>
+  <data name="JoinLabel" xml:space="preserve">
+    <value>Join</value>
+  </data>
+  <data name="FilterLabel" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="GroupByLabel" xml:space="preserve">
+    <value>GroupBy</value>
+  </data>
+  <data name="HavingLabel" xml:space="preserve">
+    <value>Having</value>
+  </data>
+  <data name="ProjectionLabel" xml:space="preserve">
+    <value>Proyección</value>
+  </data>
+  <data name="DistinctLabel" xml:space="preserve">
+    <value>Distinct</value>
+  </data>
+  <data name="SortLabel" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="LimitLabel" xml:space="preserve">
+    <value>Limit</value>
+  </data>
+  <data name="InputTablesLabel" xml:space="preserve">
+    <value>TablasEntrada</value>
+  </data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve">
+    <value>FilasEstimadasLeidas</value>
+  </data>
+  <data name="ActualRowsLabel" xml:space="preserve">
+    <value>FilasReales</value>
+  </data>
+  <data name="SelectivityPctLabel" xml:space="preserve">
+    <value>SelectividadPct</value>
+  </data>
+  <data name="RowsPerMsLabel" xml:space="preserve">
+    <value>FilasPorMs</value>
+  </data>
+  <data name="ElapsedMsLabel" xml:space="preserve">
+    <value>TiempoTranscurridoMs</value>
+  </data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve">
+    <value>RecomendacionesIndice</value>
+  </data>
+  <data name="TableLabel" xml:space="preserve">
+    <value>Tabla</value>
+  </data>
+  <data name="SuggestedIndexLabel" xml:space="preserve">
+    <value>IndiceSugerido</value>
+  </data>
+  <data name="ReasonLabel" xml:space="preserve">
+    <value>Motivo</value>
+  </data>
+  <data name="ConfidenceLabel" xml:space="preserve">
+    <value>Confianza</value>
+  </data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve">
+    <value>FilasEstimadasLeidasAntes</value>
+  </data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve">
+    <value>FilasEstimadasLeidasDespues</value>
+  </data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve">
+    <value>GananciaEstimadaPct</value>
+  </data>
+  <data name="PartsLabel" xml:space="preserve">
+    <value>Partes</value>
+  </data>
+  <data name="PartLabel" xml:space="preserve">
+    <value>Parte</value>
+  </data>
+  <data name="CombineLabel" xml:space="preserve">
+    <value>Combinar</value>
+  </data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve">
+    <value>WHERE/JOIN ({0}) + ORDER BY ({1}) sin índice compatible. Clave sugerida: {2}.</value>
+  </data>
+  <data name="ReasonFilterOnly" xml:space="preserve">
+    <value>Predicados WHERE/JOIN ({0}) sin índice compatible.</value>
+  </data>
+  <data name="ReasonOrderOnly" xml:space="preserve">
+    <value>ORDER BY ({0}) sin índice compatible.</value>
+  </data>
+  <data name="PlanWarningsLabel" xml:space="preserve">
+    <value>AdvertenciasPlan</value>
+  </data>
+  <data name="CodeLabel" xml:space="preserve">
+    <value>Codigo</value>
+  </data>
+  <data name="MessageLabel" xml:space="preserve">
+    <value>Mensaje</value>
+  </data>
+  <data name="SuggestedActionLabel" xml:space="preserve">
+    <value>AccionSugerida</value>
+  </data>
+  <data name="SeverityLabel" xml:space="preserve">
+    <value>Severidad</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitMessage" xml:space="preserve">
+    <value>ORDER BY puede ser costoso sin LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitReason" xml:space="preserve">
+    <value>ORDER BY está ordenando aproximadamente {0} filas estimadas sin LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitAction" xml:space="preserve">
+    <value>Use LIMIT/TOP/FETCH cuando sea posible, o cree/mantenga un índice alineado con las columnas de ORDER BY.</value>
+  </data>
+  <data name="WarningLowSelectivityMessage" xml:space="preserve">
+    <value>Se detectó baja selectividad con alto volumen de lectura.</value>
+  </data>
+  <data name="WarningLowSelectivityReason" xml:space="preserve">
+    <value>La consulta devolvió un alto porcentaje de las filas escaneadas (SelectivityPct={0:F2}) con EstimatedRowsRead={1}.</value>
+  </data>
+  <data name="WarningLowSelectivityAction" xml:space="preserve">
+    <value>Refine los predicados de WHERE y verifique si se necesitan predicados más selectivos o índices.</value>
+  </data>
+  <data name="WarningSelectStarMessage" xml:space="preserve">
+    <value>SELECT * en una consulta de alta lectura puede aumentar el I/O y el uso de memoria.</value>
+  </data>
+  <data name="WarningSelectStarReason" xml:space="preserve">
+    <value>Se utilizó SELECT * mientras EstimatedRowsRead es {0}.</value>
+  </data>
+  <data name="WarningSelectStarAction" xml:space="preserve">
+    <value>Proyecte solo las columnas necesarias en lugar de SELECT *.</value>
+  </data>
+  <data name="SeverityInfoValue" xml:space="preserve">
+    <value>Informacion</value>
+  </data>
+  <data name="SeverityWarningValue" xml:space="preserve">
+    <value>Advertencia</value>
+  </data>
+  <data name="SeverityHighValue" xml:space="preserve">
+    <value>Alta</value>
+  </data>
 </root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.fr.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.fr.resx
@@ -1,41 +1,168 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Plan d'exécution (mock)</value></data>
-  <data name="QueryTypeLabel" xml:space="preserve"><value>TypeRequete</value></data>
-  <data name="EstimatedCostLabel" xml:space="preserve"><value>CoutEstime</value></data>
-  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
-  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
-  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
-  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
-  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
-  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
-  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
-  <data name="ProjectionLabel" xml:space="preserve"><value>Projection</value></data>
-  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
-  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
-  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
-  <data name="InputTablesLabel" xml:space="preserve"><value>TablesEntree</value></data>
-  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>LignesEstimeesLues</value></data>
-  <data name="ActualRowsLabel" xml:space="preserve"><value>LignesReelles</value></data>
-  <data name="SelectivityPctLabel" xml:space="preserve"><value>SelectivitePct</value></data>
-  <data name="RowsPerMsLabel" xml:space="preserve"><value>LignesParMs</value></data>
-  <data name="ElapsedMsLabel" xml:space="preserve"><value>TempsEcouleMs</value></data>
-  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>RecommandationsIndex</value></data>
-  <data name="TableLabel" xml:space="preserve"><value>Table</value></data>
-  <data name="SuggestedIndexLabel" xml:space="preserve"><value>IndexSuggere</value></data>
-  <data name="ReasonLabel" xml:space="preserve"><value>Raison</value></data>
-  <data name="ConfidenceLabel" xml:space="preserve"><value>Confiance</value></data>
-  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>LignesEstimeesLuesAvant</value></data>
-  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>LignesEstimeesLuesApres</value></data>
-  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>GainEstimePct</value></data>
-  <data name="PartsLabel" xml:space="preserve"><value>Parties</value></data>
-  <data name="PartLabel" xml:space="preserve"><value>Partie</value></data>
-  <data name="CombineLabel" xml:space="preserve"><value>Combiner</value></data>
-  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) sans index compatible. Clé suggérée : {2}.</value></data>
-  <data name="ReasonFilterOnly" xml:space="preserve"><value>Prédicats WHERE/JOIN ({0}) sans index compatible.</value></data>
-  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) sans index compatible.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve">
+    <value>Plan d'exécution (mock)</value>
+  </data>
+  <data name="QueryTypeLabel" xml:space="preserve">
+    <value>TypeRequete</value>
+  </data>
+  <data name="EstimatedCostLabel" xml:space="preserve">
+    <value>CoutEstime</value>
+  </data>
+  <data name="CtesLabel" xml:space="preserve">
+    <value>CTEs</value>
+  </data>
+  <data name="CteMaterializeLabel" xml:space="preserve">
+    <value>CTE Materialize</value>
+  </data>
+  <data name="FromLabel" xml:space="preserve">
+    <value>From</value>
+  </data>
+  <data name="JoinLabel" xml:space="preserve">
+    <value>Join</value>
+  </data>
+  <data name="FilterLabel" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="GroupByLabel" xml:space="preserve">
+    <value>GroupBy</value>
+  </data>
+  <data name="HavingLabel" xml:space="preserve">
+    <value>Having</value>
+  </data>
+  <data name="ProjectionLabel" xml:space="preserve">
+    <value>Projection</value>
+  </data>
+  <data name="DistinctLabel" xml:space="preserve">
+    <value>Distinct</value>
+  </data>
+  <data name="SortLabel" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="LimitLabel" xml:space="preserve">
+    <value>Limit</value>
+  </data>
+  <data name="InputTablesLabel" xml:space="preserve">
+    <value>TablesEntree</value>
+  </data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve">
+    <value>LignesEstimeesLues</value>
+  </data>
+  <data name="ActualRowsLabel" xml:space="preserve">
+    <value>LignesReelles</value>
+  </data>
+  <data name="SelectivityPctLabel" xml:space="preserve">
+    <value>SelectivitePct</value>
+  </data>
+  <data name="RowsPerMsLabel" xml:space="preserve">
+    <value>LignesParMs</value>
+  </data>
+  <data name="ElapsedMsLabel" xml:space="preserve">
+    <value>TempsEcouleMs</value>
+  </data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve">
+    <value>RecommandationsIndex</value>
+  </data>
+  <data name="TableLabel" xml:space="preserve">
+    <value>Table</value>
+  </data>
+  <data name="SuggestedIndexLabel" xml:space="preserve">
+    <value>IndexSuggere</value>
+  </data>
+  <data name="ReasonLabel" xml:space="preserve">
+    <value>Raison</value>
+  </data>
+  <data name="ConfidenceLabel" xml:space="preserve">
+    <value>Confiance</value>
+  </data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve">
+    <value>LignesEstimeesLuesAvant</value>
+  </data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve">
+    <value>LignesEstimeesLuesApres</value>
+  </data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve">
+    <value>GainEstimePct</value>
+  </data>
+  <data name="PartsLabel" xml:space="preserve">
+    <value>Parties</value>
+  </data>
+  <data name="PartLabel" xml:space="preserve">
+    <value>Partie</value>
+  </data>
+  <data name="CombineLabel" xml:space="preserve">
+    <value>Combiner</value>
+  </data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve">
+    <value>WHERE/JOIN ({0}) + ORDER BY ({1}) sans index compatible. Clé suggérée : {2}.</value>
+  </data>
+  <data name="ReasonFilterOnly" xml:space="preserve">
+    <value>Prédicats WHERE/JOIN ({0}) sans index compatible.</value>
+  </data>
+  <data name="ReasonOrderOnly" xml:space="preserve">
+    <value>ORDER BY ({0}) sans index compatible.</value>
+  </data>
+  <data name="PlanWarningsLabel" xml:space="preserve">
+    <value>AlertesPlan</value>
+  </data>
+  <data name="CodeLabel" xml:space="preserve">
+    <value>Code</value>
+  </data>
+  <data name="MessageLabel" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="SuggestedActionLabel" xml:space="preserve">
+    <value>ActionSuggeree</value>
+  </data>
+  <data name="SeverityLabel" xml:space="preserve">
+    <value>Severite</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitMessage" xml:space="preserve">
+    <value>ORDER BY peut être coûteux sans LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitReason" xml:space="preserve">
+    <value>ORDER BY trie environ {0} lignes estimées sans LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitAction" xml:space="preserve">
+    <value>Utilisez LIMIT/TOP/FETCH lorsque possible, ou créez/maintenez un index aligné sur les colonnes de ORDER BY.</value>
+  </data>
+  <data name="WarningLowSelectivityMessage" xml:space="preserve">
+    <value>Faible sélectivité détectée avec un volume de lecture élevé.</value>
+  </data>
+  <data name="WarningLowSelectivityReason" xml:space="preserve">
+    <value>La requête a retourné un pourcentage élevé des lignes scannées (SelectivityPct={0:F2}) avec EstimatedRowsRead={1}.</value>
+  </data>
+  <data name="WarningLowSelectivityAction" xml:space="preserve">
+    <value>Affinez les prédicats WHERE et vérifiez si des prédicats plus sélectifs ou des index sont nécessaires.</value>
+  </data>
+  <data name="WarningSelectStarMessage" xml:space="preserve">
+    <value>SELECT * sur une requête à forte lecture peut augmenter l'I/O et l'utilisation mémoire.</value>
+  </data>
+  <data name="WarningSelectStarReason" xml:space="preserve">
+    <value>SELECT * a été utilisé alors que EstimatedRowsRead est {0}.</value>
+  </data>
+  <data name="WarningSelectStarAction" xml:space="preserve">
+    <value>Projetez uniquement les colonnes nécessaires au lieu de SELECT *.</value>
+  </data>
+  <data name="SeverityInfoValue" xml:space="preserve">
+    <value>Information</value>
+  </data>
+  <data name="SeverityWarningValue" xml:space="preserve">
+    <value>Avertissement</value>
+  </data>
+  <data name="SeverityHighValue" xml:space="preserve">
+    <value>Elevee</value>
+  </data>
 </root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.it.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.it.resx
@@ -1,41 +1,168 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Piano di Esecuzione (mock)</value></data>
-  <data name="QueryTypeLabel" xml:space="preserve"><value>TipoQuery</value></data>
-  <data name="EstimatedCostLabel" xml:space="preserve"><value>CostoStimato</value></data>
-  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
-  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
-  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
-  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
-  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
-  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
-  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
-  <data name="ProjectionLabel" xml:space="preserve"><value>Proiezione</value></data>
-  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
-  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
-  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
-  <data name="InputTablesLabel" xml:space="preserve"><value>TabelleInput</value></data>
-  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>RigheStimateLette</value></data>
-  <data name="ActualRowsLabel" xml:space="preserve"><value>RigheReali</value></data>
-  <data name="SelectivityPctLabel" xml:space="preserve"><value>SelettivitaPct</value></data>
-  <data name="RowsPerMsLabel" xml:space="preserve"><value>RighePerMs</value></data>
-  <data name="ElapsedMsLabel" xml:space="preserve"><value>TempoTrascorsoMs</value></data>
-  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>RaccomandazioniIndice</value></data>
-  <data name="TableLabel" xml:space="preserve"><value>Tabella</value></data>
-  <data name="SuggestedIndexLabel" xml:space="preserve"><value>IndiceSuggerito</value></data>
-  <data name="ReasonLabel" xml:space="preserve"><value>Motivo</value></data>
-  <data name="ConfidenceLabel" xml:space="preserve"><value>Confidenza</value></data>
-  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>RigheStimateLettePrima</value></data>
-  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>RigheStimateLetteDopo</value></data>
-  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>GuadagnoStimatoPct</value></data>
-  <data name="PartsLabel" xml:space="preserve"><value>Parti</value></data>
-  <data name="PartLabel" xml:space="preserve"><value>Parte</value></data>
-  <data name="CombineLabel" xml:space="preserve"><value>Combina</value></data>
-  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) senza indice corrispondente. Chiave suggerita: {2}.</value></data>
-  <data name="ReasonFilterOnly" xml:space="preserve"><value>Predicati WHERE/JOIN ({0}) senza indice corrispondente.</value></data>
-  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) senza indice corrispondente.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve">
+    <value>Piano di Esecuzione (mock)</value>
+  </data>
+  <data name="QueryTypeLabel" xml:space="preserve">
+    <value>TipoQuery</value>
+  </data>
+  <data name="EstimatedCostLabel" xml:space="preserve">
+    <value>CostoStimato</value>
+  </data>
+  <data name="CtesLabel" xml:space="preserve">
+    <value>CTEs</value>
+  </data>
+  <data name="CteMaterializeLabel" xml:space="preserve">
+    <value>CTE Materialize</value>
+  </data>
+  <data name="FromLabel" xml:space="preserve">
+    <value>From</value>
+  </data>
+  <data name="JoinLabel" xml:space="preserve">
+    <value>Join</value>
+  </data>
+  <data name="FilterLabel" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="GroupByLabel" xml:space="preserve">
+    <value>GroupBy</value>
+  </data>
+  <data name="HavingLabel" xml:space="preserve">
+    <value>Having</value>
+  </data>
+  <data name="ProjectionLabel" xml:space="preserve">
+    <value>Proiezione</value>
+  </data>
+  <data name="DistinctLabel" xml:space="preserve">
+    <value>Distinct</value>
+  </data>
+  <data name="SortLabel" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="LimitLabel" xml:space="preserve">
+    <value>Limit</value>
+  </data>
+  <data name="InputTablesLabel" xml:space="preserve">
+    <value>TabelleInput</value>
+  </data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve">
+    <value>RigheStimateLette</value>
+  </data>
+  <data name="ActualRowsLabel" xml:space="preserve">
+    <value>RigheReali</value>
+  </data>
+  <data name="SelectivityPctLabel" xml:space="preserve">
+    <value>SelettivitaPct</value>
+  </data>
+  <data name="RowsPerMsLabel" xml:space="preserve">
+    <value>RighePerMs</value>
+  </data>
+  <data name="ElapsedMsLabel" xml:space="preserve">
+    <value>TempoTrascorsoMs</value>
+  </data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve">
+    <value>RaccomandazioniIndice</value>
+  </data>
+  <data name="TableLabel" xml:space="preserve">
+    <value>Tabella</value>
+  </data>
+  <data name="SuggestedIndexLabel" xml:space="preserve">
+    <value>IndiceSuggerito</value>
+  </data>
+  <data name="ReasonLabel" xml:space="preserve">
+    <value>Motivo</value>
+  </data>
+  <data name="ConfidenceLabel" xml:space="preserve">
+    <value>Confidenza</value>
+  </data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve">
+    <value>RigheStimateLettePrima</value>
+  </data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve">
+    <value>RigheStimateLetteDopo</value>
+  </data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve">
+    <value>GuadagnoStimatoPct</value>
+  </data>
+  <data name="PartsLabel" xml:space="preserve">
+    <value>Parti</value>
+  </data>
+  <data name="PartLabel" xml:space="preserve">
+    <value>Parte</value>
+  </data>
+  <data name="CombineLabel" xml:space="preserve">
+    <value>Combina</value>
+  </data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve">
+    <value>WHERE/JOIN ({0}) + ORDER BY ({1}) senza indice corrispondente. Chiave suggerita: {2}.</value>
+  </data>
+  <data name="ReasonFilterOnly" xml:space="preserve">
+    <value>Predicati WHERE/JOIN ({0}) senza indice corrispondente.</value>
+  </data>
+  <data name="ReasonOrderOnly" xml:space="preserve">
+    <value>ORDER BY ({0}) senza indice corrispondente.</value>
+  </data>
+  <data name="PlanWarningsLabel" xml:space="preserve">
+    <value>AvvisiPiano</value>
+  </data>
+  <data name="CodeLabel" xml:space="preserve">
+    <value>Codice</value>
+  </data>
+  <data name="MessageLabel" xml:space="preserve">
+    <value>Messaggio</value>
+  </data>
+  <data name="SuggestedActionLabel" xml:space="preserve">
+    <value>AzioneSuggerita</value>
+  </data>
+  <data name="SeverityLabel" xml:space="preserve">
+    <value>Gravita</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitMessage" xml:space="preserve">
+    <value>ORDER BY può essere costoso senza LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitReason" xml:space="preserve">
+    <value>ORDER BY sta ordinando circa {0} righe stimate senza LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitAction" xml:space="preserve">
+    <value>Usa LIMIT/TOP/FETCH quando possibile oppure crea/mantieni un indice allineato alle colonne di ORDER BY.</value>
+  </data>
+  <data name="WarningLowSelectivityMessage" xml:space="preserve">
+    <value>Bassa selettività rilevata con alto volume di lettura.</value>
+  </data>
+  <data name="WarningLowSelectivityReason" xml:space="preserve">
+    <value>La query ha restituito un'alta percentuale delle righe scansionate (SelectivityPct={0:F2}) con EstimatedRowsRead={1}.</value>
+  </data>
+  <data name="WarningLowSelectivityAction" xml:space="preserve">
+    <value>Affina i predicati WHERE e verifica se sono necessari predicati più selettivi o indici.</value>
+  </data>
+  <data name="WarningSelectStarMessage" xml:space="preserve">
+    <value>SELECT * su query ad alta lettura può aumentare I/O e uso memoria.</value>
+  </data>
+  <data name="WarningSelectStarReason" xml:space="preserve">
+    <value>È stato usato SELECT * mentre EstimatedRowsRead è {0}.</value>
+  </data>
+  <data name="WarningSelectStarAction" xml:space="preserve">
+    <value>Proietta solo le colonne necessarie invece di SELECT *.</value>
+  </data>
+  <data name="SeverityInfoValue" xml:space="preserve">
+    <value>Informazione</value>
+  </data>
+  <data name="SeverityWarningValue" xml:space="preserve">
+    <value>Avviso</value>
+  </data>
+  <data name="SeverityHighValue" xml:space="preserve">
+    <value>Alta</value>
+  </data>
 </root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.pt.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.pt.resx
@@ -1,41 +1,168 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Plano de Execução (mock)</value></data>
-  <data name="QueryTypeLabel" xml:space="preserve"><value>TipoConsulta</value></data>
-  <data name="EstimatedCostLabel" xml:space="preserve"><value>CustoEstimado</value></data>
-  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
-  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
-  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
-  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
-  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
-  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
-  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
-  <data name="ProjectionLabel" xml:space="preserve"><value>Projeção</value></data>
-  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
-  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
-  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
-  <data name="InputTablesLabel" xml:space="preserve"><value>TabelasEntrada</value></data>
-  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>LinhasEstimadasLidas</value></data>
-  <data name="ActualRowsLabel" xml:space="preserve"><value>LinhasReais</value></data>
-  <data name="SelectivityPctLabel" xml:space="preserve"><value>SeletividadePct</value></data>
-  <data name="RowsPerMsLabel" xml:space="preserve"><value>LinhasPorMs</value></data>
-  <data name="ElapsedMsLabel" xml:space="preserve"><value>TempoDecorridoMs</value></data>
-  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>RecomendacoesIndice</value></data>
-  <data name="TableLabel" xml:space="preserve"><value>Tabela</value></data>
-  <data name="SuggestedIndexLabel" xml:space="preserve"><value>IndiceSugerido</value></data>
-  <data name="ReasonLabel" xml:space="preserve"><value>Motivo</value></data>
-  <data name="ConfidenceLabel" xml:space="preserve"><value>Confianca</value></data>
-  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>LinhasEstimadasLidasAntes</value></data>
-  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>LinhasEstimadasLidasDepois</value></data>
-  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>GanhoEstimadoPct</value></data>
-  <data name="PartsLabel" xml:space="preserve"><value>Partes</value></data>
-  <data name="PartLabel" xml:space="preserve"><value>Parte</value></data>
-  <data name="CombineLabel" xml:space="preserve"><value>Combinar</value></data>
-  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) sem índice aderente. Chave sugerida: {2}.</value></data>
-  <data name="ReasonFilterOnly" xml:space="preserve"><value>Predicados WHERE/JOIN ({0}) sem índice aderente.</value></data>
-  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) sem índice aderente.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve">
+    <value>Plano de Execução (mock)</value>
+  </data>
+  <data name="QueryTypeLabel" xml:space="preserve">
+    <value>TipoConsulta</value>
+  </data>
+  <data name="EstimatedCostLabel" xml:space="preserve">
+    <value>CustoEstimado</value>
+  </data>
+  <data name="CtesLabel" xml:space="preserve">
+    <value>CTEs</value>
+  </data>
+  <data name="CteMaterializeLabel" xml:space="preserve">
+    <value>CTE Materialize</value>
+  </data>
+  <data name="FromLabel" xml:space="preserve">
+    <value>From</value>
+  </data>
+  <data name="JoinLabel" xml:space="preserve">
+    <value>Join</value>
+  </data>
+  <data name="FilterLabel" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="GroupByLabel" xml:space="preserve">
+    <value>GroupBy</value>
+  </data>
+  <data name="HavingLabel" xml:space="preserve">
+    <value>Having</value>
+  </data>
+  <data name="ProjectionLabel" xml:space="preserve">
+    <value>Projeção</value>
+  </data>
+  <data name="DistinctLabel" xml:space="preserve">
+    <value>Distinct</value>
+  </data>
+  <data name="SortLabel" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="LimitLabel" xml:space="preserve">
+    <value>Limit</value>
+  </data>
+  <data name="InputTablesLabel" xml:space="preserve">
+    <value>TabelasEntrada</value>
+  </data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve">
+    <value>LinhasEstimadasLidas</value>
+  </data>
+  <data name="ActualRowsLabel" xml:space="preserve">
+    <value>LinhasReais</value>
+  </data>
+  <data name="SelectivityPctLabel" xml:space="preserve">
+    <value>SeletividadePct</value>
+  </data>
+  <data name="RowsPerMsLabel" xml:space="preserve">
+    <value>LinhasPorMs</value>
+  </data>
+  <data name="ElapsedMsLabel" xml:space="preserve">
+    <value>TempoDecorridoMs</value>
+  </data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve">
+    <value>RecomendacoesIndice</value>
+  </data>
+  <data name="TableLabel" xml:space="preserve">
+    <value>Tabela</value>
+  </data>
+  <data name="SuggestedIndexLabel" xml:space="preserve">
+    <value>IndiceSugerido</value>
+  </data>
+  <data name="ReasonLabel" xml:space="preserve">
+    <value>Motivo</value>
+  </data>
+  <data name="ConfidenceLabel" xml:space="preserve">
+    <value>Confianca</value>
+  </data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve">
+    <value>LinhasEstimadasLidasAntes</value>
+  </data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve">
+    <value>LinhasEstimadasLidasDepois</value>
+  </data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve">
+    <value>GanhoEstimadoPct</value>
+  </data>
+  <data name="PartsLabel" xml:space="preserve">
+    <value>Partes</value>
+  </data>
+  <data name="PartLabel" xml:space="preserve">
+    <value>Parte</value>
+  </data>
+  <data name="CombineLabel" xml:space="preserve">
+    <value>Combinar</value>
+  </data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve">
+    <value>WHERE/JOIN ({0}) + ORDER BY ({1}) sem índice aderente. Chave sugerida: {2}.</value>
+  </data>
+  <data name="ReasonFilterOnly" xml:space="preserve">
+    <value>Predicados WHERE/JOIN ({0}) sem índice aderente.</value>
+  </data>
+  <data name="ReasonOrderOnly" xml:space="preserve">
+    <value>ORDER BY ({0}) sem índice aderente.</value>
+  </data>
+  <data name="PlanWarningsLabel" xml:space="preserve">
+    <value>AlertasPlano</value>
+  </data>
+  <data name="CodeLabel" xml:space="preserve">
+    <value>Codigo</value>
+  </data>
+  <data name="MessageLabel" xml:space="preserve">
+    <value>Mensagem</value>
+  </data>
+  <data name="SuggestedActionLabel" xml:space="preserve">
+    <value>AcaoSugerida</value>
+  </data>
+  <data name="SeverityLabel" xml:space="preserve">
+    <value>Severidade</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitMessage" xml:space="preserve">
+    <value>ORDER BY pode ser custoso sem LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitReason" xml:space="preserve">
+    <value>ORDER BY está ordenando cerca de {0} linhas estimadas sem LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitAction" xml:space="preserve">
+    <value>Use LIMIT/TOP/FETCH quando possível, ou crie/sustente um índice alinhado às colunas de ORDER BY.</value>
+  </data>
+  <data name="WarningLowSelectivityMessage" xml:space="preserve">
+    <value>Baixa seletividade detectada com alto volume de leitura.</value>
+  </data>
+  <data name="WarningLowSelectivityReason" xml:space="preserve">
+    <value>A consulta retornou alta porcentagem das linhas varridas (SelectivityPct={0:F2}) com EstimatedRowsRead={1}.</value>
+  </data>
+  <data name="WarningLowSelectivityAction" xml:space="preserve">
+    <value>Refine os predicados de WHERE e verifique se são necessários predicados mais seletivos ou índices.</value>
+  </data>
+  <data name="WarningSelectStarMessage" xml:space="preserve">
+    <value>SELECT * em consulta de alta leitura pode aumentar I/O e uso de memória.</value>
+  </data>
+  <data name="WarningSelectStarReason" xml:space="preserve">
+    <value>SELECT * foi usado enquanto EstimatedRowsRead é {0}.</value>
+  </data>
+  <data name="WarningSelectStarAction" xml:space="preserve">
+    <value>Projete apenas as colunas necessárias em vez de SELECT *.</value>
+  </data>
+  <data name="SeverityInfoValue" xml:space="preserve">
+    <value>Informacao</value>
+  </data>
+  <data name="SeverityWarningValue" xml:space="preserve">
+    <value>Aviso</value>
+  </data>
+  <data name="SeverityHighValue" xml:space="preserve">
+    <value>Alta</value>
+  </data>
 </root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.resx
@@ -1,41 +1,168 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="ExecutionPlanTitle" xml:space="preserve"><value>Execution Plan (mock)</value></data>
-  <data name="QueryTypeLabel" xml:space="preserve"><value>QueryType</value></data>
-  <data name="EstimatedCostLabel" xml:space="preserve"><value>EstimatedCost</value></data>
-  <data name="CtesLabel" xml:space="preserve"><value>CTEs</value></data>
-  <data name="CteMaterializeLabel" xml:space="preserve"><value>CTE Materialize</value></data>
-  <data name="FromLabel" xml:space="preserve"><value>From</value></data>
-  <data name="JoinLabel" xml:space="preserve"><value>Join</value></data>
-  <data name="FilterLabel" xml:space="preserve"><value>Filter</value></data>
-  <data name="GroupByLabel" xml:space="preserve"><value>GroupBy</value></data>
-  <data name="HavingLabel" xml:space="preserve"><value>Having</value></data>
-  <data name="ProjectionLabel" xml:space="preserve"><value>Projection</value></data>
-  <data name="DistinctLabel" xml:space="preserve"><value>Distinct</value></data>
-  <data name="SortLabel" xml:space="preserve"><value>Sort</value></data>
-  <data name="LimitLabel" xml:space="preserve"><value>Limit</value></data>
-  <data name="InputTablesLabel" xml:space="preserve"><value>InputTables</value></data>
-  <data name="EstimatedRowsReadLabel" xml:space="preserve"><value>EstimatedRowsRead</value></data>
-  <data name="ActualRowsLabel" xml:space="preserve"><value>ActualRows</value></data>
-  <data name="SelectivityPctLabel" xml:space="preserve"><value>SelectivityPct</value></data>
-  <data name="RowsPerMsLabel" xml:space="preserve"><value>RowsPerMs</value></data>
-  <data name="ElapsedMsLabel" xml:space="preserve"><value>ElapsedMs</value></data>
-  <data name="IndexRecommendationsLabel" xml:space="preserve"><value>IndexRecommendations</value></data>
-  <data name="TableLabel" xml:space="preserve"><value>Table</value></data>
-  <data name="SuggestedIndexLabel" xml:space="preserve"><value>SuggestedIndex</value></data>
-  <data name="ReasonLabel" xml:space="preserve"><value>Reason</value></data>
-  <data name="ConfidenceLabel" xml:space="preserve"><value>Confidence</value></data>
-  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve"><value>EstimatedRowsReadBefore</value></data>
-  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve"><value>EstimatedRowsReadAfter</value></data>
-  <data name="EstimatedGainPctLabel" xml:space="preserve"><value>EstimatedGainPct</value></data>
-  <data name="PartsLabel" xml:space="preserve"><value>Parts</value></data>
-  <data name="PartLabel" xml:space="preserve"><value>Part</value></data>
-  <data name="CombineLabel" xml:space="preserve"><value>Combine</value></data>
-  <data name="ReasonFilterAndOrder" xml:space="preserve"><value>WHERE/JOIN ({0}) + ORDER BY ({1}) without a matching index. Suggested key: {2}.</value></data>
-  <data name="ReasonFilterOnly" xml:space="preserve"><value>WHERE/JOIN predicates ({0}) without a matching index.</value></data>
-  <data name="ReasonOrderOnly" xml:space="preserve"><value>ORDER BY ({0}) without a matching index.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExecutionPlanTitle" xml:space="preserve">
+    <value>Execution Plan (mock)</value>
+  </data>
+  <data name="QueryTypeLabel" xml:space="preserve">
+    <value>QueryType</value>
+  </data>
+  <data name="EstimatedCostLabel" xml:space="preserve">
+    <value>EstimatedCost</value>
+  </data>
+  <data name="CtesLabel" xml:space="preserve">
+    <value>CTEs</value>
+  </data>
+  <data name="CteMaterializeLabel" xml:space="preserve">
+    <value>CTE Materialize</value>
+  </data>
+  <data name="FromLabel" xml:space="preserve">
+    <value>From</value>
+  </data>
+  <data name="JoinLabel" xml:space="preserve">
+    <value>Join</value>
+  </data>
+  <data name="FilterLabel" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="GroupByLabel" xml:space="preserve">
+    <value>GroupBy</value>
+  </data>
+  <data name="HavingLabel" xml:space="preserve">
+    <value>Having</value>
+  </data>
+  <data name="ProjectionLabel" xml:space="preserve">
+    <value>Projection</value>
+  </data>
+  <data name="DistinctLabel" xml:space="preserve">
+    <value>Distinct</value>
+  </data>
+  <data name="SortLabel" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="LimitLabel" xml:space="preserve">
+    <value>Limit</value>
+  </data>
+  <data name="InputTablesLabel" xml:space="preserve">
+    <value>InputTables</value>
+  </data>
+  <data name="EstimatedRowsReadLabel" xml:space="preserve">
+    <value>EstimatedRowsRead</value>
+  </data>
+  <data name="ActualRowsLabel" xml:space="preserve">
+    <value>ActualRows</value>
+  </data>
+  <data name="SelectivityPctLabel" xml:space="preserve">
+    <value>SelectivityPct</value>
+  </data>
+  <data name="RowsPerMsLabel" xml:space="preserve">
+    <value>RowsPerMs</value>
+  </data>
+  <data name="ElapsedMsLabel" xml:space="preserve">
+    <value>ElapsedMs</value>
+  </data>
+  <data name="IndexRecommendationsLabel" xml:space="preserve">
+    <value>IndexRecommendations</value>
+  </data>
+  <data name="TableLabel" xml:space="preserve">
+    <value>Table</value>
+  </data>
+  <data name="SuggestedIndexLabel" xml:space="preserve">
+    <value>SuggestedIndex</value>
+  </data>
+  <data name="ReasonLabel" xml:space="preserve">
+    <value>Reason</value>
+  </data>
+  <data name="ConfidenceLabel" xml:space="preserve">
+    <value>Confidence</value>
+  </data>
+  <data name="EstimatedRowsReadBeforeLabel" xml:space="preserve">
+    <value>EstimatedRowsReadBefore</value>
+  </data>
+  <data name="EstimatedRowsReadAfterLabel" xml:space="preserve">
+    <value>EstimatedRowsReadAfter</value>
+  </data>
+  <data name="EstimatedGainPctLabel" xml:space="preserve">
+    <value>EstimatedGainPct</value>
+  </data>
+  <data name="PartsLabel" xml:space="preserve">
+    <value>Parts</value>
+  </data>
+  <data name="PartLabel" xml:space="preserve">
+    <value>Part</value>
+  </data>
+  <data name="CombineLabel" xml:space="preserve">
+    <value>Combine</value>
+  </data>
+  <data name="ReasonFilterAndOrder" xml:space="preserve">
+    <value>WHERE/JOIN ({0}) + ORDER BY ({1}) without a matching index. Suggested key: {2}.</value>
+  </data>
+  <data name="ReasonFilterOnly" xml:space="preserve">
+    <value>WHERE/JOIN predicates ({0}) without a matching index.</value>
+  </data>
+  <data name="ReasonOrderOnly" xml:space="preserve">
+    <value>ORDER BY ({0}) without a matching index.</value>
+  </data>
+  <data name="PlanWarningsLabel" xml:space="preserve">
+    <value>PlanWarnings</value>
+  </data>
+  <data name="CodeLabel" xml:space="preserve">
+    <value>Code</value>
+  </data>
+  <data name="MessageLabel" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="SuggestedActionLabel" xml:space="preserve">
+    <value>SuggestedAction</value>
+  </data>
+  <data name="SeverityLabel" xml:space="preserve">
+    <value>Severity</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitMessage" xml:space="preserve">
+    <value>ORDER BY may be expensive without LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitReason" xml:space="preserve">
+    <value>ORDER BY is sorting an estimated {0} rows without LIMIT/TOP/FETCH.</value>
+  </data>
+  <data name="WarningOrderByWithoutLimitAction" xml:space="preserve">
+    <value>Use LIMIT/TOP/FETCH when possible, or create/support an index aligned with ORDER BY columns.</value>
+  </data>
+  <data name="WarningLowSelectivityMessage" xml:space="preserve">
+    <value>Low selectivity detected with high read volume.</value>
+  </data>
+  <data name="WarningLowSelectivityReason" xml:space="preserve">
+    <value>Query returned a high percentage of scanned rows (SelectivityPct={0:F2}) with EstimatedRowsRead={1}.</value>
+  </data>
+  <data name="WarningLowSelectivityAction" xml:space="preserve">
+    <value>Refine WHERE predicates and verify if additional selective predicates or indexes are needed.</value>
+  </data>
+  <data name="WarningSelectStarMessage" xml:space="preserve">
+    <value>SELECT * on high-read query can increase I/O and memory usage.</value>
+  </data>
+  <data name="WarningSelectStarReason" xml:space="preserve">
+    <value>SELECT * was used while EstimatedRowsRead is {0}.</value>
+  </data>
+  <data name="WarningSelectStarAction" xml:space="preserve">
+    <value>Project only required columns instead of SELECT *.</value>
+  </data>
+  <data name="SeverityInfoValue" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="SeverityWarningValue" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="SeverityHighValue" xml:space="preserve">
+    <value>High</value>
+  </data>
 </root>


### PR DESCRIPTION
### Motivation
- Make PlanWarnings output fully localizable by avoiding printing the `Severity` enum directly and instead mapping severity labels through resources. 
- Provide practical developer guidance in the execution plan by adding a `PlanWarnings` section with common checks (ORDER BY without LIMIT, low selectivity, SELECT * on high-read queries). 
- Keep SQL keywords and canonical contract unchanged while improving UX for international consumers of the execution plan text. 

### Description
- Added `SqlPlanWarningSeverity` enum and `SqlPlanWarning` record, and wired `BuildPlanWarnings` into `AstQueryExecutorBase.ExecuteSelect` to emit warnings gated by a `HighReadThreshold`. 
- Updated `SqlExecutionPlanFormatter` to accept `planWarnings`, render a `PlanWarnings` section, and map severity values to localized strings via a new `FormatWarningSeverity` helper. 
- Extended `SqlExecutionPlanMessages` with new labels and value accessors (`PlanWarningsLabel`, `CodeLabel`, `MessageLabel`, `SuggestedActionLabel`, `SeverityLabel`, `SeverityInfoValue`, `SeverityWarningValue`, `SeverityHighValue`, and warning messages/reasons/actions) and updated the `.resx` resource files for base and supported locales. 
- Added execution-plan-focused tests in `ExecutionPlanTests.cs` for MySQL/SQL Server/SQLite that assert emission and suppression of warnings (PW001/PW002/PW003) and introduced a `SeedUsers` helper to make high/low-volume scenarios explicit. 

### Testing
- Performed structural validation of all updated `.resx` files with `xml.etree.ElementTree` (parsing succeeded). 
- Verified code usage of the new symbols with `rg` for `SeverityInfoValue|SeverityWarningValue|SeverityHighValue|FormatWarningSeverity(` which succeeded. 
- Attempted to run `dotnet --info`/`dotnet test` but the .NET SDK is not available in this environment (`command not found`), so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b950cc038832ca2e9bc524f121d8d)