### PR TITLE
Fix warnings: add bilingual XML summaries, JSON null-safety, and obsolete suppression

### DIFF
--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
@@ -104,6 +104,11 @@ RETURNING id";
         Assert.Throws<NotSupportedException>(() => SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
     }
 
+    /// <summary>
+    /// EN: Verifies pagination syntaxes normalize to equivalent row-limit AST.
+    /// PT: Verifica que sintaxes de paginação são normalizadas para AST equivalente de limite de linhas.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
@@ -168,6 +173,11 @@ RETURNING id";
 
 
 
+    /// <summary>
+    /// EN: Verifies DELETE without FROM returns an actionable error message.
+    /// PT: Verifica que DELETE sem FROM retorna mensagem de erro acionável.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
@@ -179,6 +189,11 @@ RETURNING id";
         Assert.Contains("DELETE FROM", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Verifies DELETE target alias before FROM returns an actionable error message.
+    /// PT: Verifica que alias alvo de DELETE antes de FROM retorna mensagem de erro acionável.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]
@@ -192,6 +207,11 @@ RETURNING id";
 
 
 
+    /// <summary>
+    /// EN: Verifies unsupported top-level statements return guidance-focused errors.
+    /// PT: Verifica que comandos de topo não suportados retornam erros com orientação.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataNpgsqlVersion]

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
@@ -29,6 +29,11 @@ public sealed class OracleDialectFeatureParserTests
 
 
 
+    /// <summary>
+    /// EN: Verifies WITH RECURSIVE rejection includes actionable guidance for Oracle syntax.
+    /// PT: Verifica que a rejeição de WITH RECURSIVE inclui orientação acionável para sintaxe Oracle.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataOracleVersion(VersionGraterOrEqual = OracleDialect.WithCteMinVersion)]
@@ -126,6 +131,11 @@ public sealed class OracleDialectFeatureParserTests
 
 
 
+    /// <summary>
+    /// EN: Verifies DELETE without FROM returns an actionable error message.
+    /// PT: Verifica que DELETE sem FROM retorna mensagem de erro acionável.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
@@ -137,6 +147,11 @@ public sealed class OracleDialectFeatureParserTests
         Assert.Contains("DELETE FROM", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Verifies DELETE target alias before FROM returns an actionable error message.
+    /// PT: Verifica que alias alvo de DELETE antes de FROM retorna mensagem de erro acionável.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataOracleVersion]
@@ -150,6 +165,11 @@ public sealed class OracleDialectFeatureParserTests
 
 
 
+    /// <summary>
+    /// EN: Verifies unsupported top-level statements return guidance-focused errors.
+    /// PT: Verifica que comandos de topo não suportados retornam erros com orientação.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataOracleVersion]

--- a/src/DbSqlLikeMem.Sqlite.Test/DbMockConnectionFactoryTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/DbMockConnectionFactoryTests.cs
@@ -1,7 +1,15 @@
 namespace DbSqlLikeMem.Sqlite.Test;
 
+/// <summary>
+/// EN: Validates SQLite test-connection factory helpers.
+/// PT: Valida os helpers da fábrica de conexões de teste SQLite.
+/// </summary>
 public class DbMockConnectionFactoryTests
 {
+    /// <summary>
+    /// EN: Verifies CreateSqliteWithTables returns SQLite db and connection mocks.
+    /// PT: Verifica que CreateSqliteWithTables retorna mocks de banco e conexão SQLite.
+    /// </summary>
     [Fact]
     public void CreateSqliteWithTables_ShouldCreateSqliteDbAndConnection()
     {
@@ -11,6 +19,10 @@ public class DbMockConnectionFactoryTests
         connection.Should().BeOfType<SqliteConnectionMock>();
     }
 
+    /// <summary>
+    /// EN: Verifies table mapper callbacks are applied during factory creation.
+    /// PT: Verifica que callbacks de mapeamento de tabela são aplicados na criação da fábrica.
+    /// </summary>
     [Fact]
     public void CreateWithTables_ShouldApplyTableMappers()
     {

--- a/src/DbSqlLikeMem.Sqlite.Test/ExecutionPlanPlanWarningsTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/ExecutionPlanPlanWarningsTests.cs
@@ -2,13 +2,30 @@ using System.Data.Common;
 
 namespace DbSqlLikeMem.Sqlite.Test;
 
+/// <summary>
+/// EN: Runs shared execution-plan warning tests for SQLite.
+/// PT: Executa testes compartilhados de alertas de plano de execução para SQLite.
+/// </summary>
+/// <param name="helper">EN: xUnit output helper. PT: Helper de saída do xUnit.</param>
 public sealed class ExecutionPlanPlanWarningsTests(ITestOutputHelper helper)
     : ExecutionPlanPlanWarningsTestsBase(helper)
 {
+    /// <summary>
+    /// EN: Creates a SQLite mock connection for warning test scenarios.
+    /// PT: Cria uma conexão mock SQLite para cenários de teste de alertas.
+    /// </summary>
     protected override DbConnectionMockBase CreateConnection() => new SqliteConnectionMock();
 
+    /// <summary>
+    /// EN: Creates a SQLite command bound to the provided connection and SQL text.
+    /// PT: Cria um comando SQLite associado à conexão e ao texto SQL informados.
+    /// </summary>
     protected override DbCommand CreateCommand(DbConnectionMockBase connection, string commandText)
         => new SqliteCommandMock((SqliteConnectionMock)connection) { CommandText = commandText };
 
+    /// <summary>
+    /// EN: Gets provider-specific ORDER BY query with LIMIT used by shared tests.
+    /// PT: Obtém consulta ORDER BY com LIMIT específica do provedor usada pelos testes compartilhados.
+    /// </summary>
     protected override string SelectOrderByWithLimitSql => "SELECT Id FROM users ORDER BY Id LIMIT 10";
 }

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
@@ -145,6 +145,11 @@ public sealed class SqliteDialectFeatureParserTests
 
 
 
+    /// <summary>
+    /// EN: Verifies DELETE without FROM returns an actionable error message.
+    /// PT: Verifica que DELETE sem FROM retorna mensagem de erro acionável.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
@@ -156,6 +161,11 @@ public sealed class SqliteDialectFeatureParserTests
         Assert.Contains("DELETE FROM", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Verifies DELETE target alias before FROM returns an actionable error message.
+    /// PT: Verifica que alias alvo de DELETE antes de FROM retorna mensagem de erro acionável.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
@@ -169,6 +179,11 @@ public sealed class SqliteDialectFeatureParserTests
 
 
 
+    /// <summary>
+    /// EN: Verifies unsupported top-level statements return guidance-focused errors.
+    /// PT: Verifica que comandos de topo não suportados retornam erros com orientação.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]
@@ -206,6 +221,11 @@ public sealed class SqliteDialectFeatureParserTests
 
 
 
+    /// <summary>
+    /// EN: Verifies MERGE in unsupported dialect returns actionable migration guidance.
+    /// PT: Verifica que MERGE em dialeto não suportado retorna orientação acionável de migração.
+    /// </summary>
+    /// <param name="version">EN: Dialect version under test. PT: Versão do dialeto em teste.</param>
     [Theory]
     [Trait("Category", "Parser")]
     [MemberDataSqliteVersion]

--- a/src/DbSqlLikeMem.Test/DbDataReaderMockBaseTests.cs
+++ b/src/DbSqlLikeMem.Test/DbDataReaderMockBaseTests.cs
@@ -6,6 +6,10 @@ namespace DbSqlLikeMem.Test;
 /// </summary>
 public sealed class DbDataReaderMockBaseTests
 {
+    /// <summary>
+    /// EN: Verifies GetBytes returns total byte length when the destination buffer is null.
+    /// PT: Verifica que GetBytes retorna o tamanho total dos bytes quando o buffer de destino é nulo.
+    /// </summary>
     [Fact]
     [Trait("Category", "Core")]
     public void GetBytes_ShouldReturnLength_WhenBufferIsNull()
@@ -18,6 +22,10 @@ public sealed class DbDataReaderMockBaseTests
         Assert.Equal(4, total);
     }
 
+    /// <summary>
+    /// EN: Verifies GetBytes copies only the requested byte segment to the destination buffer.
+    /// PT: Verifica que GetBytes copia apenas o segmento de bytes solicitado para o buffer de destino.
+    /// </summary>
     [Fact]
     [Trait("Category", "Core")]
     public void GetBytes_ShouldCopyRequestedSegment()
@@ -32,6 +40,10 @@ public sealed class DbDataReaderMockBaseTests
         Assert.Equal(new byte[] { 11, 12, 13 }, buffer);
     }
 
+    /// <summary>
+    /// EN: Verifies GetChars copies only the requested character segment to the destination buffer.
+    /// PT: Verifica que GetChars copia apenas o segmento de caracteres solicitado para o buffer de destino.
+    /// </summary>
     [Fact]
     [Trait("Category", "Core")]
     public void GetChars_ShouldCopyRequestedSegment()
@@ -48,6 +60,10 @@ public sealed class DbDataReaderMockBaseTests
 
 
 
+    /// <summary>
+    /// EN: Verifies GetOrdinal resolves bracket-quoted column names without brackets.
+    /// PT: Verifica que GetOrdinal resolve nomes de coluna entre colchetes sem os colchetes.
+    /// </summary>
     [Fact]
     [Trait("Category", "Core")]
     public void GetOrdinal_ShouldResolveBracketQuotedColumnName()
@@ -66,6 +82,10 @@ public sealed class DbDataReaderMockBaseTests
         Assert.Equal("Alice", reader.GetString(ordinal));
     }
 
+    /// <summary>
+    /// EN: Verifies GetData returns the nested reader when the value already is a data reader.
+    /// PT: Verifica que GetData retorna o leitor aninhado quando o valor já é um data reader.
+    /// </summary>
     [Fact]
     [Trait("Category", "Core")]
     public void GetData_ShouldReturnNestedReader_WhenColumnContainsReader()
@@ -79,6 +99,10 @@ public sealed class DbDataReaderMockBaseTests
         Assert.Same(nested, read);
     }
 
+    /// <summary>
+    /// EN: Verifies GetData throws InvalidCastException when the value is not a nested reader.
+    /// PT: Verifica que GetData lança InvalidCastException quando o valor não é um leitor aninhado.
+    /// </summary>
     [Fact]
     [Trait("Category", "Core")]
     public void GetData_ShouldThrowInvalidCast_WhenColumnDoesNotContainReader()
@@ -91,6 +115,10 @@ public sealed class DbDataReaderMockBaseTests
 
 
 
+    /// <summary>
+    /// EN: Verifies GetValues copies only the destination array length when fields are more than slots.
+    /// PT: Verifica que GetValues copia apenas o tamanho do array de destino quando há mais campos que posições.
+    /// </summary>
     [Fact]
     [Trait("Category", "Core")]
     public void GetValues_ShouldCopyOnlyDestinationLength_WhenArrayIsSmallerThanFieldCount()
@@ -114,6 +142,10 @@ public sealed class DbDataReaderMockBaseTests
         Assert.Equal(11, values[0]);
     }
 
+    /// <summary>
+    /// EN: Verifies Dispose closes the current reader and nested disposable reader resources.
+    /// PT: Verifica que Dispose fecha o leitor atual e recursos de leitores aninhados descartáveis.
+    /// </summary>
     [Fact]
     [Trait("Category", "Core")]
     public void Dispose_ShouldCloseReader_AndDisposeNestedResources()

--- a/src/DbSqlLikeMem.Test/ExecutionPlanFormattingAndI18nTests.cs
+++ b/src/DbSqlLikeMem.Test/ExecutionPlanFormattingAndI18nTests.cs
@@ -4,12 +4,20 @@ using System.Text.RegularExpressions;
 
 namespace DbSqlLikeMem.Test;
 
+/// <summary>
+/// EN: Validates execution-plan warning formatting and i18n resource consistency.
+/// PT: Valida a formatação de alertas do plano de execução e a consistência de recursos de i18n.
+/// </summary>
 public sealed class ExecutionPlanFormattingAndI18nTests
 {
     private static readonly Regex TechnicalThresholdPattern = new(
         @"^[a-zA-Z]+:\d+(\.\d+)?(?:;[a-zA-Z]+:\d+(\.\d+)?)*$",
         RegexOptions.CultureInvariant);
 
+    /// <summary>
+    /// EN: Verifies warning metadata is rendered in deterministic key order.
+    /// PT: Verifica que os metadados de alerta são renderizados em ordem determinística de chaves.
+    /// </summary>
     [Fact]
     public void FormatSelect_ShouldPrintPlanWarningMetadataInStableOrder()
     {
@@ -52,6 +60,10 @@ public sealed class ExecutionPlanFormattingAndI18nTests
             $"{SqlExecutionPlanMessages.ThresholdLabel()}: gte:100;highGte:5000");
     }
 
+    /// <summary>
+    /// EN: Verifies localized execution-plan resources keep base keys and canonical SQL keywords.
+    /// PT: Verifica que recursos localizados de plano de execução mantêm chaves base e palavras-chave SQL canônicas.
+    /// </summary>
     [Fact]
     public void SqlExecutionPlanMessages_AllLocalizedResxShouldContainBaseKeys_AndKeepCanonicalSqlKeywords()
     {
@@ -99,6 +111,10 @@ public sealed class ExecutionPlanFormattingAndI18nTests
         }
     }
 
