### PR TITLE
Parser TDD: actionable unknown-top-level tests + normalize pagination AST

### DIFF
--- a/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
@@ -312,7 +312,7 @@ public sealed class MySqlDialectFeatureParserTests
         var sql = "SELECT id FROM users OPTION (MAXDOP 1)";
 
         var ex = Assert.Throws<NotSupportedException>(() => SqlQueryParser.Parse(sql, new MySqlDialect(version)));
-        Assert.Contains("OPTION", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("OPTION(query hints)", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("USE/IGNORE/FORCE INDEX", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
@@ -85,7 +85,7 @@ public sealed class OracleDialectFeatureParserTests
         var sql = "SELECT id FROM users OPTION (MAXDOP 1)";
 
         var ex = Assert.Throws<NotSupportedException>(() => SqlQueryParser.Parse(sql, new OracleDialect(version)));
-        Assert.Contains("OPTION", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("OPTION(query hints)", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Use hints compatíveis", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -102,7 +102,7 @@ public sealed class OracleDialectFeatureParserTests
         var sql = "SELECT id FROM users UNION SELECT id FROM users OPTION (MAXDOP 1)";
 
         var ex = Assert.Throws<NotSupportedException>(() => SqlQueryParser.Parse(sql, new OracleDialect(version)));
-        Assert.Contains("OPTION", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("OPTION(query hints)", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
@@ -66,7 +66,7 @@ public sealed class SqliteDialectFeatureParserTests
         var sql = "SELECT id FROM users OPTION (MAXDOP 1)";
 
         var ex = Assert.Throws<NotSupportedException>(() => SqlQueryParser.Parse(sql, new SqliteDialect(version)));
-        Assert.Contains("OPTION", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("OPTION(query hints)", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Use hints compatíveis", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
@@ -1239,10 +1239,10 @@ internal sealed class SqlQueryParser
                 if (IsWord(Peek(), "ONLY"))
                     Consume();
 
-                return new SqlFetch(Count: count, Offset: offset);
+                return new SqlLimitOffset(Count: count, Offset: offset);
             }
 
-            return new SqlFetch(Count: int.MaxValue, Offset: offset);
+            return new SqlLimitOffset(Count: int.MaxValue, Offset: offset);
         }
 
         // Oracle/Postgres: FETCH FIRST n ROWS ONLY
@@ -1263,7 +1263,7 @@ internal sealed class SqlQueryParser
             if (IsWord(Peek(), "ONLY"))
                 Consume();
 
-            return new SqlFetch(Count: count, Offset: null);
+            return new SqlLimitOffset(Count: count, Offset: null);
         }
 
         return null;


### PR DESCRIPTION
### Motivation
- Add missing dialect-specific parser tests so unsupported top-level statements surface an actionable message across all dialects. 
- Make `OPTION(query hints)` assertions explicit so tests validate the actionable hint text instead of a fragile substring. 
- Normalize pagination AST nodes so different pagination syntaxes (`LIMIT/OFFSET`, `OFFSET/FETCH`, `FETCH FIRST`) map to a single canonical `SqlLimitOffset` representation to simplify runtime logic and future evolution. 

### Description
- Added `ParseUnsupportedTopLevelStatement_ShouldUseActionableMessage` tests for DB2 and Npgsql to mirror existing coverage in other dialects and validate the actionable text `token inicial` + `SELECT/INSERT/UPDATE/DELETE`. 
- Strengthened query-hint tests by asserting `OPTION(query hints)` text in parser rejection tests across MySQL, SQLite, Oracle, DB2 and Npgsql to ensure the message is actionable and consistent. 
- Introduced cross-dialect red tests `ParseSelect_PaginationSyntaxes_ShouldNormalizeRowLimitAst` in DB2 and Npgsql that parse `LIMIT/OFFSET`, `OFFSET/FETCH` and `FETCH FIRST` and assert the `RowLimit` is a `SqlLimitOffset` with equivalent values. 
- Implemented a minimal parser change in `src/DbSqlLikeMem/Parser/SqlQueryParser.cs` to return `SqlLimitOffset` from the `OFFSET/FETCH` and `FETCH FIRST` parse paths so the AST is normalized without altering existing dialect gates. 

Key files changed: `src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs`, `src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs`, `src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs`, `src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs`, `src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs`, and `src/DbSqlLikeMem/Parser/SqlQueryParser.cs`.

### Testing
- ✅ `rg -n "ParseUnsupportedTopLevelStatement_ShouldUseActionableMessage|OPTION\(query hints\)" src/DbSqlLikeMem.*.Test/Parser/*DialectFeatureParserTests.cs` — confirmed updated assertions and new tests are present. 
- ✅ `rg -n "NormalizeRowLimitAst|SqlLimitOffset\(Count: count|SqlLimitOffset\(Count: int.MaxValue" src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs src/DbSqlLikeMem/Parser/SqlQueryParser.cs` — confirmed parser now emits `SqlLimitOffset` for the targeted pagination paths and cross-dialect tests reference it. 
- ⚠️ `dotnet --info` — not available in the environment (`bash: command not found: dotnet`), so the unit test suite could not be executed; runtime test execution remains pending in a dotnet-enabled environment. 

Known limitations: automated unit tests were not run due to missing `dotnet` toolchain; changes were validated via code inspection and `rg` checks only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e436d8b7c832cadcc25c17799982f)