### PR TITLE
Add PW005 (DISTINCT on high-read) warning, include plan-warning metadata, i18n and tests

### DIFF
--- a/docs/p7-p10-implementation-plan.md
+++ b/docs/p7-p10-implementation-plan.md
@@ -124,3 +124,19 @@ Documento gerado por `scripts/generate_p7_p10_plan.py` para orientar implementa�
 - [x] Cobrir cenários positivos e negativos por regra em `ExecutionPlanTests` (MySQL, SQL Server, SQLite).
 - [x] Aplicar gate de alto volume de leitura para warnings (`EstimatedRowsRead` alto), evitando ruído em consultas pequenas.
 
+
+### PlanWarnings (etapa evolução)
+- [x] Refinar severidade por contexto: `PW002` escala para `High` em seletividade muito alta e `PW003` escala para `Warning` em leitura muito alta.
+- [x] Adicionar metadados técnicos opcionais por alerta (`MetricName`, `ObservedValue`, `Threshold`) preservando compatibilidade do contrato textual.
+- [x] Expandir testes de borda para thresholds (abaixo/igual/acima) das regras `PW001`, `PW002` e `PW003` nos 3 providers.
+- [x] Validar não regressão de `IndexRecommendations` em cenários com `PlanWarnings` simultâneos.
+- [x] Atualizar resources (base + culturas suportadas) para novas labels/mensagens mantendo keywords SQL canônicas.
+- [x] Validar borda de severidade contextual para `PW002` (`84%` => `Warning`, `85%` => `High`) nos 3 providers.
+- [x] Validar borda de severidade contextual para `PW003` (`999` => `Info`, `1000` => `Warning`) nos 3 providers.
+- [x] Garantir consistência entre severidade e texto/metadados (`Threshold`/`ObservedValue`) no output textual.
+- [x] Refinar severidade de `PW003` com faixa crítica de leitura (`>=5000` => `High`) para priorização de risco extremo.
+- [x] Padronizar `Threshold` em formato técnico estável/language-neutral (ex.: `gte:100;warningGte:1000;highGte:5000`) para evitar texto não-localizável no payload.
+- [x] Implementar `PW004` para consultas sem `WHERE` com alto `EstimatedRowsRead`, com severidade contextual (`Warning`/`High`) e metadados técnicos estáveis.
+- [x] Implementar `PW005` para `DISTINCT` em alto `EstimatedRowsRead`, com severidade contextual (`Warning`/`High`) e metadados técnicos estáveis.
+
+