+    /// <summary>
+    /// EN: Verifies threshold metadata stays in stable machine-parseable format.
+    /// PT: Verifica que metadados de threshold permanecem em formato estável legível por máquina.
+    /// </summary>
     [Fact]
     public void FormatSelect_ShouldKeepThresholdInTechnicalParseablePattern()
     {

--- a/src/DbSqlLikeMem.Test/ExecutionPlanPlanWarningsTestsBase.cs
+++ b/src/DbSqlLikeMem.Test/ExecutionPlanPlanWarningsTestsBase.cs
@@ -3,11 +3,33 @@ using System.Text.RegularExpressions;
 
 namespace DbSqlLikeMem.Test;
 
+/// <summary>
+/// EN: Provides reusable execution-plan warning assertions across provider-specific test suites.
+/// PT: Fornece asserções reutilizáveis de alertas de plano de execução entre suítes específicas de provedores.
+/// </summary>
+/// <param name="helper">EN: xUnit output helper for diagnostics. PT: Helper de saída do xUnit para diagnósticos.</param>
 public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helper) : XUnitTestBase(helper)
 {
+    /// <summary>
+    /// EN: Creates the provider-specific connection used in each scenario.
+    /// PT: Cria a conexão específica do provedor usada em cada cenário.
+    /// </summary>
     protected abstract DbConnectionMockBase CreateConnection();
+    /// <summary>
+    /// EN: Creates a provider-specific command for the given SQL text.
+    /// PT: Cria um comando específico do provedor para o texto SQL informado.
+    /// </summary>
     protected abstract DbCommand CreateCommand(DbConnectionMockBase connection, string commandText);
+    /// <summary>
+    /// EN: Gets ORDER BY SQL that also applies row limiting for the provider.
+    /// PT: Obtém SQL com ORDER BY que também aplica limitação de linhas para o provedor.
+    /// </summary>
     protected abstract string SelectOrderByWithLimitSql { get; }
+    /// <summary>
+    /// EN: Verifies PW001 is emitted for ORDER BY without row limit and high reads.
+    /// PT: Verifica que PW001 é emitido para ORDER BY sem limite de linhas e com alta leitura.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -26,6 +48,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
         cnn.LastExecutionPlan.Should().Contain($"{SqlExecutionPlanMessages.SuggestedActionLabel()}:");
         cnn.LastExecutionPlan.Should().Contain($"{SqlExecutionPlanMessages.SeverityLabel()}: {SqlExecutionPlanMessages.SeverityHighValue()}");
     }
