### PR TITLE
feat: add ROWS window-frame parsing & runtime support, dialect gates, and forward/sliding-frame tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,9 @@ Este diretório organiza o conteúdo por contexto para facilitar navegação, ma
   - matriz por banco
   - capacidades SQL por dialeto/versão
   - sugestões de evolução do parser
+- [Roadmap do Core (Parser/Executor)](core-parser-executor-roadmap.md)
+  - melhorias priorizadas por parser/executor
+  - separação de especificidades por dialeto/versão
 - [Prompts de implementação (copy/paste)](implementation-prompts.md)
   - roadmap em fases
   - prompts prontos para paralelizar implementações

--- a/docs/core-parser-executor-roadmap.md
+++ b/docs/core-parser-executor-roadmap.md
@@ -1,0 +1,180 @@
+# Roadmap revalidado do Core (Parser/Executor) sem duplicação e sem risco de build
+
+> Reavaliação do roadmap anterior com foco em: **não duplicar código**, **não criar abstrações paralelas** e **evitar quebra de build**.
+
+## Contexto de revalidação
+
+O core já possui base importante para evolução orientada a dialect:
+
+- `ISqlDialect` já centraliza várias capacidades de parser/runtime (CTE, UPSERT, JSON, paginação, hints, comparação textual, date add, window etc.).
+- `SqlQueryParser` já aplica diversos gates por capability/version.
+- `AstQueryExecutorFactory` ainda é parcial (fallback de não implementado para dialetos sem executor AST registrado), então mudanças no executor precisam ser incrementais para não quebrar compatibilidade.
+
+## Decisão principal
+
+Para evitar duplicação de código e problemas de build:
+
+1. **Não criar uma nova interface paralela (`IDialectCapabilities`) agora**.
+2. Evoluir o que já existe em `ISqlDialect` com propriedades/métodos pequenos e específicos.
+3. Implementar funcionalidades novas atrás de feature gate + testes por provider/versão.
+
+---
+
+
+## Status de implementação (estimado)
+
+> Percentuais estimados com base no que já foi entregue no parser/executor e nos testes por provider/versão.
+
+| Item | Progresso | Observações rápidas |
+| --- | --- | --- |
+| 1) CTE avançada | **70%** | Gates principais já existem; faltam cenários/versionamento mais fino em cobertura. |
+| 2) Window functions além de `ROW_NUMBER` | **82%** | Gating por nome/versão, validação de aridade/`ORDER BY`, parser com suporte de leitura para frame `ROWS` (com `RANGE/GROUPS` gateados), validação semântica de limites de frame (`start <= end`) e execução de frame `ROWS` para `FIRST_VALUE`/`LAST_VALUE`/`NTH_VALUE` já implementadas (incluindo cenários de frame deslizante e forward por linha). Fail-fast para função desconhecida e hardening de aridade/ranges literais (`NTILE`/`LAG`/`LEAD`/`NTH_VALUE`) também entregues. Pendências: ampliar execução de frames para demais funções e unidades adicionais. |
+| 3) UPSERT por família de banco | **55%** | Parser com capacidades base; ainda há execução/semântica por provider a consolidar. |
+| 4) Tipos/literais/coerção | **45%** | Base central em `SqlExtensions`; falta extrair mais regras específicas por dialect/version. |
+| 5) JSON cross-dialect | **50%** | Gates e parte do parser prontos; falta ampliar cobertura de execução por provider. |
+| 6) Plano físico com custo | **15%** | Ainda não iniciado como motor dedicado; apenas evolução incremental do executor atual. |
+| 7) JOIN/subquery com heurística | **30%** | Há caminhos funcionais; faltam heurísticas/caching explícitos com meta de custo. |
+| 8) Semântica transacional por isolamento | **25%** | Suporte parcial por cenários; falta modelagem mais completa por provider/version. |
+| 9) `RETURNING`/`OUTPUT`/`RETURNING INTO` | **35%** | Capabilities e parser base; falta payload consistente no executor multi-provider. |
+| 10) Collation/null ordering | **40%** | Parte da comparação textual já centralizada; faltam regras completas de `NULLS FIRST/LAST` e collation. |
+
+## Reavaliação das propostas (válido x ajustar x adiar)
+
+## 1) CTE avançada
+
+**Status:** ✅ **Válido** (já existe base).
+
+- Já há flags como `SupportsWithCte`, `SupportsWithRecursive` e `SupportsWithMaterializedHint`.
+- A ação correta é ampliar cobertura de testes e casos sem criar novo eixo arquitetural.
+
+**Implementação recomendada:**
+
+- manter parser usando os gates já existentes;
+- adicionar testes por versão para cada provider onde houver comportamento diferente.
+
+## 2) Window functions além de `ROW_NUMBER`
+
+**Status:** ✅ **Válido com ajuste**.
+
+- Já existe `SupportsWindowFunctions` e inferência de tipo para window function no dialect.
+- Evitar engine nova nesse momento; evoluir no executor atual por passos pequenos.
+
+**Incremento seguro:**
+
+- primeiro `RANK`/`DENSE_RANK`;
+- depois `LAG`/`LEAD`;
+- por último `ROWS/RANGE` (maior risco).
+
+## 3) UPSERT por família de banco
+
+**Status:** ✅ **Válido**.
+
+- Já há `SupportsOnDuplicateKeyUpdate`, `SupportsOnConflictClause`, `SupportsMerge` no dialect.
+- O parser já usa essas capacidades.
+
+**Implementação recomendada:**
+
+- padronizar nó AST de upsert sem quebrar contratos existentes;
+- completar execução por provider sem duplicar regras em parser + strategy.
+
+## 4) Tipos/literais/coerção
+
+**Status:** ✅ **Válido com prioridade alta**.
+
+- Hoje há semântica compartilhada em `SqlExtensions` (`Compare`, `EqualsSql`, `ToDec`, `ToBool`).
+- Risco de duplicação é alto se cada provider reimplementar isso.
+
+**Implementação recomendada:**
+
+- manter helpers centrais;
+- extrair somente pontos variáveis para hooks do dialect (`TextComparison`, `SupportsImplicitNumericStringComparison`, `LikeIsCaseInsensitive` já existem).
+
+## 5) JSON cross-dialect
+
+**Status:** ✅ **Válido**.
+
+- Parser/tokenizer já têm gates (`SupportsJsonArrowOperators`, `SupportsJsonExtractFunction`, `SupportsJsonValueFunction`, `SupportsOpenJsonFunction`).
+
+**Implementação recomendada:**
+
+- ampliar executor por estratégia de função/operador;
+- manter fallback explícito de não suportado quando necessário.
+
+## 6) Plano físico completo com custo
+
+**Status:** ⚠️ **Adiar** (alto risco de churn).
+
+- Embora desejável, refatorar para engine física completa agora aumenta risco de regressão/build.
+- Melhor seguir com melhorias localizadas no executor atual e instrumentação incremental de plano.
+
+## 7) JOIN/subquery com heurística de custo
+
+**Status:** ⚠️ **Parcial (somente otimizações localizadas)**.
+
+- Válido otimizar `EXISTS` short-circuit e cache de subquery correlacionada em pontos críticos;
+- não recomendado introduzir framework de otimização novo nessa etapa.
+
+## 8) Semântica transacional por isolamento completo
+
+**Status:** ⚠️ **Parcial**.
+
+- Implementar subset mínimo por provider quando houver demanda clara de testes;
+- adiar modelagem ampla de isolation levels para fase posterior.
+
+## 9) `RETURNING` / `OUTPUT` / `RETURNING INTO`
+
+**Status:** ✅ **Válido**.
+
+- Já existe capability `SupportsReturning`; evolução natural é completar payload no executor por provider.
+- Priorizar PostgreSQL primeiro (menor ambiguidade no modelo atual).
+
+## 10) Collation/null ordering
+
+**Status:** ✅ **Válido com foco em centralização**.
+
+- Base existente: `TextComparison` e regras de comparação centralizadas.
+- Próximo passo: consolidar `NULLS FIRST/LAST` e manter `ORDER BY` coerente com dialect.
+
+---
+
+## O que foi considerado inválido no roadmap anterior
+
+- ❌ **Criar agora uma interface paralela grande (`IDialectCapabilities`)**.
+  - Motivo: o projeto já tem `ISqlDialect` robusto; criar outro contrato agora tende a duplicar regra e aumentar custo de manutenção/build.
+
+- ❌ **Troca ampla imediata para novo motor físico completo**.
+  - Motivo: alto risco de regressão antes de fechar gaps mais diretos de parser/executor já mapeados.
+
+---
+
+## Plano enxuto recomendado (sem quebrar build)
+
+1. **Parser gates + testes por versão** (CTE, paginação, JSON, hints, upsert).
+2. **Executor: completar semântica pendente por feature** (`RETURNING`, window extras, JSON subset).
+3. **Centralização de coerção/comparação** evitando duplicação por provider.
+4. **Hardening** com matriz fixa provider/versão antes de refatorações estruturais grandes.
+
+## Critérios de aceite para cada feature nova
+
+Uma implementação só entra se cumprir os quatro itens:
+
+- parser com gate em dialect;
+- executor sem regra duplicada por provider (apenas variação necessária);
+- testes por versão cobrindo aceitação/rejeição + semântica;
+- fallback padronizado (`SqlUnsupported` / `NotSupported`) quando não suportado.
+
+## Backlog revisado (ordem segura)
+
+1. `RANK/DENSE_RANK` no executor AST + testes por provider/versão.
+2. Completar `ON CONFLICT ... DO UPDATE` e `excluded` sem duplicar parsing.
+3. `MERGE` com subset estável e testes de regressão por SQL Server/DB2/Oracle.
+4. `RETURNING` funcional no executor para `INSERT/UPDATE/DELETE` (PostgreSQL primeiro).
+5. Consolidar comportamento de comparação/ordenação (`TextComparison`, `NULLS FIRST/LAST`).
+6. Expandir cobertura JSON por função/operador já gateada no dialect.
+
+## Referências relacionadas
+
+- [Provedores, versões e compatibilidade](providers-and-features.md)
+- [Matriz SQL (feature x dialeto)](sql-compatibility-matrix.md)
+- [Checklist de known gaps](known-gaps-checklist.md)
+- [Testes por versão de dialeto](testes-por-versao-dialect.md)

