### PR TITLE
Add provider-aware DbMock/connection factory helper

### DIFF
--- a/src/DbSqlLikeMem.Sqlite.Test/DbMockConnectionFactoryTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/DbMockConnectionFactoryTests.cs
@@ -1,0 +1,26 @@
+namespace DbSqlLikeMem.Sqlite.Test;
+
+public class DbMockConnectionFactoryTests
+{
+    [Fact]
+    public void CreateSqliteWithTables_ShouldCreateSqliteDbAndConnection()
+    {
+        var (db, connection) = DbMockConnectionFactory.CreateSqliteWithTables();
+
+        db.Should().BeOfType<SqliteDbMock>();
+        connection.Should().BeOfType<SqliteConnectionMock>();
+    }
+
+    [Fact]
+    public void CreateWithTables_ShouldApplyTableMappers()
+    {
+        var (db, _) = DbMockConnectionFactory.CreateWithTables(
+            "Sqlite",
+            it => it.AddTable(
+                "Users",
+                [new Col("Id", DataTypeDef.Int32()), new Col("Name", DataTypeDef.String())],
+                [new Dictionary<int, object?> { [0] = 1, [1] = "Ana" }]));
+
+        db.GetTable("Users").Rows.Should().HaveCount(1);
+    }
+}

--- a/src/DbSqlLikeMem/Extensions/DbMockConnectionFactory.cs
+++ b/src/DbSqlLikeMem/Extensions/DbMockConnectionFactory.cs
@@ -1,0 +1,154 @@
+using System.Reflection;
+
+namespace DbSqlLikeMem;
+
+/// <summary>
+/// EN: Creates provider database mocks and their matching <see cref="IDbConnection"/> instances with optional table mapping setup.
+/// PT: Cria mocks de banco por provedor e suas conexões <see cref="IDbConnection"/> correspondentes, com configuração opcional de mapeamento de tabelas.
+/// </summary>
+public static class DbMockConnectionFactory
+{
+    public static (DbMock Db, IDbConnection Connection) CreateOracleWithTables(params Action<DbMock>[] tableMappers)
+        => CreateWithTables("Oracle", tableMappers);
+
+    public static (DbMock Db, IDbConnection Connection) CreateSqlServerWithTables(params Action<DbMock>[] tableMappers)
+        => CreateWithTables("SqlServer", tableMappers);
+
+    public static (DbMock Db, IDbConnection Connection) CreateMySqlWithTables(params Action<DbMock>[] tableMappers)
+        => CreateWithTables("MySql", tableMappers);
+
+    public static (DbMock Db, IDbConnection Connection) CreateSqliteWithTables(params Action<DbMock>[] tableMappers)
+        => CreateWithTables("Sqlite", tableMappers);
+
+    public static (DbMock Db, IDbConnection Connection) CreateDb2WithTables(params Action<DbMock>[] tableMappers)
+        => CreateWithTables("Db2", tableMappers);
+
+    public static (DbMock Db, IDbConnection Connection) CreateNpgsqlWithTables(params Action<DbMock>[] tableMappers)
+        => CreateWithTables("Npgsql", tableMappers);
+
+    /// <summary>
+    /// EN: Creates a provider-specific <see cref="DbMock"/> and resolves an <see cref="IDbConnection"/> for it.
+    /// PT: Cria um <see cref="DbMock"/> específico do provedor e resolve um <see cref="IDbConnection"/> para ele.
+    /// </summary>
+    /// <param name="providerHint">EN: Provider name hint like Oracle, SqlServer, MySql, Sqlite, Db2 or Npgsql. PT: Indicação do provedor como Oracle, SqlServer, MySql, Sqlite, Db2 ou Npgsql.</param>
+    /// <param name="tableMappers">EN: Optional actions to configure tables/schemas on the created mock. PT: Ações opcionais para configurar tabelas/esquemas no mock criado.</param>
+    public static (DbMock Db, IDbConnection Connection) CreateWithTables(
+        string providerHint,
+        params Action<DbMock>[] tableMappers)
+    {
+        var db = CreateDbMock(providerHint);
+
+        foreach (var map in tableMappers)
+        {
+            map(db);
+        }
+
+        var connection = ResolveConnection(db, providerHint);
+        return (db, connection);
+    }
+
+    private static DbMock CreateDbMock(string providerHint)
+    {
+        var allTypes = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .SelectMany(SafeGetTypes)
+            .Where(type =>
+                typeof(DbMock).IsAssignableFrom(type)
+                && !type.IsAbstract
+                && type.GetConstructor(Type.EmptyTypes) is not null)
+            .ToArray();
+
+        var preferred = allTypes
+            .FirstOrDefault(type => ContainsProviderHint(type, providerHint))
+            ?? allTypes.FirstOrDefault();
+
+        if (preferred is null)
+        {
+            throw new InvalidOperationException(
+                $"No concrete DbMock implementation was found. Loaded assemblies: {AppDomain.CurrentDomain.GetAssemblies().Length}.");
+        }
+
+        return (DbMock)Activator.CreateInstance(preferred)!;
+    }
+
+    private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(type => type is not null)!;
+        }
+    }
+
+    private static IDbConnection ResolveConnection(DbMock db, string providerHint)
+    {
+        if (db is IDbConnection directConnection)
+        {
+            return directConnection;
+        }
+
+        var candidateMembers = db.GetType()
+            .GetMembers(BindingFlags.Instance | BindingFlags.Public)
+            .Where(member =>
+                member is PropertyInfo property && typeof(IDbConnection).IsAssignableFrom(property.PropertyType)
+                || member is MethodInfo method && typeof(IDbConnection).IsAssignableFrom(method.ReturnType) && method.GetParameters().Length == 0);
+
+        foreach (var member in candidateMembers)
+        {
+            object? value = member switch
+            {
+                PropertyInfo property => property.GetValue(db),
+                MethodInfo method => method.Invoke(db, null),
+                _ => null
+            };
+
+            if (value is IDbConnection connection)
+            {
+                return connection;
+            }
+        }
+
+        var connectionType = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .SelectMany(SafeGetTypes)
+            .Where(type =>
+                typeof(IDbConnection).IsAssignableFrom(type)
+                && !type.IsAbstract
+                && ContainsProviderHint(type, providerHint))
+            .OrderByDescending(type => type.Name.Contains("Connection", StringComparison.OrdinalIgnoreCase))
+            .FirstOrDefault(type =>
+                type.GetConstructor([db.GetType()]) is not null
+                || type.GetConstructor([typeof(DbMock)]) is not null);
+
+        if (connectionType is not null)
+        {
+            var byExactCtor = connectionType.GetConstructor([db.GetType()]);
+            var byBaseCtor = connectionType.GetConstructor([typeof(DbMock)]);
+            if (byExactCtor is not null)
+            {
+                return (IDbConnection)byExactCtor.Invoke([db]);
+            }
+
+            if (byBaseCtor is not null)
+            {
+                return (IDbConnection)byBaseCtor.Invoke([db]);
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not resolve an IDbConnection from DbMock type '{db.GetType().FullName}' with provider hint '{providerHint}'.");
+    }
+
+    private static bool ContainsProviderHint(Type type, string providerHint)
+    {
+        if (string.IsNullOrWhiteSpace(providerHint))
+            return false;
+
+        return type.Name.Contains(providerHint, StringComparison.OrdinalIgnoreCase)
+            || (type.Namespace?.Contains(providerHint, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (type.Assembly.GetName().Name?.Contains(providerHint, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+}

--- a/src/DbSqlLikeMem/README.md
+++ b/src/DbSqlLikeMem/README.md
@@ -29,6 +29,28 @@ dotnet add package DbSqlLikeMem
 
 Escolha também um pacote de provedor (MySql, SqlServer, Oracle, Npgsql, Sqlite ou Db2) para simular o dialeto do seu sistema.
 
+
+## Factory rápida para testes
+
+Para facilitar o uso no dia a dia, você pode criar `DbMock` + `IDbConnection` com uma chamada única:
+
+```csharp
+var (db, conn) = DbMockConnectionFactory.CreateSqliteWithTables(
+    d => d.AddTable("Users",
+        [new Col("Id", DataTypeDef.Int32()), new Col("Name", DataTypeDef.String())],
+        [new Dictionary<int, object?> { [0] = 1, [1] = "Ana" }]));
+```
+
+Também existem atalhos por banco: `CreateOracleWithTables`, `CreateSqlServerWithTables`, `CreateMySqlWithTables`, `CreateSqliteWithTables`, `CreateDb2WithTables` e `CreateNpgsqlWithTables`.
+
+Se preferir, use a versão genérica por string:
+
+```csharp
+var (db, conn) = DbMockConnectionFactory.CreateWithTables("SqlServer", d => { /* mapeamentos */ });
+```
+
+> Dica: a factory resolve a conexão automaticamente via reflexão, então ela funciona melhor quando o pacote do provedor já está referenciado e carregado no seu projeto de teste.
+
 ## Contribuindo
 
 Contribuições são super bem-vindas 💙


### PR DESCRIPTION
### Motivation

- Provide a simple, provider-aware factory to quickly create `(DbMock Db, IDbConnection Connection)` tuples for tests and seed tables with a single call using `CreateWithTables` or provider-specific shortcuts like `CreateSqliteWithTables`.
- Improve robustness of resolving the `IDbConnection` for a created `DbMock` so tests and examples work consistently across provider packages loaded in the test project.

### Description

- Added a new factory `DbMockConnectionFactory` (`src/DbSqlLikeMem/Extensions/DbMockConnectionFactory.cs`) with provider shortcuts (`CreateOracleWithTables`, `CreateSqlServerWithTables`, `CreateMySqlWithTables`, `CreateSqliteWithTables`, `CreateDb2WithTables`, `CreateNpgsqlWithTables`) and a generic `CreateWithTables(string providerHint, ...)` method.
- Implemented `CreateDbMock` which scans loaded assemblies and picks a concrete `DbMock` implementation preferring types that match the `providerHint` and have a parameterless constructor.
- Implemented `ResolveConnection` which resolves an `IDbConnection` by trying (1) if the `DbMock` itself implements `IDbConnection`, (2) public properties or parameterless methods returning `IDbConnection`, and (3) reflection-based instantiation of a matching `IDbConnection` type that accepts the `DbMock` (preferring types with "Connection" in the name and matching constructors).
- Added tests `DbMockConnectionFactoryTests` (`src/DbSqlLikeMem.Sqlite.Test/DbMockConnectionFactoryTests.cs`) that assert correct `DbMock`/connection type resolution for Sqlite and that table mappers are applied, and updated `src/DbSqlLikeMem/README.md` with usage examples.

### Testing

- Added unit tests `DbMockConnectionFactoryTests` under `src/DbSqlLikeMem.Sqlite.Test` but running them in this environment failed because `dotnet` is not available when attempting `dotnet test src/DbSqlLikeMem.Sqlite.Test/DbSqlLikeMem.Sqlite.Test.csproj -f net8.0 --filter DbMockConnectionFactoryTests` (error: `bash: command not found: dotnet`).
- No automated tests were executed successfully in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c50b44fbc832c88f6902b9be7f67c)