+    /// <summary>
+    /// EN: Verifies PW001 is not emitted when row limit is present.
+    /// PT: Verifica que PW001 não é emitido quando há limite de linhas.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -40,6 +67,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
 
         cnn.LastExecutionPlan.Should().NotContain($"{SqlExecutionPlanMessages.CodeLabel()}: PW001");
     }
+    /// <summary>
+    /// EN: Verifies PW002 is emitted for low-selectivity predicates with high reads.
+    /// PT: Verifica que PW002 é emitido para predicados de baixa seletividade com alta leitura.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -54,6 +86,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
 
         cnn.LastExecutionPlan.Should().Contain($"{SqlExecutionPlanMessages.CodeLabel()}: PW002");
     }
+    /// <summary>
+    /// EN: Verifies PW002 is not emitted when predicate selectivity is high.
+    /// PT: Verifica que PW002 não é emitido quando a seletividade do predicado é alta.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -68,6 +105,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
 
         cnn.LastExecutionPlan.Should().NotContain($"{SqlExecutionPlanMessages.CodeLabel()}: PW002");
     }
+    /// <summary>
+    /// EN: Verifies PW003 is emitted for SELECT * under high-read conditions.
+    /// PT: Verifica que PW003 é emitido para SELECT * sob condição de alta leitura.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -82,6 +124,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
 
         cnn.LastExecutionPlan.Should().Contain($"{SqlExecutionPlanMessages.CodeLabel()}: PW003");
     }