--- a/src/DbSqlLikeMem.MySql.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/ExecutionPlanTests.cs
@@ -442,6 +442,348 @@ public sealed class ExecutionPlanTests(
 
 
 
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW001_WhenEstimatedRowsReadEqualsThreshold()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 100, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW001");
+        cnn.LastExecutionPlan.Should().Contain("MetricName: EstimatedRowsRead");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 100");
+        cnn.LastExecutionPlan.Should().Contain("Threshold: gte:100");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarnings_WhenEstimatedRowsReadIsBelowThreshold()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 99, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("PlanWarnings:");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldKeepPW002AsWarning_WhenSelectivityIsAtLowThreshold()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 100, i => i <= 60 ? 1 : 0);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Warning");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 60.00");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePW002ToHigh_WhenSelectivityIsVeryLow()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 120, i => i <= 102 ? 1 : 0);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("MetricName: SelectivityPct");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePW003ToWarning_WhenReadVolumeIsVeryHigh()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 1000, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW003");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Warning");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 1000");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitIndexRecommendationsAlongsidePlanWarnings_WhenApplicable()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("IndexRecommendations:");
+        cnn.LastExecutionPlan.Should().Contain("PlanWarnings:");
+        cnn.LastExecutionPlan.Should().Contain("Code: PW001");
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+        cnn.LastExecutionPlan.Should().Contain("Code: PW003");
+    }
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldKeepPW002AsWarning_WhenSelectivityIsBelowHighImpactThreshold()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 100, i => i <= 84 ? 1 : 0);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Warning");
+        cnn.LastExecutionPlan.Should().NotContain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("Threshold: gte:60;highImpactGte:85");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePW002ToHigh_WhenSelectivityEqualsHighImpactThreshold()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 100, i => i <= 85 ? 1 : 0);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 85.00");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldKeepPW003AsInfo_WhenReadVolumeIsBelowVeryHighThreshold()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 999, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW003");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Info");
+        cnn.LastExecutionPlan.Should().Contain("Threshold: gte:100;warningGte:1000;highGte:5000");
+    }
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePW003ToHigh_WhenReadVolumeIsCritical()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 5000, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW003");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 5000");
+        cnn.LastExecutionPlan.Should().Contain("highGte:5000");
+    }
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW004_WhenNoWhereAndHighRead()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW004");
+        cnn.LastExecutionPlan.Should().Contain("MetricName: EstimatedRowsRead");
+        cnn.LastExecutionPlan.Should().Contain("Threshold: gte:100;highGte:5000");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Warning");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePlanWarningPW004ToHigh_WhenNoWhereAndCriticalRead()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 5000, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW004");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 5000");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarningPW004_WhenWhereIsPresent()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW004");
+    }
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW005_WhenDistinctAndHighRead()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT DISTINCT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW005");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Warning");
+        cnn.LastExecutionPlan.Should().Contain("MetricName: EstimatedRowsRead");
+        cnn.LastExecutionPlan.Should().Contain("Threshold: gte:100;highGte:5000");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePlanWarningPW005ToHigh_WhenDistinctAndCriticalRead()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 5000, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT DISTINCT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW005");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 5000");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarningPW005_WhenDistinctAndReadIsBelowThreshold()
+    {
+        using var cnn = new MySqlConnectionMock();
+
+        SeedUsers(cnn, 99, _ => 1);
+
+        using var cmd = new MySqlCommandMock(cnn)
+        {
+            CommandText = "SELECT DISTINCT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW005");
+    }
     private static void SeedUsers(MySqlConnectionMock cnn, int totalRows, Func<int, int> activeSelector)
     {
         cnn.Define("users");

--- a/src/DbSqlLikeMem.SqlServer.Test/ExecutionPlanTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/ExecutionPlanTests.cs
@@ -326,6 +326,348 @@ public sealed class ExecutionPlanTests : XUnitTestBase
 
 
 
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW001_WhenEstimatedRowsReadEqualsThreshold()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 100, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW001");
+        cnn.LastExecutionPlan.Should().Contain("MetricName: EstimatedRowsRead");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 100");
+        cnn.LastExecutionPlan.Should().Contain("Threshold: gte:100");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarnings_WhenEstimatedRowsReadIsBelowThreshold()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 99, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("PlanWarnings:");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldKeepPW002AsWarning_WhenSelectivityIsAtLowThreshold()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 100, i => i <= 60 ? 1 : 0);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Warning");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 60.00");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePW002ToHigh_WhenSelectivityIsVeryLow()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, i => i <= 102 ? 1 : 0);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("MetricName: SelectivityPct");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePW003ToWarning_WhenReadVolumeIsVeryHigh()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 1000, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW003");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Warning");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 1000");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitIndexRecommendationsAlongsidePlanWarnings_WhenApplicable()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users WHERE Active = 1 ORDER BY Id"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("IndexRecommendations:");
+        cnn.LastExecutionPlan.Should().Contain("PlanWarnings:");
+        cnn.LastExecutionPlan.Should().Contain("Code: PW001");
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+        cnn.LastExecutionPlan.Should().Contain("Code: PW003");
+    }
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldKeepPW002AsWarning_WhenSelectivityIsBelowHighImpactThreshold()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 100, i => i <= 84 ? 1 : 0);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Warning");
+        cnn.LastExecutionPlan.Should().NotContain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("Threshold: gte:60;highImpactGte:85");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePW002ToHigh_WhenSelectivityEqualsHighImpactThreshold()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 100, i => i <= 85 ? 1 : 0);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW002");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 85.00");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldKeepPW003AsInfo_WhenReadVolumeIsBelowVeryHighThreshold()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 999, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW003");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Info");
+        cnn.LastExecutionPlan.Should().Contain("Threshold: gte:100;warningGte:1000;highGte:5000");
+    }
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePW003ToHigh_WhenReadVolumeIsCritical()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 5000, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT * FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW003");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 5000");
+        cnn.LastExecutionPlan.Should().Contain("highGte:5000");
+    }
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW004_WhenNoWhereAndHighRead()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW004");
+        cnn.LastExecutionPlan.Should().Contain("MetricName: EstimatedRowsRead");
+        cnn.LastExecutionPlan.Should().Contain("Threshold: gte:100;highGte:5000");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Warning");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePlanWarningPW004ToHigh_WhenNoWhereAndCriticalRead()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 5000, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW004");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 5000");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarningPW004_WhenWhereIsPresent()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT Id FROM users WHERE Active = 1"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW004");
+    }
+
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEmitPlanWarningPW005_WhenDistinctAndHighRead()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 120, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT DISTINCT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW005");
+        cnn.LastExecutionPlan.Should().Contain("Severity: Warning");
+        cnn.LastExecutionPlan.Should().Contain("MetricName: EstimatedRowsRead");
+        cnn.LastExecutionPlan.Should().Contain("Threshold: gte:100;highGte:5000");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldEscalatePlanWarningPW005ToHigh_WhenDistinctAndCriticalRead()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 5000, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT DISTINCT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().Contain("Code: PW005");
+        cnn.LastExecutionPlan.Should().Contain("Severity: High");
+        cnn.LastExecutionPlan.Should().Contain("ObservedValue: 5000");
+    }
+
+    [Fact]
+    [Trait("Category", "ExecutionPlan")]
+    public void ExecuteReader_ShouldNotEmitPlanWarningPW005_WhenDistinctAndReadIsBelowThreshold()
+    {
+        using var cnn = new SqlServerConnectionMock();
+
+        SeedUsers(cnn, 99, _ => 1);
+
+        using var cmd = new SqlServerCommandMock(cnn)
+        {
+            CommandText = "SELECT DISTINCT Id FROM users"
+        };
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) { }
+
+        cnn.LastExecutionPlan.Should().NotContain("Code: PW005");
+    }
     private static void SeedUsers(SqlServerConnectionMock cnn, int totalRows, Func<int, int> activeSelector)
     {
         cnn.Define("users");

--- a/src/DbSqlLikeMem/Query/SqlExecutionPlanFormatter.cs
+++ b/src/DbSqlLikeMem/Query/SqlExecutionPlanFormatter.cs
@@ -38,7 +38,10 @@ internal sealed record SqlPlanWarning(
     string Message,
     string Reason,
     string SuggestedAction,
-    SqlPlanWarningSeverity Severity);
+    SqlPlanWarningSeverity Severity,
+    string? MetricName = null,
+    string? ObservedValue = null,
+    string? Threshold = null);
 
 internal static class SqlExecutionPlanFormatter
 {
@@ -122,6 +125,15 @@ internal static class SqlExecutionPlanFormatter
             sb.AppendLine($"    {SqlExecutionPlanMessages.ReasonLabel()}: {warning.Reason}");
             sb.AppendLine($"    {SqlExecutionPlanMessages.SuggestedActionLabel()}: {warning.SuggestedAction}");
             sb.AppendLine($"    {SqlExecutionPlanMessages.SeverityLabel()}: {FormatWarningSeverity(warning.Severity)}");
+
+            if (!string.IsNullOrWhiteSpace(warning.MetricName))
+                sb.AppendLine($"    {SqlExecutionPlanMessages.MetricNameLabel()}: {warning.MetricName}");
+
+            if (!string.IsNullOrWhiteSpace(warning.ObservedValue))
+                sb.AppendLine($"    {SqlExecutionPlanMessages.ObservedValueLabel()}: {warning.ObservedValue}");
+
+            if (!string.IsNullOrWhiteSpace(warning.Threshold))
+                sb.AppendLine($"    {SqlExecutionPlanMessages.ThresholdLabel()}: {warning.Threshold}");
         }
     }
 

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.cs
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.cs
@@ -43,6 +43,9 @@ internal static class SqlExecutionPlanMessages
     public static string MessageLabel() => Format(nameof(MessageLabel));
     public static string SuggestedActionLabel() => Format(nameof(SuggestedActionLabel));
     public static string SeverityLabel() => Format(nameof(SeverityLabel));
