### PR TITLE
Fix build errors in versioned test attributes and warning block extraction

### DIFF
--- a/src/DbSqlLikeMem.Test/ExecutionPlanPlanWarningsTestsBase.cs
+++ b/src/DbSqlLikeMem.Test/ExecutionPlanPlanWarningsTestsBase.cs
@@ -278,11 +278,20 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
         var start = Array.FindIndex(lines, line => line == $"- {SqlExecutionPlanMessages.CodeLabel()}: {code}");
         start.Should().BeGreaterThanOrEqualTo(0);
 
-        var end = Array.FindIndex(start + 1 < lines.Length ? lines[(start + 1)..] : [], line => line.StartsWith($"- {SqlExecutionPlanMessages.CodeLabel()}:", StringComparison.Ordinal));
-        if (end >= 0)
-            return lines[start..(start + 1 + end)];
+        var nextCodeOffset = -1;
+        for (var i = start + 1; i < lines.Length; i++)
+        {
+            if (lines[i].StartsWith($"- {SqlExecutionPlanMessages.CodeLabel()}:", StringComparison.Ordinal))
+            {
+                nextCodeOffset = i - start;
+                break;
+            }
+        }
 
-        return lines[start..];
+        if (nextCodeOffset >= 0)
+            return lines.Skip(start).Take(nextCodeOffset).ToArray();
+
+        return lines.Skip(start).ToArray();
     }
 
     protected static void SeedUsers(DbConnectionMockBase cnn, int totalRows, Func<int, int> activeSelector)

--- a/src/DbSqlLikeMem/Attributes/MemberDataByVersionAttribute.cs
+++ b/src/DbSqlLikeMem/Attributes/MemberDataByVersionAttribute.cs
@@ -22,12 +22,17 @@ public abstract class MemberDataByVersionAttribute(
     /// EN: Gets or sets VersionGraterOrEqual.
     /// PT: Obtém ou define VersionGraterOrEqual.
     /// </summary>
-    public int? VersionGraterOrEqual { get; set; }
+    public int VersionGraterOrEqual { get; set; } = int.MinValue;
     /// <summary>
     /// EN: Gets or sets VersionLessOrEqual.
     /// PT: Obtém ou define VersionLessOrEqual.
     /// </summary>
-    public int? VersionLessOrEqual { get; set; }
+    public int VersionLessOrEqual { get; set; } = int.MinValue;
+    /// <summary>
+    /// EN: Gets or sets VersionLowerThan.
+    /// PT: Obtém ou define VersionLowerThan.
+    /// </summary>
+    public int VersionLowerThan { get; set; } = int.MinValue;
 
     /// <summary>
     /// DbVersions to be used in the test when SpecificVersions is null.
@@ -54,10 +59,12 @@ public abstract class MemberDataByVersionAttribute(
 
         var versions = SpecificVersions ?? Versions;
 
-        if (VersionGraterOrEqual != null)
+        if (VersionGraterOrEqual != int.MinValue)
             versions = versions.Where(_ => _ >= VersionGraterOrEqual);
-        if (VersionLessOrEqual != null)
+        if (VersionLessOrEqual != int.MinValue)
             versions = versions.Where(_ => _ <= VersionLessOrEqual);
+        if (VersionLowerThan != int.MinValue)
+            versions = versions.Where(_ => _ < VersionLowerThan);
 
         versions = [.. versions];
 

--- a/src/DbSqlLikeMem/Attributes/MemberDataVersionAttribute.cs
+++ b/src/DbSqlLikeMem/Attributes/MemberDataVersionAttribute.cs
@@ -21,12 +21,17 @@ public abstract class MemberDataVersionAttribute
     /// EN: Gets or sets VersionGraterOrEqual.
     /// PT: Obtém ou define VersionGraterOrEqual.
     /// </summary>
-    public int? VersionGraterOrEqual { get; set; }
+    public int VersionGraterOrEqual { get; set; } = int.MinValue;
     /// <summary>
     /// EN: Gets or sets VersionLessOrEqual.
     /// PT: Obtém ou define VersionLessOrEqual.
     /// </summary>
-    public int? VersionLessOrEqual { get; set; }
+    public int VersionLessOrEqual { get; set; } = int.MinValue;
+    /// <summary>
+    /// EN: Gets or sets VersionLowerThan.
+    /// PT: Obtém ou define VersionLowerThan.
+    /// </summary>
+    public int VersionLowerThan { get; set; } = int.MinValue;
 
     /// <summary>
     /// DbVersions to be used in the test when SpecificVersions is null.
@@ -45,10 +50,12 @@ public abstract class MemberDataVersionAttribute
     { 
         var versions = SpecificVersions ?? Versions;
 
-        if (VersionGraterOrEqual != null)
+        if (VersionGraterOrEqual != int.MinValue)
             versions = versions.Where(_ => _ >= VersionGraterOrEqual);
-        if (VersionLessOrEqual != null)
+        if (VersionLessOrEqual != int.MinValue)
             versions = versions.Where(_ => _ <= VersionLessOrEqual);
+        if (VersionLowerThan != int.MinValue)
+            versions = versions.Where(_ => _ < VersionLowerThan);
 
         versions = [.. versions];
 


### PR DESCRIPTION
### Motivation
- Resolve compilation failures caused by attribute named-argument types and use of C# range/slice features that depend on newer runtime helpers. 
- Ensure version-filtering test attributes accept named arguments in test attributes and support strict upper-bound filtering.
- Remove reliance on array slicing that triggered missing runtime members on older targets. 

### Description
- Converted `VersionGraterOrEqual` and `VersionLessOrEqual` from `int?` to `int` with `int.MinValue` sentinel defaults so they can be used as attribute named arguments. 
- Added `VersionLowerThan` property to `MemberDataVersionAttribute` and `MemberDataByVersionAttribute` and applied `<` filtering when set. 
- Updated version-filter checks to compare against `int.MinValue` instead of `null` so filters are only applied when explicitly provided. 
- Replaced range/slice usage in `ExecutionPlanPlanWarningsTestsBase.ExtractWarningBlock` with an explicit loop and `Skip/Take` to avoid `RuntimeHelpers.GetSubArray` dependency. 

### Testing
- Attempted to run `dotnet build DbSqlLikeMem.sln -v minimal`, but the command could not run in this environment because `dotnet` is not installed (`bash: command not found: dotnet`), so no build or test execution completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4547c6c8832c86b395b2f5ead889)