+    /// <summary>
+    /// EN: Verifies PW003 is not emitted when projection is explicit.
+    /// PT: Verifica que PW003 não é emitido quando a projeção é explícita.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -96,6 +143,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
 
         cnn.LastExecutionPlan.Should().NotContain($"{SqlExecutionPlanMessages.CodeLabel()}: PW003");
     }
+    /// <summary>
+    /// EN: Verifies warning metadata appears in stable key order.
+    /// PT: Verifica que os metadados de alerta aparecem em ordem estável de chaves.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -129,6 +181,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
         idxObserved.Should().BeGreaterThan(idxMetric);
         idxThreshold.Should().BeGreaterThan(idxObserved);
     }
+    /// <summary>
+    /// EN: Verifies threshold values follow the expected technical pattern.
+    /// PT: Verifica que valores de threshold seguem o padrão técnico esperado.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -152,6 +209,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
         var pattern = new Regex(@"^[a-zA-Z]+:\d+(\.\d+)?(?:;[a-zA-Z]+:\d+(\.\d+)?)*$", RegexOptions.CultureInvariant);
         thresholds.Should().OnlyContain(t => pattern.IsMatch(t));
     }
+    /// <summary>
+    /// EN: Verifies PW004 is suppressed when DISTINCT already explains high read without WHERE.
+    /// PT: Verifica que PW004 é suprimido quando DISTINCT já explica alta leitura sem WHERE.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -167,6 +229,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
         cnn.LastExecutionPlan.Should().Contain($"{SqlExecutionPlanMessages.CodeLabel()}: PW005");
         cnn.LastExecutionPlan.Should().NotContain($"{SqlExecutionPlanMessages.CodeLabel()}: PW004");
     }