+    public static string MetricNameLabel() => Format(nameof(MetricNameLabel));
+    public static string ObservedValueLabel() => Format(nameof(ObservedValueLabel));
+    public static string ThresholdLabel() => Format(nameof(ThresholdLabel));
 
     public static string ReasonFilterAndOrder(string filters, string orders, string key)
         => Format(nameof(ReasonFilterAndOrder), filters, orders, key);
@@ -70,6 +73,9 @@ internal static class SqlExecutionPlanMessages
     public static string WarningLowSelectivityMessage()
         => Format(nameof(WarningLowSelectivityMessage));
 
+    public static string WarningLowSelectivityHighImpactMessage()
+        => Format(nameof(WarningLowSelectivityHighImpactMessage));
+
     public static string WarningLowSelectivityReason(double selectivityPct, long estimatedRowsRead)
         => Format(nameof(WarningLowSelectivityReason), selectivityPct, estimatedRowsRead);
 
@@ -79,11 +85,43 @@ internal static class SqlExecutionPlanMessages
     public static string WarningSelectStarMessage()
         => Format(nameof(WarningSelectStarMessage));
 
+    public static string WarningSelectStarHighImpactMessage()
+        => Format(nameof(WarningSelectStarHighImpactMessage));
+
+    public static string WarningSelectStarCriticalImpactMessage()
+        => Format(nameof(WarningSelectStarCriticalImpactMessage));
+
     public static string WarningSelectStarReason(long estimatedRowsRead)
         => Format(nameof(WarningSelectStarReason), estimatedRowsRead);
 
     public static string WarningSelectStarAction()
         => Format(nameof(WarningSelectStarAction));