--- a/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
@@ -199,4 +199,162 @@ public sealed class Db2DialectFeatureParserTests
         Assert.True(d.SupportsTriggers);
     }
 
+    /// <summary>
+    /// EN: Validates known and unknown window function capability for DB2 dialect versions.
+    /// PT: Valida a capacidade de funções de janela conhecidas e desconhecidas nas versões do dialeto DB2.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void WindowFunctionCapability_ShouldAllowKnownAndRejectUnknownFunctions(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        Assert.True(dialect.SupportsWindowFunction("ROW_NUMBER"));
+        Assert.True(dialect.SupportsWindowFunction("CUME_DIST"));
+        Assert.False(dialect.SupportsWindowFunction("PERCENTILE_CONT"));
+    }
+
+    /// <summary>
+    /// EN: Ensures parser accepts known window functions and rejects unknown names for DB2 dialect versions.
+    /// PT: Garante que o parser aceite funções de janela conhecidas e rejeite nomes desconhecidos nas versões do DB2.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_WindowFunctionName_ShouldAllowKnownAndRejectUnknown(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var expr = SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id)", dialect);
+        Assert.IsType<WindowFunctionExpr>(expr);
+        Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("PERCENTILE_CONT(0.5) OVER (ORDER BY id)", dialect));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window functions that require ordering reject OVER clauses without ORDER BY.
+    /// PT: Garante que funções de janela que exigem ordenação rejeitem cláusulas OVER sem ORDER BY.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_WindowFunctionWithoutOrderBy_ShouldRespectDialectRules(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER ()", dialect));
+
+        Assert.Contains("requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures parser validates window function argument arity for supported functions.
+    /// PT: Garante que o parser valide a aridade dos argumentos de funções de janela suportadas.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_WindowFunctionArguments_ShouldValidateArity(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var exRowNumber = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER(1) OVER (ORDER BY id)", dialect));
+        Assert.Contains("does not accept arguments", exRowNumber.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exNtile = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTILE() OVER (ORDER BY id)", dialect));
+        Assert.Contains("exactly 1 argument", exNtile.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exLag = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LAG(id, 1, 0, 99) OVER (ORDER BY id)", dialect));
+        Assert.Contains("between 1 and 3 arguments", exLag.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures parser validates literal semantic ranges for window function arguments.
+    /// PT: Garante que o parser valide intervalos semânticos literais para argumentos de funções de janela.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_WindowFunctionLiteralArguments_ShouldValidateSemanticRange(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var exNtile = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTILE(0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("positive bucket count", exNtile.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exLag = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LAG(id, -1, 0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("non-negative offset", exLag.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exNthValue = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTH_VALUE(id, 0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("greater than zero", exNthValue.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ORDER BY requirement for window functions is exposed through dialect runtime hook.
+    /// PT: Garante que o requisito de ORDER BY para funções de janela seja exposto pelo hook de runtime do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void WindowFunctionOrderByRequirementHook_ShouldRespectVersion(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        Assert.True(dialect.RequiresOrderByInWindowFunction("ROW_NUMBER"));
+        Assert.True(dialect.RequiresOrderByInWindowFunction("LAG"));
+
+        Assert.False(dialect.RequiresOrderByInWindowFunction("COUNT"));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window function argument arity metadata is exposed through dialect hook.
+    /// PT: Garante que os metadados de aridade de argumentos de função de janela sejam expostos pelo hook do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void WindowFunctionArgumentArityHook_ShouldRespectVersion(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        Assert.True(dialect.TryGetWindowFunctionArgumentArity("ROW_NUMBER", out var rnMin, out var rnMax));
+        Assert.Equal(0, rnMin);
+        Assert.Equal(0, rnMax);
+
+        Assert.True(dialect.TryGetWindowFunctionArgumentArity("LAG", out var lagMin, out var lagMax));
+        Assert.Equal(1, lagMin);
+        Assert.Equal(3, lagMax);
+
+        Assert.False(dialect.TryGetWindowFunctionArgumentArity("COUNT", out _, out _));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window frame clause tokens are gated by dialect capability.
+    /// PT: Garante que tokens de cláusula de frame de janela sejam controlados pela capability do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_WindowFrameClause_ShouldBeRejectedByDialectCapability(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect));
+
+        Assert.Contains("window frame", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
@@ -272,4 +272,229 @@ public sealed class MySqlDialectFeatureParserTests
         Assert.Contains("OPTION", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Validates window function capability by MySQL version and function name.
+    /// PT: Valida a capacidade de funções de janela por versão do MySQL e nome da função.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void WindowFunctionCapability_ShouldRespectVersionAndKnownFunctions(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        var expected = version >= MySqlDialect.WindowFunctionsMinVersion;
+        Assert.Equal(expected, dialect.SupportsWindowFunction("ROW_NUMBER"));
+        Assert.Equal(expected, dialect.SupportsWindowFunction("RANK"));
+        Assert.False(dialect.SupportsWindowFunction("PERCENTILE_CONT"));
+    }
+
+    /// <summary>
+    /// EN: Ensures parser validates window function names against MySQL dialect capabilities by version.
+    /// PT: Garante que o parser valide nomes de função de janela contra as capacidades do dialeto MySQL por versão.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_WindowFunctionName_ShouldRespectDialectCapability(int version)
+    {
+        var supported = "ROW_NUMBER() OVER (ORDER BY id)";
+        var unsupported = "PERCENTILE_CONT(0.5) OVER (ORDER BY id)";
+        var dialect = new MySqlDialect(version);
+
+        if (version < MySqlDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar(supported, dialect));
+            return;
+        }
+
+        var expr = SqlExpressionParser.ParseScalar(supported, dialect);
+        Assert.IsType<WindowFunctionExpr>(expr);
+        Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar(unsupported, dialect));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window functions that require ordering reject OVER clauses without ORDER BY.
+    /// PT: Garante que funções de janela que exigem ordenação rejeitem cláusulas OVER sem ORDER BY.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_WindowFunctionWithoutOrderBy_ShouldRespectDialectRules(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        if (version < MySqlDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER ()", dialect));
+            return;
+        }
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER ()", dialect));
+
+        Assert.Contains("requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures parser validates window function argument arity for supported functions.
+    /// PT: Garante que o parser valide a aridade dos argumentos de funções de janela suportadas.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_WindowFunctionArguments_ShouldValidateArity(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        if (version < MySqlDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER(1) OVER (ORDER BY id)", dialect));
+            return;
+        }
+
+        var exRowNumber = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER(1) OVER (ORDER BY id)", dialect));
+        Assert.Contains("does not accept arguments", exRowNumber.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exNtile = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTILE() OVER (ORDER BY id)", dialect));
+        Assert.Contains("exactly 1 argument", exNtile.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exLag = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LAG(id, 1, 0, 99) OVER (ORDER BY id)", dialect));
+        Assert.Contains("between 1 and 3 arguments", exLag.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures parser validates literal semantic ranges for window function arguments.
+    /// PT: Garante que o parser valide intervalos semânticos literais para argumentos de funções de janela.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_WindowFunctionLiteralArguments_ShouldValidateSemanticRange(int version)
+    {
+        var dialect = new MySqlDialect(version);
+        if (version < MySqlDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("NTILE(0) OVER (ORDER BY id)", dialect));
+            return;
+        }
+
+
+        var exNtile = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTILE(0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("positive bucket count", exNtile.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exLag = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LAG(id, -1, 0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("non-negative offset", exLag.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exNthValue = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTH_VALUE(id, 0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("greater than zero", exNthValue.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ORDER BY requirement for window functions is exposed through dialect runtime hook.
+    /// PT: Garante que o requisito de ORDER BY para funções de janela seja exposto pelo hook de runtime do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void WindowFunctionOrderByRequirementHook_ShouldRespectVersion(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        var expected = version >= MySqlDialect.WindowFunctionsMinVersion;
+        Assert.Equal(expected, dialect.RequiresOrderByInWindowFunction("ROW_NUMBER"));
+        Assert.Equal(expected, dialect.RequiresOrderByInWindowFunction("LAG"));
+
+        Assert.False(dialect.RequiresOrderByInWindowFunction("COUNT"));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window function argument arity metadata is exposed through dialect hook.
+    /// PT: Garante que os metadados de aridade de argumentos de função de janela sejam expostos pelo hook do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void WindowFunctionArgumentArityHook_ShouldRespectVersion(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        if (version < MySqlDialect.WindowFunctionsMinVersion)
+        {
+            Assert.False(dialect.TryGetWindowFunctionArgumentArity("ROW_NUMBER", out _, out _));
+            return;
+        }
+
+        Assert.True(dialect.TryGetWindowFunctionArgumentArity("ROW_NUMBER", out var rnMin, out var rnMax));
+        Assert.Equal(0, rnMin);
+        Assert.Equal(0, rnMax);
+
+        Assert.True(dialect.TryGetWindowFunctionArgumentArity("LAG", out var lagMin, out var lagMax));
+        Assert.Equal(1, lagMin);
+        Assert.Equal(3, lagMax);
+
+        Assert.False(dialect.TryGetWindowFunctionArgumentArity("COUNT", out _, out _));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ROWS window frame clauses parse when supported and RANGE remains gated.
+    /// PT: Garante que cláusulas ROWS de frame de janela sejam interpretadas quando suportadas e que RANGE continue bloqueado.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_WindowFrameClause_ShouldRespectDialectCapabilities(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        if (version < MySqlDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect));
+            return;
+        }
+
+        var expr = SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect);
+        Assert.IsType<WindowFunctionExpr>(expr);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect));
+        Assert.Contains("window frame unit", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures invalid window frame bound ordering is rejected by parser semantic validation.
+    /// PT: Garante que ordenação inválida de limites de frame de janela seja rejeitada pela validação semântica do parser.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_WindowFrameClauseInvalidBounds_ShouldBeRejected(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        if (version < MySqlDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 PRECEDING)", dialect));
+            return;
+        }
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 PRECEDING)", dialect));
+
+        Assert.Contains("start bound cannot be greater", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.MySql/MySqlDialect.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDialect.cs
@@ -127,6 +127,12 @@ internal sealed class MySqlDialect : SqlDialectBase
     /// PT: Indica se funções de janela SQL são suportadas pela versão configurada do MySQL.
     /// </summary>
     public override bool SupportsWindowFunctions => Version >= WindowFunctionsMinVersion;
+
+    /// <summary>
+    /// EN: Indicates whether SQL window frame clauses are supported by the configured version.
+    /// PT: Indica se cláusulas de frame de janela SQL são suportadas pela versão configurada.
+    /// </summary>
+    public override bool SupportsWindowFrameClause => Version >= WindowFunctionsMinVersion;
     /// <summary>
     /// EN: Gets or sets SupportsNullSafeEq.
     /// PT: Obtém ou define SupportsNullSafeEq.

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
@@ -38,6 +38,7 @@ internal sealed class NpgsqlDialect : SqlDialectBase
     internal const int WithCteMinVersion = 6;
     internal const int MergeMinVersion = 15;
     internal const int JsonbMinVersion = 9;
+    internal const int WindowFunctionsMinVersion = 8;
 
     /// <summary>
     /// EN: Gets or sets identifier escape style.
@@ -78,6 +79,18 @@ internal sealed class NpgsqlDialect : SqlDialectBase
     /// PT: Obtém se há suporte a limit offset.
     /// </summary>
     public override bool SupportsLimitOffset => true;
+
+    /// <summary>
+    /// EN: Indicates whether SQL window functions are supported by the configured PostgreSQL version.
+    /// PT: Indica se funções de janela SQL são suportadas pela versão configurada do PostgreSQL.
+    /// </summary>
+    public override bool SupportsWindowFunctions => Version >= WindowFunctionsMinVersion;
+
+    /// <summary>
+    /// EN: Indicates whether SQL window frame clauses are supported by the configured version.
+    /// PT: Indica se cláusulas de frame de janela SQL são suportadas pela versão configurada.
+    /// </summary>
+    public override bool SupportsWindowFrameClause => Version >= WindowFunctionsMinVersion;
     /// <summary>
     /// EN: Gets whether fetch first is supported.
     /// PT: Obtém se há suporte a fetch first.

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
@@ -149,4 +149,229 @@ public sealed class OracleDialectFeatureParserTests
         Assert.Contains("oracle", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Validates window function capability by Oracle version and function name.
+    /// PT: Valida a capacidade de funções de janela por versão do Oracle e nome da função.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void WindowFunctionCapability_ShouldRespectVersionAndKnownFunctions(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        var expected = version >= OracleDialect.WindowFunctionsMinVersion;
+        Assert.Equal(expected, dialect.SupportsWindowFunction("ROW_NUMBER"));
+        Assert.Equal(expected, dialect.SupportsWindowFunction("NTILE"));
+        Assert.False(dialect.SupportsWindowFunction("PERCENTILE_CONT"));
+    }
+
+    /// <summary>
+    /// EN: Ensures parser validates window function names against Oracle dialect capabilities by version.
+    /// PT: Garante que o parser valide nomes de função de janela contra as capacidades do dialeto Oracle por versão.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_WindowFunctionName_ShouldRespectDialectCapability(int version)
+    {
+        var supported = "ROW_NUMBER() OVER (ORDER BY id)";
+        var unsupported = "PERCENTILE_CONT(0.5) OVER (ORDER BY id)";
+        var dialect = new OracleDialect(version);
+
+        if (version < OracleDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar(supported, dialect));
+            return;
+        }
+
+        var expr = SqlExpressionParser.ParseScalar(supported, dialect);
+        Assert.IsType<WindowFunctionExpr>(expr);
+        Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar(unsupported, dialect));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window functions that require ordering reject OVER clauses without ORDER BY.
+    /// PT: Garante que funções de janela que exigem ordenação rejeitem cláusulas OVER sem ORDER BY.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_WindowFunctionWithoutOrderBy_ShouldRespectDialectRules(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        if (version < OracleDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER ()", dialect));
+            return;
+        }
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER ()", dialect));
+
+        Assert.Contains("requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures parser validates window function argument arity for supported functions.
+    /// PT: Garante que o parser valide a aridade dos argumentos de funções de janela suportadas.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_WindowFunctionArguments_ShouldValidateArity(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        if (version < OracleDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER(1) OVER (ORDER BY id)", dialect));
+            return;
+        }
+
+        var exRowNumber = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER(1) OVER (ORDER BY id)", dialect));
+        Assert.Contains("does not accept arguments", exRowNumber.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exNtile = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTILE() OVER (ORDER BY id)", dialect));
+        Assert.Contains("exactly 1 argument", exNtile.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exLag = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LAG(id, 1, 0, 99) OVER (ORDER BY id)", dialect));
+        Assert.Contains("between 1 and 3 arguments", exLag.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures parser validates literal semantic ranges for window function arguments.
+    /// PT: Garante que o parser valide intervalos semânticos literais para argumentos de funções de janela.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_WindowFunctionLiteralArguments_ShouldValidateSemanticRange(int version)
+    {
+        var dialect = new OracleDialect(version);
+        if (version < OracleDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("NTILE(0) OVER (ORDER BY id)", dialect));
+            return;
+        }
+
+
+        var exNtile = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTILE(0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("positive bucket count", exNtile.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exLag = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LAG(id, -1, 0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("non-negative offset", exLag.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exNthValue = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTH_VALUE(id, 0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("greater than zero", exNthValue.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ORDER BY requirement for window functions is exposed through dialect runtime hook.
+    /// PT: Garante que o requisito de ORDER BY para funções de janela seja exposto pelo hook de runtime do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void WindowFunctionOrderByRequirementHook_ShouldRespectVersion(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        var expected = version >= OracleDialect.WindowFunctionsMinVersion;
+        Assert.Equal(expected, dialect.RequiresOrderByInWindowFunction("ROW_NUMBER"));
+        Assert.Equal(expected, dialect.RequiresOrderByInWindowFunction("LAG"));
+
+        Assert.False(dialect.RequiresOrderByInWindowFunction("COUNT"));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window function argument arity metadata is exposed through dialect hook.
+    /// PT: Garante que os metadados de aridade de argumentos de função de janela sejam expostos pelo hook do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void WindowFunctionArgumentArityHook_ShouldRespectVersion(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        if (version < OracleDialect.WindowFunctionsMinVersion)
+        {
+            Assert.False(dialect.TryGetWindowFunctionArgumentArity("ROW_NUMBER", out _, out _));
+            return;
+        }
+
+        Assert.True(dialect.TryGetWindowFunctionArgumentArity("ROW_NUMBER", out var rnMin, out var rnMax));
+        Assert.Equal(0, rnMin);
+        Assert.Equal(0, rnMax);
+
+        Assert.True(dialect.TryGetWindowFunctionArgumentArity("LAG", out var lagMin, out var lagMax));
+        Assert.Equal(1, lagMin);
+        Assert.Equal(3, lagMax);
+
+        Assert.False(dialect.TryGetWindowFunctionArgumentArity("COUNT", out _, out _));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ROWS window frame clauses parse when supported and RANGE remains gated.
+    /// PT: Garante que cláusulas ROWS de frame de janela sejam interpretadas quando suportadas e que RANGE continue bloqueado.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_WindowFrameClause_ShouldRespectDialectCapabilities(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        if (version < OracleDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect));
+            return;
+        }
+
+        var expr = SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect);
+        Assert.IsType<WindowFunctionExpr>(expr);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect));
+        Assert.Contains("window frame unit", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures invalid window frame bound ordering is rejected by parser semantic validation.
+    /// PT: Garante que ordenação inválida de limites de frame de janela seja rejeitada pela validação semântica do parser.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_WindowFrameClauseInvalidBounds_ShouldBeRejected(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        if (version < OracleDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 PRECEDING)", dialect));
+            return;
+        }
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 PRECEDING)", dialect));
+
+        Assert.Contains("start bound cannot be greater", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.Oracle/OracleDialect.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDialect.cs
@@ -30,6 +30,7 @@ internal sealed class OracleDialect : SqlDialectBase
 
     internal const int WithCteMinVersion = 9;
     internal const int MergeMinVersion = 9;
+    internal const int WindowFunctionsMinVersion = 8;
     internal const int OffsetFetchMinVersion = 12;
     internal const int FetchFirstMinVersion = 12;
 
@@ -66,6 +67,18 @@ internal sealed class OracleDialect : SqlDialectBase
     /// PT: Obtém se há suporte a fetch first.
     /// </summary>
     public override bool SupportsFetchFirst => Version >= FetchFirstMinVersion;
+
+    /// <summary>
+    /// EN: Indicates whether SQL window functions are supported by the configured Oracle version.
+    /// PT: Indica se funções de janela SQL são suportadas pela versão configurada do Oracle.
+    /// </summary>
+    public override bool SupportsWindowFunctions => Version >= WindowFunctionsMinVersion;
+
+    /// <summary>
+    /// EN: Indicates whether SQL window frame clauses are supported by the configured version.
+    /// PT: Indica se cláusulas de frame de janela SQL são suportadas pela versão configurada.
+    /// </summary>
+    public override bool SupportsWindowFrameClause => Version >= WindowFunctionsMinVersion;
     /// <summary>
     /// EN: Gets whether order by nulls modifier is supported.
     /// PT: Obtém se há suporte a order by nulls modifier.

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
@@ -215,4 +215,229 @@ public sealed class SqlServerDialectFeatureParserTests
         Assert.Contains("sqlserver", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Validates window function capability by SQL Server version and function name.
+    /// PT: Valida a capacidade de funções de janela por versão do SQL Server e nome da função.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void WindowFunctionCapability_ShouldRespectVersionAndKnownFunctions(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        var expected = version >= SqlServerDialect.WindowFunctionsMinVersion;
+        Assert.Equal(expected, dialect.SupportsWindowFunction("ROW_NUMBER"));
+        Assert.Equal(expected, dialect.SupportsWindowFunction("DENSE_RANK"));
+        Assert.False(dialect.SupportsWindowFunction("PERCENTILE_CONT"));
+    }
+
+    /// <summary>
+    /// EN: Ensures parser validates window function names against SQL Server dialect capabilities by version.
+    /// PT: Garante que o parser valide nomes de função de janela contra as capacidades do dialeto SQL Server por versão.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_WindowFunctionName_ShouldRespectDialectCapability(int version)
+    {
+        var supported = "ROW_NUMBER() OVER (ORDER BY id)";
+        var unsupported = "PERCENTILE_CONT(0.5) OVER (ORDER BY id)";
+        var dialect = new SqlServerDialect(version);
+
+        if (version < SqlServerDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar(supported, dialect));
+            return;
+        }
+
+        var expr = SqlExpressionParser.ParseScalar(supported, dialect);
+        Assert.IsType<WindowFunctionExpr>(expr);
+        Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar(unsupported, dialect));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window functions that require ordering reject OVER clauses without ORDER BY.
+    /// PT: Garante que funções de janela que exigem ordenação rejeitem cláusulas OVER sem ORDER BY.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_WindowFunctionWithoutOrderBy_ShouldRespectDialectRules(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        if (version < SqlServerDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER ()", dialect));
+            return;
+        }
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER ()", dialect));
+
+        Assert.Contains("requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures parser validates window function argument arity for supported functions.
+    /// PT: Garante que o parser valide a aridade dos argumentos de funções de janela suportadas.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_WindowFunctionArguments_ShouldValidateArity(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        if (version < SqlServerDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER(1) OVER (ORDER BY id)", dialect));
+            return;
+        }
+
+        var exRowNumber = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER(1) OVER (ORDER BY id)", dialect));
+        Assert.Contains("does not accept arguments", exRowNumber.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exNtile = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTILE() OVER (ORDER BY id)", dialect));
+        Assert.Contains("exactly 1 argument", exNtile.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exLag = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LAG(id, 1, 0, 99) OVER (ORDER BY id)", dialect));
+        Assert.Contains("between 1 and 3 arguments", exLag.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures parser validates literal semantic ranges for window function arguments.
+    /// PT: Garante que o parser valide intervalos semânticos literais para argumentos de funções de janela.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_WindowFunctionLiteralArguments_ShouldValidateSemanticRange(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+        if (version < SqlServerDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("NTILE(0) OVER (ORDER BY id)", dialect));
+            return;
+        }
+
+
+        var exNtile = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTILE(0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("positive bucket count", exNtile.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exLag = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LAG(id, -1, 0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("non-negative offset", exLag.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exNthValue = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTH_VALUE(id, 0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("greater than zero", exNthValue.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ORDER BY requirement for window functions is exposed through dialect runtime hook.
+    /// PT: Garante que o requisito de ORDER BY para funções de janela seja exposto pelo hook de runtime do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void WindowFunctionOrderByRequirementHook_ShouldRespectVersion(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        var expected = version >= SqlServerDialect.WindowFunctionsMinVersion;
+        Assert.Equal(expected, dialect.RequiresOrderByInWindowFunction("ROW_NUMBER"));
+        Assert.Equal(expected, dialect.RequiresOrderByInWindowFunction("LAG"));
+
+        Assert.False(dialect.RequiresOrderByInWindowFunction("COUNT"));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window function argument arity metadata is exposed through dialect hook.
+    /// PT: Garante que os metadados de aridade de argumentos de função de janela sejam expostos pelo hook do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void WindowFunctionArgumentArityHook_ShouldRespectVersion(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        if (version < SqlServerDialect.WindowFunctionsMinVersion)
+        {
+            Assert.False(dialect.TryGetWindowFunctionArgumentArity("ROW_NUMBER", out _, out _));
+            return;
+        }
+
+        Assert.True(dialect.TryGetWindowFunctionArgumentArity("ROW_NUMBER", out var rnMin, out var rnMax));
+        Assert.Equal(0, rnMin);
+        Assert.Equal(0, rnMax);
+
+        Assert.True(dialect.TryGetWindowFunctionArgumentArity("LAG", out var lagMin, out var lagMax));
+        Assert.Equal(1, lagMin);
+        Assert.Equal(3, lagMax);
+
+        Assert.False(dialect.TryGetWindowFunctionArgumentArity("COUNT", out _, out _));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ROWS window frame clauses parse when supported and RANGE remains gated.
+    /// PT: Garante que cláusulas ROWS de frame de janela sejam interpretadas quando suportadas e que RANGE continue bloqueado.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_WindowFrameClause_ShouldRespectDialectCapabilities(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        if (version < SqlServerDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect));
+            return;
+        }
+
+        var expr = SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect);
+        Assert.IsType<WindowFunctionExpr>(expr);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect));
+        Assert.Contains("window frame unit", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures invalid window frame bound ordering is rejected by parser semantic validation.
+    /// PT: Garante que ordenação inválida de limites de frame de janela seja rejeitada pela validação semântica do parser.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_WindowFrameClauseInvalidBounds_ShouldBeRejected(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        if (version < SqlServerDialect.WindowFunctionsMinVersion)
+        {
+            Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 PRECEDING)", dialect));
+            return;
+        }
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 PRECEDING)", dialect));
+
+        Assert.Contains("start bound cannot be greater", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
@@ -32,6 +32,7 @@ internal sealed class SqlServerDialect : SqlDialectBase
     internal const int MergeMinVersion = 2008;
     internal const int OffsetFetchMinVersion = 2012;
     internal const int JsonFunctionsMinVersion = 2016;
+    internal const int WindowFunctionsMinVersion = 2005;
 
     /// <summary>
     /// EN: Gets or sets allows bracket identifiers.
@@ -66,6 +67,18 @@ internal sealed class SqlServerDialect : SqlDialectBase
     /// PT: Obtém se há suporte a top.
     /// </summary>
     public override bool SupportsTop => true;
+
+    /// <summary>
+    /// EN: Indicates whether SQL window functions are supported by the configured SQL Server version.
+    /// PT: Indica se funções de janela SQL são suportadas pela versão configurada do SQL Server.
+    /// </summary>
+    public override bool SupportsWindowFunctions => Version >= WindowFunctionsMinVersion;
+
+    /// <summary>
+    /// EN: Indicates whether SQL window frame clauses are supported by the configured version.
+    /// PT: Indica se cláusulas de frame de janela SQL são suportadas pela versão configurada.
+    /// </summary>
+    public override bool SupportsWindowFrameClause => Version >= WindowFunctionsMinVersion;
 
     // OFFSET ... FETCH entrou no SQL Server 2012.
     /// <summary>

--- a/src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAdvancedSqlGapTests.cs
@@ -158,6 +158,63 @@ ORDER BY id").ToList();
         Assert.Equal(["Jane", "Jane", "Jane"], [.. rows.Select(r => (string)r.last_name)]);
     }
 
+    /// <summary>
+    /// EN: Tests Window_FirstLastValue_WithRowsCurrentRowFrame_ShouldRespectFrame behavior.
+    /// PT: Testa o comportamento de Window_FirstLastValue_WithRowsCurrentRowFrame_ShouldRespectFrame.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_FirstLastValue_WithRowsCurrentRowFrame_ShouldRespectFrame()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(name) OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS first_name,
+       LAST_VALUE(name) OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS last_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["John", "Bob", "Jane"], [.. rows.Select(r => (string)r.first_name)]);
+        Assert.Equal(["John", "Bob", "Jane"], [.. rows.Select(r => (string)r.last_name)]);
+    }
+
+    /// <summary>
+    /// EN: Tests Window_FirstLastValue_WithRowsSlidingFrame_ShouldRespectFrame behavior.
+    /// PT: Testa o comportamento de Window_FirstLastValue_WithRowsSlidingFrame_ShouldRespectFrame.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_FirstLastValue_WithRowsSlidingFrame_ShouldRespectFrame()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(name) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS first_name,
+       LAST_VALUE(name) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS last_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["John", "John", "Bob"], [.. rows.Select(r => (string)r.first_name)]);
+        Assert.Equal(["John", "Bob", "Jane"], [.. rows.Select(r => (string)r.last_name)]);
+    }
+
+    /// <summary>
+    /// EN: Tests Window_FirstLastValue_WithRowsForwardFrame_ShouldRespectFrame behavior.
+    /// PT: Testa o comportamento de Window_FirstLastValue_WithRowsForwardFrame_ShouldRespectFrame.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_FirstLastValue_WithRowsForwardFrame_ShouldRespectFrame()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(name) OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS first_name,
+       LAST_VALUE(name) OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS last_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["John", "Bob", "Jane"], [.. rows.Select(r => (string)r.first_name)]);
+        Assert.Equal(["Bob", "Jane", "Jane"], [.. rows.Select(r => (string)r.last_name)]);
+    }
+
 
     /// <summary>
     /// EN: Tests Window_NthValue_ShouldWork behavior.
@@ -174,6 +231,57 @@ FROM users
 ORDER BY id").ToList();
 
         Assert.Equal(["Bob", "Bob", "Bob"], [.. rows.Select(r => (string)r.second_name)]);
+    }
+
+    /// <summary>
+    /// EN: Tests Window_NthValue_WithRowsCurrentRowFrame_ShouldReturnNull behavior.
+    /// PT: Testa o comportamento de Window_NthValue_WithRowsCurrentRowFrame_ShouldReturnNull.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_NthValue_WithRowsCurrentRowFrame_ShouldReturnNull()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTH_VALUE(name, 2) OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND CURRENT ROW) AS second_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([null, null, null], [.. rows.Select(r => (string?)r.second_name)]);
+    }
+
+    /// <summary>
+    /// EN: Tests Window_NthValue_WithRowsSlidingFrame_ShouldResolvePerRow behavior.
+    /// PT: Testa o comportamento de Window_NthValue_WithRowsSlidingFrame_ShouldResolvePerRow.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_NthValue_WithRowsSlidingFrame_ShouldResolvePerRow()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTH_VALUE(name, 2) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS second_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([null, "Bob", "Jane"], [.. rows.Select(r => (string?)r.second_name)]);
+    }
+
+    /// <summary>
+    /// EN: Tests Window_NthValue_WithRowsForwardFrame_ShouldResolvePerRow behavior.
+    /// PT: Testa o comportamento de Window_NthValue_WithRowsForwardFrame_ShouldResolvePerRow.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAdvancedSqlGap")]
+    public void Window_NthValue_WithRowsForwardFrame_ShouldResolvePerRow()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       NTH_VALUE(name, 2) OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS second_name
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal(["Bob", "Jane", null], [.. rows.Select(r => (string?)r.second_name)]);
     }
 
 

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
@@ -165,4 +165,162 @@ public sealed class SqliteDialectFeatureParserTests
         Assert.True(d.SupportsTriggers);
     }
 
+    /// <summary>
+    /// EN: Validates known and unknown window function capability for SQLite dialect versions.
+    /// PT: Valida a capacidade de funções de janela conhecidas e desconhecidas nas versões do dialeto SQLite.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void WindowFunctionCapability_ShouldAllowKnownAndRejectUnknownFunctions(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        Assert.True(dialect.SupportsWindowFunction("ROW_NUMBER"));
+        Assert.True(dialect.SupportsWindowFunction("FIRST_VALUE"));
+        Assert.False(dialect.SupportsWindowFunction("PERCENTILE_CONT"));
+    }
+
+    /// <summary>
+    /// EN: Ensures parser accepts known window functions and rejects unknown names for SQLite dialect versions.
+    /// PT: Garante que o parser aceite funções de janela conhecidas e rejeite nomes desconhecidos nas versões do SQLite.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_WindowFunctionName_ShouldAllowKnownAndRejectUnknown(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var expr = SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id)", dialect);
+        Assert.IsType<WindowFunctionExpr>(expr);
+        Assert.Throws<NotSupportedException>(() => SqlExpressionParser.ParseScalar("PERCENTILE_CONT(0.5) OVER (ORDER BY id)", dialect));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window functions that require ordering reject OVER clauses without ORDER BY.
+    /// PT: Garante que funções de janela que exigem ordenação rejeitem cláusulas OVER sem ORDER BY.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_WindowFunctionWithoutOrderBy_ShouldRespectDialectRules(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER ()", dialect));
+
+        Assert.Contains("requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures parser validates window function argument arity for supported functions.
+    /// PT: Garante que o parser valide a aridade dos argumentos de funções de janela suportadas.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_WindowFunctionArguments_ShouldValidateArity(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var exRowNumber = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER(1) OVER (ORDER BY id)", dialect));
+        Assert.Contains("does not accept arguments", exRowNumber.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exNtile = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTILE() OVER (ORDER BY id)", dialect));
+        Assert.Contains("exactly 1 argument", exNtile.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exLag = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LAG(id, 1, 0, 99) OVER (ORDER BY id)", dialect));
+        Assert.Contains("between 1 and 3 arguments", exLag.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures parser validates literal semantic ranges for window function arguments.
+    /// PT: Garante que o parser valide intervalos semânticos literais para argumentos de funções de janela.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_WindowFunctionLiteralArguments_ShouldValidateSemanticRange(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var exNtile = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTILE(0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("positive bucket count", exNtile.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exLag = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LAG(id, -1, 0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("non-negative offset", exLag.Message, StringComparison.OrdinalIgnoreCase);
+
+        var exNthValue = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("NTH_VALUE(id, 0) OVER (ORDER BY id)", dialect));
+        Assert.Contains("greater than zero", exNthValue.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ORDER BY requirement for window functions is exposed through dialect runtime hook.
+    /// PT: Garante que o requisito de ORDER BY para funções de janela seja exposto pelo hook de runtime do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void WindowFunctionOrderByRequirementHook_ShouldRespectVersion(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        Assert.True(dialect.RequiresOrderByInWindowFunction("ROW_NUMBER"));
+        Assert.True(dialect.RequiresOrderByInWindowFunction("LAG"));
+
+        Assert.False(dialect.RequiresOrderByInWindowFunction("COUNT"));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window function argument arity metadata is exposed through dialect hook.
+    /// PT: Garante que os metadados de aridade de argumentos de função de janela sejam expostos pelo hook do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void WindowFunctionArgumentArityHook_ShouldRespectVersion(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        Assert.True(dialect.TryGetWindowFunctionArgumentArity("ROW_NUMBER", out var rnMin, out var rnMax));
+        Assert.Equal(0, rnMin);
+        Assert.Equal(0, rnMax);
+
+        Assert.True(dialect.TryGetWindowFunctionArgumentArity("LAG", out var lagMin, out var lagMax));
+        Assert.Equal(1, lagMin);
+        Assert.Equal(3, lagMax);
+
+        Assert.False(dialect.TryGetWindowFunctionArgumentArity("COUNT", out _, out _));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures window frame clause tokens are gated by dialect capability.
+    /// PT: Garante que tokens de cláusula de frame de janela sejam controlados pela capability do dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_WindowFrameClause_ShouldBeRejectedByDialectCapability(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("ROW_NUMBER() OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)", dialect));
+
+        Assert.Contains("window frame", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem/Parser/ExprAst.cs
+++ b/src/DbSqlLikeMem/Parser/ExprAst.cs
@@ -19,8 +19,15 @@ internal sealed record FunctionCallExpr(string Name, IReadOnlyList<SqlExpr> Args
 internal sealed record JsonAccessExpr(SqlExpr Target, SqlExpr Path, bool Unquote) : SqlExpr;
 internal sealed record CallExpr(string Name, IReadOnlyList<SqlExpr> Args, bool Distinct = false) : SqlExpr;
 internal sealed record WindowFunctionExpr(string Name, IReadOnlyList<SqlExpr> Args, WindowSpec Spec, bool Distinct = false) : SqlExpr;
-internal sealed record WindowSpec(IReadOnlyList<SqlExpr> PartitionBy, IReadOnlyList<WindowOrderItem> OrderBy);
+internal sealed record WindowSpec(
+    IReadOnlyList<SqlExpr> PartitionBy,
+    IReadOnlyList<WindowOrderItem> OrderBy,
+    WindowFrameSpec? Frame = null);
 internal sealed record WindowOrderItem(SqlExpr Expr, bool Desc);
+internal enum WindowFrameUnit { Rows, Range, Groups }
+internal enum WindowFrameBoundKind { UnboundedPreceding, Preceding, CurrentRow, Following, UnboundedFollowing }
+internal sealed record WindowFrameBound(WindowFrameBoundKind Kind, int? Offset);
+internal sealed record WindowFrameSpec(WindowFrameUnit Unit, WindowFrameBound Start, WindowFrameBound End);
 internal sealed record BetweenExpr(
     SqlExpr Expr,
     SqlExpr Low,

--- a/src/DbSqlLikeMem/Parser/SqlExpressionParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlExpressionParser.cs
@@ -860,8 +860,12 @@ internal sealed class SqlExpressionParser(
             // ✅ Window function: ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)
             if (IsKeywordOrIdentifierWord(Peek(), "OVER"))
             {
+                EnsureWindowFunctionSupport(call.Name);
+                EnsureWindowFunctionArguments(call.Name, call.Args);
+
                 Consume(); // OVER
                 var spec = ParseWindowSpec();
+                EnsureWindowSpecSupport(call.Name, spec);
                 expr = new WindowFunctionExpr(call.Name, call.Args, spec, call.Distinct);
                 return true;
             }
@@ -872,6 +876,138 @@ internal sealed class SqlExpressionParser(
 
         expr = ParseIdentifierChainOrColumn(name);
         return true;
+    }
+
+
+    /// <summary>
+    /// EN: Validates whether a window function name is supported by the current dialect/version.
+    /// PT: Valida se o nome da função de janela é suportado pelo dialeto/versão atual.
+    /// </summary>
+    private void EnsureWindowFunctionSupport(string functionName)
+    {
+        if (!_dialect.SupportsWindowFunctions || !_dialect.SupportsWindowFunction(functionName))
+            throw SqlUnsupported.ForDialect(_dialect, $"window functions ({functionName})");
+    }
+
+
+
+    /// <summary>
+    /// EN: Validates argument count and basic literal semantics for supported window functions.
+    /// PT: Valida a quantidade de argumentos e semântica literal básica para funções de janela suportadas.
+    /// </summary>
+    private void EnsureWindowFunctionArguments(string functionName, IReadOnlyList<SqlExpr> args)
+    {
+        var argCount = args.Count;
+        if (argCount < 0)
+            throw Error("Invalid window function argument count.", Peek());
+
+        if (!_dialect.TryGetWindowFunctionArgumentArity(functionName, out var minArgs, out var maxArgs))
+            return;
+
+        if (minArgs == maxArgs && argCount != minArgs)
+        {
+            var message = minArgs == 0
+                ? $"Window function '{functionName}' does not accept arguments."
+                : $"Window function '{functionName}' requires exactly {minArgs} argument{(minArgs == 1 ? "" : "s")}.";
+            throw Error(message, Peek());
+        }
+
+        if (argCount < minArgs || argCount > maxArgs)
+            throw Error($"Window function '{functionName}' requires between {minArgs} and {maxArgs} arguments.", Peek());
+
+        EnsureWindowFunctionArgumentLiteralRanges(functionName, args);
+    }
+
+    /// <summary>
+    /// EN: Validates literal-only value ranges for selected window function arguments.
+    /// PT: Valida intervalos de valores apenas para literais em argumentos selecionados de funções de janela.
+    /// </summary>
+    private void EnsureWindowFunctionArgumentLiteralRanges(string functionName, IReadOnlyList<SqlExpr> args)
+    {
+        if (functionName.Equals("NTILE", StringComparison.OrdinalIgnoreCase)
+            && args.Count >= 1
+            && TryReadIntegralLiteral(args[0], out var ntileBuckets)
+            && ntileBuckets <= 0)
+            throw Error("Window function 'NTILE' requires a positive bucket count.", Peek());
+
+        if ((functionName.Equals("LAG", StringComparison.OrdinalIgnoreCase)
+            || functionName.Equals("LEAD", StringComparison.OrdinalIgnoreCase))
+            && args.Count >= 2
+            && TryReadIntegralLiteral(args[1], out var lagLeadOffset)
+            && lagLeadOffset < 0)
+            throw Error($"Window function '{functionName}' requires a non-negative offset.", Peek());
+
+        if (functionName.Equals("NTH_VALUE", StringComparison.OrdinalIgnoreCase)
+            && args.Count >= 2
+            && TryReadIntegralLiteral(args[1], out var nthIndex)
+            && nthIndex <= 0)
+            throw Error("Window function 'NTH_VALUE' requires position argument greater than zero.", Peek());
+    }
+
+    /// <summary>
+    /// EN: Attempts to read an integer literal value from an expression argument.
+    /// PT: Tenta ler um valor literal inteiro de um argumento de expressão.
+    /// </summary>
+    private static bool TryReadIntegralLiteral(SqlExpr expr, out long value)
+    {
+        value = default;
+        if (expr is not LiteralExpr { Value: not null and not DBNull and IConvertible literalValue })
+            return false;
+
+        try
+        {
+            value = Convert.ToInt64(literalValue, CultureInfo.InvariantCulture);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// EN: Validates semantic window specification requirements for each supported function.
+    /// PT: Valida os requisitos semânticos da especificação de janela para cada função suportada.
+    /// </summary>
+    private void EnsureWindowSpecSupport(string functionName, WindowSpec spec)
+    {
+        ArgumentNullExceptionCompatible.ThrowIfNull(spec, nameof(spec));
+
+        if (_dialect.RequiresOrderByInWindowFunction(functionName) && spec.OrderBy.Count == 0)
+            throw Error($"Window function '{functionName}' requires ORDER BY in OVER clause.", Peek());
+
+        if (spec.Frame is not null)
+            EnsureWindowFrameSemanticRange(spec.Frame);
+    }
+
+    /// <summary>
+    /// EN: Validates whether a parsed window frame has a coherent start/end ordering.
+    /// PT: Valida se um frame de janela interpretado possui ordenação coerente de início/fim.
+    /// </summary>
+    private void EnsureWindowFrameSemanticRange(WindowFrameSpec frame)
+    {
+        var startRank = GetWindowFrameBoundRank(frame.Start);
+        var endRank = GetWindowFrameBoundRank(frame.End);
+
+        if (startRank > endRank)
+            throw Error("Window frame start bound cannot be greater than end bound.", Peek());
+    }
+
+    /// <summary>
+    /// EN: Converts a window frame bound into an ordered rank for semantic comparison.
+    /// PT: Converte um limite de frame de janela em rank ordenável para comparação semântica.
+    /// </summary>
+    private static long GetWindowFrameBoundRank(WindowFrameBound bound)
+    {
+        return bound.Kind switch
+        {
+            WindowFrameBoundKind.UnboundedPreceding => long.MinValue,
+            WindowFrameBoundKind.Preceding => -bound.Offset.GetValueOrDefault(),
+            WindowFrameBoundKind.CurrentRow => 0,
+            WindowFrameBoundKind.Following => bound.Offset.GetValueOrDefault(),
+            WindowFrameBoundKind.UnboundedFollowing => long.MaxValue,
+            _ => 0
+        };
     }
 
     private CallExpr ParseCallAfterName(string name)
@@ -1063,6 +1199,7 @@ internal sealed class SqlExpressionParser(
 
         var parts = new List<SqlExpr>();
         var order = new List<WindowOrderItem>();
+        WindowFrameSpec? frame = null;
 
         // PARTITION BY ...
         if (IsKeywordOrIdentifierWord(Peek(), "PARTITION"))
@@ -1106,8 +1243,119 @@ internal sealed class SqlExpressionParser(
             }
         }
 
+        if (IsKeywordOrIdentifierWord(Peek(), "ROWS")
+            || IsKeywordOrIdentifierWord(Peek(), "RANGE")
+            || IsKeywordOrIdentifierWord(Peek(), "GROUPS"))
+        {
+            if (!_dialect.SupportsWindowFrameClause)
+                throw SqlUnsupported.ForDialect(_dialect, "window frame clause (ROWS/RANGE/GROUPS)");
+
+            frame = ParseWindowFrameClause();
+        }
+
         ExpectSymbol(")");
-        return new WindowSpec(parts, order);
+        return new WindowSpec(parts, order, frame);
+    }
+
+    /// <summary>
+    /// EN: Parses a simplified SQL window frame clause.
+    /// PT: Faz o parse de uma cláusula simplificada de frame de janela SQL.
+    /// </summary>
+    private WindowFrameSpec ParseWindowFrameClause()
+    {
+        var unit = ParseWindowFrameUnit();
+        if (unit is WindowFrameUnit.Range or WindowFrameUnit.Groups)
+            throw SqlUnsupported.ForDialect(_dialect, $"window frame unit ({unit.ToString().ToUpperInvariant()})");
+
+        WindowFrameBound start;
+        WindowFrameBound end;
+        if (IsKeywordOrIdentifierWord(Peek(), "BETWEEN"))
+        {
+            Consume(); // BETWEEN
+            start = ParseWindowFrameBound();
+            if (!IsKeywordOrIdentifierWord(Peek(), "AND"))
+                throw Error("Expected AND in window frame clause.", Peek());
+            Consume(); // AND
+            end = ParseWindowFrameBound();
+        }
+        else
+        {
+            start = ParseWindowFrameBound();
+            end = new WindowFrameBound(WindowFrameBoundKind.CurrentRow, null);
+        }
+
+        return new WindowFrameSpec(unit, start, end);
+    }
+
+    private WindowFrameUnit ParseWindowFrameUnit()
+    {
+        if (IsKeywordOrIdentifierWord(Peek(), "ROWS"))
+        {
+            Consume();
+            return WindowFrameUnit.Rows;
+        }
+
+        if (IsKeywordOrIdentifierWord(Peek(), "RANGE"))
+        {
+            Consume();
+            return WindowFrameUnit.Range;
+        }
+
+        if (IsKeywordOrIdentifierWord(Peek(), "GROUPS"))
+        {
+            Consume();
+            return WindowFrameUnit.Groups;
+        }
+
+        throw Error("Expected ROWS, RANGE or GROUPS in window frame clause.", Peek());
+    }
+
+    private WindowFrameBound ParseWindowFrameBound()
+    {
+        if (IsKeywordOrIdentifierWord(Peek(), "UNBOUNDED"))
+        {
+            Consume();
+            if (IsKeywordOrIdentifierWord(Peek(), "PRECEDING"))
+            {
+                Consume();
+                return new WindowFrameBound(WindowFrameBoundKind.UnboundedPreceding, null);
+            }
+
+            if (IsKeywordOrIdentifierWord(Peek(), "FOLLOWING"))
+            {
+                Consume();
+                return new WindowFrameBound(WindowFrameBoundKind.UnboundedFollowing, null);
+            }
+
+            throw Error("Expected PRECEDING or FOLLOWING after UNBOUNDED in window frame clause.", Peek());
+        }
+
+        if (IsKeywordOrIdentifierWord(Peek(), "CURRENT"))
+        {
+            Consume();
+            if (!IsKeywordOrIdentifierWord(Peek(), "ROW"))
+                throw Error("Expected ROW after CURRENT in window frame clause.", Peek());
+            Consume();
+            return new WindowFrameBound(WindowFrameBoundKind.CurrentRow, null);
+        }
+
+        var boundExpr = ParseExpression(0);
+        if (!TryReadIntegralLiteral(boundExpr, out var offset) || offset < 0 || offset > int.MaxValue)
+            throw Error("Expected a non-negative integer literal in window frame bound.", Peek());
+
+        if (IsKeywordOrIdentifierWord(Peek(), "PRECEDING"))
+        {
+            Consume();
+            return new WindowFrameBound(WindowFrameBoundKind.Preceding, (int)offset);
+        }
+
+        if (IsKeywordOrIdentifierWord(Peek(), "FOLLOWING"))
+        {
+            Consume();
+            return new WindowFrameBound(WindowFrameBoundKind.Following, (int)offset);
+        }
+
+        throw Error("Expected PRECEDING or FOLLOWING in window frame bound.", Peek());
     }
 
     private IReadOnlyList<SqlExpr> ParseExprListUntilOrderOrParenClose()


### PR DESCRIPTION
### Motivation
- Provide proper `ROWS` window-frame parsing and per-row runtime semantics for value window functions and align parser/runtime behavior with dialect/version gates to fail-fast on unsupported usage.
- Harden name/arity/literal-range validation for window functions so invalid queries are rejected early and runtime is protected from silent incorrect behavior.
- Increase confidence with integration scenarios for sliding and forward `ROWS` frames and reflect progress in the project roadmap.

### Description
- Extended the AST to represent window frames by adding `WindowFrameUnit`, `WindowFrameBoundKind`, `WindowFrameBound`, `WindowFrameSpec` and by extending `WindowSpec` to carry an optional `Frame`.
- Enhanced the parser with `ParseWindowFrameClause`, `ParseWindowFrameBound`, `ParseWindowFrameUnit`, and guards `EnsureWindowFunctionSupport`, `EnsureWindowFunctionArguments`, `EnsureWindowSpecSupport`, plus literal-range checks and semantic validation of frame bounds (`start <= end`).
- Added dialect/runtime capability hooks and defaults: `SupportsWindowFrameClause`, `SupportsWindowFunction`, `RequiresOrderByInWindowFunction`, `TryGetWindowFunctionArgumentArity` and `WindowFunctionsMinVersion`, and wired them into concrete dialects (MySQL, Npgsql, Oracle, SqlServer, Sqlite) and `SqlDialectBase`.
- Implemented ROWS-frame runtime helpers and per-row resolution in the executor: `ResolveRowsFrameRange`, `ResolveRowsFrameBoundIndex`, `RowsFrameRange` and updated `FillFirstOrLastValue` and `FillNthValue` to compute results per row, plus runtime fail-fast checks for unsupported functions, missing `ORDER BY`, and non-`ROWS` frame units.
- Added parser and integration tests across dialects and providers, new SQLite Dapper tests covering sliding and forward `ROWS` frames, and updated the roadmap `docs/core-parser-executor-roadmap.md` progress from `80%` to `82%`.

### Testing
- Ran repository discovery/search with `rg` to verify added symbols and test cases, which completed successfully.
- Ran formatting/hygiene checks with `git diff --check`, which reported no issues.
- Could not run `dotnet test` in this environment because the `dotnet` CLI is not available, so unit and integration test execution was not performed here.
- Static/runtime execution validation beyond the above was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c58b7fd0c832c9940779be88099af)