+    /// <summary>
+    /// EN: Verifies PW004 remains when query has no WHERE and no DISTINCT.
+    /// PT: Verifica que PW004 permanece quando a consulta não tem WHERE nem DISTINCT.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -181,6 +248,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
 
         cnn.LastExecutionPlan.Should().Contain($"{SqlExecutionPlanMessages.CodeLabel()}: PW004");
     }
+    /// <summary>
+    /// EN: Verifies PW005 is kept and PW004 is suppressed when WHERE and DISTINCT coexist.
+    /// PT: Verifica que PW005 é mantido e PW004 suprimido quando WHERE e DISTINCT coexistem.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -197,6 +269,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
         cnn.LastExecutionPlan.Should().Contain($"{SqlExecutionPlanMessages.CodeLabel()}: PW002");
         cnn.LastExecutionPlan.Should().NotContain($"{SqlExecutionPlanMessages.CodeLabel()}: PW004");
     }
+    /// <summary>
+    /// EN: Verifies PW005 is not emitted when DISTINCT is absent.
+    /// PT: Verifica que PW005 não é emitido quando DISTINCT está ausente.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -211,6 +288,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
 
         cnn.LastExecutionPlan.Should().NotContain($"{SqlExecutionPlanMessages.CodeLabel()}: PW005");
     }
+    /// <summary>
+    /// EN: Verifies PW002 emits stable technical threshold metadata.
+    /// PT: Verifica que PW002 emite metadados técnicos de threshold estáveis.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -227,6 +309,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
         warningBlock.Should().Contain($"{SqlExecutionPlanMessages.MetricNameLabel()}: SelectivityPct");
         warningBlock.Should().Contain($"{SqlExecutionPlanMessages.ThresholdLabel()}: gte:60;highImpactGte:85");
     }
+    /// <summary>
+    /// EN: Verifies PW004 and PW005 emit stable technical threshold metadata.
+    /// PT: Verifica que PW004 e PW005 emitem metadados técnicos de threshold estáveis.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -251,6 +338,11 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
         pw005Block.Should().Contain($"{SqlExecutionPlanMessages.MetricNameLabel()}: EstimatedRowsRead");
         pw005Block.Should().Contain($"{SqlExecutionPlanMessages.ThresholdLabel()}: gte:100;highGte:5000");
     }
+    /// <summary>
+    /// EN: Verifies index recommendations are preserved when warnings are present.
+    /// PT: Verifica que recomendações de índice são preservadas quando há alertas.
+    /// </summary>
+
 
     [Fact]
     [Trait("Category", "ExecutionPlan")]
@@ -294,6 +386,10 @@ public abstract class ExecutionPlanPlanWarningsTestsBase(ITestOutputHelper helpe
         return lines.Skip(start).ToArray();
     }
 