+
+
+    public static string WarningNoWhereHighReadMessage()
+        => Format(nameof(WarningNoWhereHighReadMessage));
+
+    public static string WarningNoWhereHighReadHighImpactMessage()
+        => Format(nameof(WarningNoWhereHighReadHighImpactMessage));
+
+    public static string WarningNoWhereHighReadReason(long estimatedRowsRead)
+        => Format(nameof(WarningNoWhereHighReadReason), estimatedRowsRead);
+
+    public static string WarningNoWhereHighReadAction()
+        => Format(nameof(WarningNoWhereHighReadAction));
+
+
+    public static string WarningDistinctHighReadMessage()
+        => Format(nameof(WarningDistinctHighReadMessage));
+
+    public static string WarningDistinctHighReadHighImpactMessage()
+        => Format(nameof(WarningDistinctHighReadHighImpactMessage));
+
+    public static string WarningDistinctHighReadReason(long estimatedRowsRead)
+        => Format(nameof(WarningDistinctHighReadReason), estimatedRowsRead);
+
+    public static string WarningDistinctHighReadAction()
+        => Format(nameof(WarningDistinctHighReadAction));
 
     private static string Format(string key, params object?[] args)
     {

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.de.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.de.resx
@@ -156,6 +156,48 @@
   <data name="WarningSelectStarAction" xml:space="preserve">
     <value>Projizieren Sie nur benötigte Spalten statt SELECT *.</value>
   </data>
+  <data name="MetricNameLabel" xml:space="preserve">
+    <value>Metrikname</value>
+  </data>
+  <data name="ObservedValueLabel" xml:space="preserve">
+    <value>BeobachteterWert</value>
+  </data>
+  <data name="ThresholdLabel" xml:space="preserve">
+    <value>Schwellenwert</value>
+  </data>
+  <data name="WarningLowSelectivityHighImpactMessage" xml:space="preserve">
+    <value>Sehr niedrige Selektivität bei hohem Lesevolumen erkannt.</value>
+  </data>
+  <data name="WarningSelectStarHighImpactMessage" xml:space="preserve">
+    <value>SELECT * bei sehr hoher Leselast erhöht I/O- und Speicherrisiko deutlich.</value>
+  </data>
+  <data name="WarningSelectStarCriticalImpactMessage" xml:space="preserve">
+    <value>SELECT * bei extrem hoher Leselast hat ein kritisches I/O- und Speicherrisiko.</value>
+  </data>
+  <data name="WarningNoWhereHighReadMessage" xml:space="preserve">
+    <value>Abfrage mit hoher Leselast ohne WHERE kann einen vollständigen Scan auslösen.</value>
+  </data>
+  <data name="WarningNoWhereHighReadHighImpactMessage" xml:space="preserve">
+    <value>Abfrage mit sehr hoher Leselast ohne WHERE hat kritisches Vollscan-Risiko.</value>
+  </data>
+  <data name="WarningNoWhereHighReadReason" xml:space="preserve">
+    <value>Kein WHERE-Prädikat angegeben, während EstimatedRowsRead {0} beträgt.</value>
+  </data>
+  <data name="WarningNoWhereHighReadAction" xml:space="preserve">
+    <value>Fügen Sie nach Möglichkeit selektive WHERE-Prädikate hinzu oder bestätigen Sie, dass ein Vollscan beabsichtigt ist.</value>
+  </data>
+  <data name="WarningDistinctHighReadMessage" xml:space="preserve">
+    <value>DISTINCT bei Abfrage mit hoher Leselast kann teure Deduplizierung verursachen.</value>
+  </data>
+  <data name="WarningDistinctHighReadHighImpactMessage" xml:space="preserve">
+    <value>DISTINCT bei Abfrage mit sehr hoher Leselast hat kritisches Deduplizierungsrisiko.</value>
+  </data>
+  <data name="WarningDistinctHighReadReason" xml:space="preserve">
+    <value>DISTINCT wird angewendet, während EstimatedRowsRead {0} beträgt.</value>
+  </data>
+  <data name="WarningDistinctHighReadAction" xml:space="preserve">
+    <value>Verwenden Sie DISTINCT nur wenn nötig und prüfen Sie, ob Filter/Indizes die Zeilen vor der Deduplizierung reduzieren können.</value>
+  </data>
   <data name="SeverityInfoValue" xml:space="preserve">
     <value>Info</value>
   </data>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.es.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.es.resx
@@ -156,6 +156,48 @@
   <data name="WarningSelectStarAction" xml:space="preserve">
     <value>Proyecte solo las columnas necesarias en lugar de SELECT *.</value>
   </data>
+  <data name="MetricNameLabel" xml:space="preserve">
+    <value>NombreMetrica</value>
+  </data>
+  <data name="ObservedValueLabel" xml:space="preserve">
+    <value>ValorObservado</value>
+  </data>
+  <data name="ThresholdLabel" xml:space="preserve">
+    <value>Umbral</value>
+  </data>
+  <data name="WarningLowSelectivityHighImpactMessage" xml:space="preserve">
+    <value>Se detectó selectividad muy baja con alto volumen de lectura.</value>
+  </data>
+  <data name="WarningSelectStarHighImpactMessage" xml:space="preserve">
+    <value>SELECT * en una consulta de lectura muy alta eleva el riesgo de I/O y memoria.</value>
+  </data>
+  <data name="WarningSelectStarCriticalImpactMessage" xml:space="preserve">
+    <value>SELECT * en una consulta de lectura extremadamente alta tiene riesgo crítico de I/O y memoria.</value>
+  </data>
+  <data name="WarningNoWhereHighReadMessage" xml:space="preserve">
+    <value>Una consulta de alta lectura sin WHERE puede provocar un escaneo completo.</value>
+  </data>
+  <data name="WarningNoWhereHighReadHighImpactMessage" xml:space="preserve">
+    <value>Una consulta de lectura muy alta sin WHERE tiene riesgo crítico de escaneo completo.</value>
+  </data>
+  <data name="WarningNoWhereHighReadReason" xml:space="preserve">
+    <value>No se proporcionó predicado WHERE mientras EstimatedRowsRead es {0}.</value>
+  </data>
+  <data name="WarningNoWhereHighReadAction" xml:space="preserve">
+    <value>Agregue predicados WHERE selectivos cuando sea posible o confirme que el escaneo completo es intencional.</value>
+  </data>
+  <data name="WarningDistinctHighReadMessage" xml:space="preserve">
+    <value>DISTINCT en una consulta de alta lectura puede agregar costo elevado de deduplicación.</value>
+  </data>
+  <data name="WarningDistinctHighReadHighImpactMessage" xml:space="preserve">
+    <value>DISTINCT en una consulta de lectura muy alta tiene riesgo crítico de costo por deduplicación.</value>
+  </data>
+  <data name="WarningDistinctHighReadReason" xml:space="preserve">
+    <value>Se está aplicando DISTINCT mientras EstimatedRowsRead es {0}.</value>
+  </data>
+  <data name="WarningDistinctHighReadAction" xml:space="preserve">
+    <value>Use DISTINCT solo cuando sea necesario y evalúe si filtros/índices pueden reducir filas antes de deduplicar.</value>
+  </data>
   <data name="SeverityInfoValue" xml:space="preserve">
     <value>Informacion</value>
   </data>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.fr.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.fr.resx
@@ -156,6 +156,30 @@
   <data name="WarningSelectStarAction" xml:space="preserve">
     <value>Projetez uniquement les colonnes nécessaires au lieu de SELECT *.</value>
   </data>
+  <data name="WarningNoWhereHighReadMessage" xml:space="preserve">
+    <value>Une requête à forte lecture sans WHERE peut déclencher un scan complet.</value>
+  </data>
+  <data name="WarningNoWhereHighReadHighImpactMessage" xml:space="preserve">
+    <value>Une requête à très forte lecture sans WHERE présente un risque critique de scan complet.</value>
+  </data>
+  <data name="WarningNoWhereHighReadReason" xml:space="preserve">
+    <value>Aucun prédicat WHERE n'a été fourni alors que EstimatedRowsRead est {0}.</value>
+  </data>
+  <data name="WarningNoWhereHighReadAction" xml:space="preserve">
+    <value>Ajoutez des prédicats WHERE sélectifs lorsque possible ou confirmez qu'un scan complet est intentionnel.</value>
+  </data>
+  <data name="WarningDistinctHighReadMessage" xml:space="preserve">
+    <value>DISTINCT sur une requête à forte lecture peut ajouter un coût élevé de déduplication.</value>
+  </data>
+  <data name="WarningDistinctHighReadHighImpactMessage" xml:space="preserve">
+    <value>DISTINCT sur une requête à très forte lecture présente un risque critique de coût de déduplication.</value>
+  </data>
+  <data name="WarningDistinctHighReadReason" xml:space="preserve">
+    <value>DISTINCT est appliqué alors que EstimatedRowsRead est de {0}.</value>
+  </data>
+  <data name="WarningDistinctHighReadAction" xml:space="preserve">
+    <value>Utilisez DISTINCT uniquement si nécessaire et vérifiez si des filtres/index peuvent réduire les lignes avant déduplication.</value>
+  </data>
   <data name="SeverityInfoValue" xml:space="preserve">
     <value>Information</value>
   </data>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.it.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.it.resx
@@ -156,6 +156,48 @@
   <data name="WarningSelectStarAction" xml:space="preserve">
     <value>Proietta solo le colonne necessarie invece di SELECT *.</value>
   </data>
+  <data name="MetricNameLabel" xml:space="preserve">
+    <value>NomeMetrica</value>
+  </data>
+  <data name="ObservedValueLabel" xml:space="preserve">
+    <value>ValoreOsservato</value>
+  </data>
+  <data name="ThresholdLabel" xml:space="preserve">
+    <value>Soglia</value>
+  </data>
+  <data name="WarningLowSelectivityHighImpactMessage" xml:space="preserve">
+    <value>Rilevata selettività molto bassa con alto volume di lettura.</value>
+  </data>
+  <data name="WarningSelectStarHighImpactMessage" xml:space="preserve">
+    <value>SELECT * su query con lettura molto alta aumenta il rischio di I/O e memoria.</value>
+  </data>
+  <data name="WarningSelectStarCriticalImpactMessage" xml:space="preserve">
+    <value>SELECT * su query con lettura estremamente alta ha rischio critico di I/O e memoria.</value>
+  </data>
+  <data name="WarningNoWhereHighReadMessage" xml:space="preserve">
+    <value>Una query ad alta lettura senza WHERE può causare una scansione completa.</value>
+  </data>
+  <data name="WarningNoWhereHighReadHighImpactMessage" xml:space="preserve">
+    <value>Una query con lettura molto alta senza WHERE ha rischio critico di scansione completa.</value>
+  </data>
+  <data name="WarningNoWhereHighReadReason" xml:space="preserve">
+    <value>Nessun predicato WHERE fornito mentre EstimatedRowsRead è {0}.</value>
+  </data>
+  <data name="WarningNoWhereHighReadAction" xml:space="preserve">
+    <value>Aggiungi predicati WHERE selettivi quando possibile oppure conferma che la scansione completa è intenzionale.</value>
+  </data>
+  <data name="WarningDistinctHighReadMessage" xml:space="preserve">
+    <value>DISTINCT su query ad alta lettura può aggiungere un costo elevato di deduplicazione.</value>
+  </data>
+  <data name="WarningDistinctHighReadHighImpactMessage" xml:space="preserve">
+    <value>DISTINCT su query con lettura molto alta ha rischio critico di costo di deduplicazione.</value>
+  </data>
+  <data name="WarningDistinctHighReadReason" xml:space="preserve">
+    <value>DISTINCT è applicato mentre EstimatedRowsRead è {0}.</value>
+  </data>
+  <data name="WarningDistinctHighReadAction" xml:space="preserve">
+    <value>Usa DISTINCT solo quando necessario e valuta se filtri/indici possono ridurre le righe prima della deduplicazione.</value>
+  </data>
   <data name="SeverityInfoValue" xml:space="preserve">
     <value>Informazione</value>
   </data>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.pt.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.pt.resx
@@ -156,6 +156,30 @@
   <data name="WarningSelectStarAction" xml:space="preserve">
     <value>Projete apenas as colunas necessárias em vez de SELECT *.</value>
   </data>
+  <data name="WarningNoWhereHighReadMessage" xml:space="preserve">
+    <value>Consulta de alta leitura sem WHERE pode causar full scan.</value>
+  </data>
+  <data name="WarningNoWhereHighReadHighImpactMessage" xml:space="preserve">
+    <value>Consulta de leitura muito alta sem WHERE tem risco crítico de full scan.</value>
+  </data>
+  <data name="WarningNoWhereHighReadReason" xml:space="preserve">
+    <value>Nenhum predicado WHERE foi informado enquanto EstimatedRowsRead é {0}.</value>
+  </data>
+  <data name="WarningNoWhereHighReadAction" xml:space="preserve">
+    <value>Adicione predicados WHERE seletivos quando possível ou confirme que o full scan é intencional.</value>
+  </data>
+  <data name="WarningDistinctHighReadMessage" xml:space="preserve">
+    <value>DISTINCT em consulta de alta leitura pode adicionar custo elevado de deduplicação.</value>
+  </data>
+  <data name="WarningDistinctHighReadHighImpactMessage" xml:space="preserve">
+    <value>DISTINCT em consulta de leitura muito alta tem risco crítico de custo de deduplicação.</value>
+  </data>
+  <data name="WarningDistinctHighReadReason" xml:space="preserve">
+    <value>DISTINCT está sendo aplicado enquanto EstimatedRowsRead é {0}.</value>
+  </data>
+  <data name="WarningDistinctHighReadAction" xml:space="preserve">
+    <value>Use DISTINCT apenas quando necessário e avalie se filtros/índices podem reduzir linhas antes da deduplicação.</value>
+  </data>
   <data name="SeverityInfoValue" xml:space="preserve">
     <value>Informacao</value>
   </data>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.resx
@@ -156,6 +156,48 @@
   <data name="WarningSelectStarAction" xml:space="preserve">
     <value>Project only required columns instead of SELECT *.</value>
   </data>
+  <data name="MetricNameLabel" xml:space="preserve">
+    <value>MetricName</value>
+  </data>
+  <data name="ObservedValueLabel" xml:space="preserve">
+    <value>ObservedValue</value>
+  </data>
+  <data name="ThresholdLabel" xml:space="preserve">
+    <value>Threshold</value>
+  </data>
+  <data name="WarningLowSelectivityHighImpactMessage" xml:space="preserve">
+    <value>Very low selectivity detected with high read volume.</value>
+  </data>
+  <data name="WarningSelectStarHighImpactMessage" xml:space="preserve">
+    <value>SELECT * on very high-read query has elevated I/O and memory risk.</value>
+  </data>
+  <data name="WarningSelectStarCriticalImpactMessage" xml:space="preserve">
+    <value>SELECT * on extremely high-read query has critical I/O and memory risk.</value>
+  </data>
+  <data name="WarningNoWhereHighReadMessage" xml:space="preserve">
+    <value>High-read query without WHERE may trigger a full scan.</value>
+  </data>
+  <data name="WarningNoWhereHighReadHighImpactMessage" xml:space="preserve">
+    <value>Very high-read query without WHERE has critical full-scan risk.</value>
+  </data>
+  <data name="WarningNoWhereHighReadReason" xml:space="preserve">
+    <value>No WHERE predicate was provided while EstimatedRowsRead is {0}.</value>
+  </data>
+  <data name="WarningNoWhereHighReadAction" xml:space="preserve">
+    <value>Add selective WHERE predicates when possible or confirm that a full scan is intended.</value>
+  </data>
+  <data name="WarningDistinctHighReadMessage" xml:space="preserve">
+    <value>DISTINCT on high-read query may add expensive deduplication cost.</value>
+  </data>
+  <data name="WarningDistinctHighReadHighImpactMessage" xml:space="preserve">
+    <value>DISTINCT on very high-read query has critical deduplication cost risk.</value>
+  </data>
+  <data name="WarningDistinctHighReadReason" xml:space="preserve">
+    <value>DISTINCT is being applied while EstimatedRowsRead is {0}.</value>
+  </data>
+  <data name="WarningDistinctHighReadAction" xml:space="preserve">
+    <value>Use DISTINCT only when necessary and evaluate if filtering/indexing can reduce rows before deduplication.</value>
+  </data>
   <data name="SeverityInfoValue" xml:space="preserve">
     <value>Info</value>
   </data>


### PR DESCRIPTION
### Motivation
- Surface a costly anti-pattern where `DISTINCT` applied to very large scans can add expensive deduplication cost and escalate severity when reads are critical. 
- Make plan warnings more machine-friendly by attaching stable technical metadata (`MetricName`, `ObservedValue`, `Threshold`) so consumers can parse severity/context reliably. 
- Improve prioritization by refining severity heuristics for existing plan warnings (selectivity, SELECT * and no-WHERE cases) and complete i18n coverage for new messages.

### Description
- Add new rule `PW005` in `BuildPlanWarnings` to emit a warning when `query.Distinct` is true and `EstimatedRowsRead` crosses the high/critical thresholds, with severity `Warning` or `High` and metadata `MetricName: EstimatedRowsRead`, `ObservedValue`, `Threshold`.
- Extend `SqlPlanWarning` (signature) to include optional `MetricName`, `ObservedValue`, and `Threshold`, and update `SqlExecutionPlanFormatter.AppendPlanWarnings` to print those fields when present.
- Introduce/readjust thresholds and severity logic in `AstQueryExecutorBase.cs` (`HighReadThreshold`, `VeryHighReadThreshold`, `CriticalReadThreshold`, `Low/VeryLowSelectivity`), and adjust `PW001`/`PW002`/`PW003`/`PW004` behavior accordingly.
- Add resource wrapper methods and `.resx` entries (base + `de`/`es`/`fr`/`it`/`pt`) for the new messages and new labels (`MetricName`, `ObservedValue`, `Threshold`) used in the formatted plan.
- Add execution-plan unit tests for MySQL/SQL Server/SQLite covering `PW005` (warning/high/negative) and expanded boundary tests for `PW001`/`PW002`/`PW003`/`PW004`, and update the implementation checklist in `docs/p7-p10-implementation-plan.md`.

### Testing
- Ran static verification/search with `rg -n` to confirm presence of new warning codes, resource keys and threshold tokens across modified files; the search returned the expected artifacts. (succeeded)
- Attempted to inspect the .NET SDK / run tests (`dotnet --info` / `dotnet test`) but the environment lacks the SDK, so unit tests were added but not executed here (`dotnet: command not found`). (not executed)
- Performed local commits and verified the latest commit message to record the changes. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c44302000832c8337c0d135bb9be5)