### PR TITLE
Centraliza Roslynator e analyzers como dependências privadas

### DIFF
--- a/src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj
+++ b/src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj
@@ -10,12 +10,6 @@
 		<PackageReference Include="AsyncFriendlyStackTrace" Version="1.7.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" />
-		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0" />
-		<PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
-		<PackageReference Include="Roslynator.CodeFixes" Version="4.15.0" />
-		<PackageReference Include="Roslynator.CSharp" Version="4.15.0" />
-		<PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/src/DbSqlLikeMem/DbSqlLikeMem.csproj
+++ b/src/DbSqlLikeMem/DbSqlLikeMem.csproj
@@ -14,13 +14,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
 		<PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
 		<PackageReference Include="System.Collections.Immutable" Version="10.0.3" />
-		<PackageReference Include="Roslynator.CSharp" Version="4.15.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
 	</ItemGroup>
 	
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'netstandard2.1'">
-		<PackageReference Include="Roslynator.CSharp" Version="4.15.0" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
@@ -33,10 +31,6 @@
 		<PackageReference Include="AsyncFixer" Version="2.1.0" />
 		<PackageReference Include="AsyncFriendlyStackTrace" Version="1.7.0" />
 		<PackageReference Include="CsvHelper" Version="33.1.0" />
-		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0" />
-		<PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
-		<PackageReference Include="Roslynator.CodeFixes" Version="4.15.0" />
-		<PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,4 +43,13 @@
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" PrivateAssets="All" />
+		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All" />
+		<PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" PrivateAssets="All" />
+		<PackageReference Include="Roslynator.CodeFixes" Version="4.15.0" PrivateAssets="All" />
+		<PackageReference Include="Roslynator.CSharp" Version="4.15.0" PrivateAssets="All" />
+		<PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.15.0" PrivateAssets="All" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
### Motivation
- Centralizar os analyzers e o Roslynator para que fiquem disponíveis em todos os projetos sem se tornarem dependências obrigatórias nos pacotes NuGet.
- Eliminar referências duplicadas nos projetos individuais para simplificar manutenção e evitar vazamento de dependências.

### Description
- Adiciona em `src/Directory.Build.props` `PackageReference` para `Microsoft.CodeAnalysis.NetAnalyzers` e os pacotes `Roslynator.*` com `PrivateAssets="All"` para torná-los dependências privadas e herdadas por todos os projetos.
- Remove as referências duplicadas de Roslynator/analyzers dos arquivos `src/DbSqlLikeMem/DbSqlLikeMem.csproj` e `src/DbSqlLikeMem.VisualStudioExtension.Core/DbSqlLikeMem.VisualStudioExtension.Core.csproj`.
- Mantém as referências específicas de `Microsoft.CodeAnalysis.*` e outros pacotes por `TargetFramework` quando ainda necessárias.

### Testing
- Foi executada tentativa de build com `dotnet build src/DbSqlLikeMem/DbSqlLikeMem.csproj`, que falhou devido à ausência do SDK no ambiente (`bash: command not found: dotnet`).
- Não foram executados testes de unidade automáticos por falta do SDK; as mudanças foram verificadas inspecionando os arquivos alterados (`src/Directory.Build.props`, `src/DbSqlLikeMem/DbSqlLikeMem.csproj`, `src/DbSqlLikeMem.VisualStudioExtension.Core/...`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2f4e27f8832ca2c2247c602f156a)