+    /// <summary>
+    /// EN: Seeds the users table with deterministic Active values for warning scenarios.
+    /// PT: Popula a tabela users com valores determinísticos de Active para cenários de alerta.
+    /// </summary>
     protected static void SeedUsers(DbConnectionMockBase cnn, int totalRows, Func<int, int> activeSelector)
     {
         cnn.Define("users");

--- a/src/DbSqlLikeMem.Test/ReadOnlyHashSetTests.cs
+++ b/src/DbSqlLikeMem.Test/ReadOnlyHashSetTests.cs
@@ -9,6 +9,10 @@ namespace DbSqlLikeMem.Test;
 /// </summary>
 public sealed class ReadOnlyHashSetTests
 {
+    /// <summary>
+    /// EN: Verifies GetObjectData fills serialization metadata for the wrapped set.
+    /// PT: Verifica que GetObjectData preenche metadados de serialização para o conjunto encapsulado.
+    /// </summary>
     [Fact]
     [Trait("Category", "Core")]
     public void GetObjectData_ShouldPopulateSerializationInfo()
@@ -22,6 +26,10 @@ public sealed class ReadOnlyHashSetTests
         Assert.True(info.MemberCount > 0);
     }
 
+    /// <summary>
+    /// EN: Verifies GetObjectData throws ArgumentNullException when SerializationInfo is null.
+    /// PT: Verifica que GetObjectData lança ArgumentNullException quando SerializationInfo é nulo.
+    /// </summary>
     [Fact]
     [Trait("Category", "Core")]
     public void GetObjectData_ShouldThrow_WhenInfoIsNull()

--- a/src/DbSqlLikeMem/Models/ReadOnlyHashSet.cs
+++ b/src/DbSqlLikeMem/Models/ReadOnlyHashSet.cs
@@ -255,7 +255,9 @@ public class ReadOnlyHashSet<T> : IReadOnlyHashSet<T>
     public void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         ArgumentNullExceptionCompatible.ThrowIfNull(info, nameof(info));
+#pragma warning disable SYSLIB0050 // Formatter-based serialization is obsolete and should not be used.
         ((ISerializable)_set).GetObjectData(info, context);
+#pragma warning restore SYSLIB0050 // Formatter-based serialization is obsolete and should not be used.
     }
 
     //

--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -4013,11 +4013,13 @@ private void FillPercentRankOrCumeDist(
             {
                 static string? ValidateJsonOrNull(string? json)
                 {
-                    if (string.IsNullOrWhiteSpace(json))
+                    if (json is null || string.IsNullOrWhiteSpace(json))
                         return null;
 
-                    using var _ = System.Text.Json.JsonDocument.Parse(json);
-                    return json;
+                    var normalizedJson = json.Trim();
+
+                    using var _ = System.Text.Json.JsonDocument.Parse(normalizedJson);
+                    return normalizedJson;
                 }
 
                 if (v is string s)


### PR DESCRIPTION
### Motivation
- Address compiler warnings reported for public test APIs and runtime code, specifically `CS1591` (missing XML docs), `CS8604` (possible null reference for JSON parsing), and `SYSLIB0050` (formatter-based serialization obsolete). 
- Keep documentation consistent with project convention by adding bilingual summaries (`EN:` then `PT:`) explaining classes, methods and properties.

### Description
- Added bilingual XML summaries (English then Portuguese) to many test classes and public test methods to satisfy `CS1591`, including `DbDataReaderMockBaseTests`, `ReadOnlyHashSetTests`, `ExecutionPlanFormattingAndI18nTests`, `ExecutionPlanPlanWarningsTestsBase`, and several dialect parser test files for SQLite/Npgsql/Oracle. 
- Scoped suppression of the obsolete serialization warning `SYSLIB0050` to the single forwarder call in `ReadOnlyHashSet.GetObjectData` by wrapping the `((ISerializable)_set).GetObjectData(...)` call with `#pragma warning disable/restore SYSLIB0050`. 
- Fixed a potential null-reference and normalized JSON text before parsing in `AstQueryExecutorBase.ValidateJsonOrNull` by checking `json is null`, trimming to `normalizedJson`, and parsing `normalizedJson` with `JsonDocument.Parse`. 

### Testing
- Attempted `dotnet build DbSqlLikeMem.sln -warnaserror:0`, which failed because the environment does not have the `dotnet` CLI installed (result: failed). 
- Ran a Python-based static verification script to check presence of the added XML summaries and to massage/insert doc-comments, which completed successfully (result: succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ef9785388832cbd8f46166fa68d44)