### PR TITLE
Support colon-prefixed Oracle parameters in OracleValueHelper

### DIFF
--- a/src/DbSqlLikeMem.Oracle.Test/SqlValueHelperTests .cs
+++ b/src/DbSqlLikeMem.Oracle.Test/SqlValueHelperTests .cs
@@ -32,6 +32,48 @@ public sealed class SqlValueHelperTests(
     }
 
     /// <summary>
+    /// EN: Tests Resolve_ShouldReadDapperParameter_WithColonPrefix behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_WithColonPrefix.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
+    public void Resolve_ShouldReadDapperParameter_WithColonPrefix()
+    {
+        using var cnn = new OracleConnectionMock();
+        using var cmd = cnn.CreateCommand();
+
+        var p = cmd.CreateParameter();
+        p.ParameterName = "Id";
+        p.Value = 1;
+        cmd.Parameters.Add(p);
+
+        var v = OracleValueHelper.Resolve(":Id", DbType.Int32, isNullable: false, cmd.Parameters, colDict: null);
+
+        Assert.Equal(1, v);
+    }
+
+    /// <summary>
+    /// EN: Tests Resolve_ShouldReadDapperParameter_WhenCollectionStoresPrefixedName behavior.
+    /// PT: Testa o comportamento de Resolve_ShouldReadDapperParameter_WhenCollectionStoresPrefixedName.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlValueHelperTests ")]
+    public void Resolve_ShouldReadDapperParameter_WhenCollectionStoresPrefixedName()
+    {
+        using var cnn = new OracleConnectionMock();
+        using var cmd = cnn.CreateCommand();
+
+        var p = cmd.CreateParameter();
+        p.ParameterName = ":Id";
+        p.Value = 1;
+        cmd.Parameters.Add(p);
+
+        var v = OracleValueHelper.Resolve(":Id", DbType.Int32, isNullable: false, cmd.Parameters, colDict: null);
+
+        Assert.Equal(1, v);
+    }
+
+    /// <summary>
     /// EN: Tests Resolve_ShouldThrow_WhenParameterMissing behavior.
     /// PT: Testa o comportamento de Resolve_ShouldThrow_WhenParameterMissing.
     /// </summary>


### PR DESCRIPTION
### Motivation

- Oracle SQL commonly uses `:name` bind variables and the helper previously only handled `@name`, causing parameter tokens like `:Id` to be treated as literals and triggering parse errors (`DbType não suportado: Object`).
- The change aims to make `OracleValueHelper.Resolve` robust when receiving parameters from Dapper/Oracle providers that may store parameter names with or without prefixes.

### Description

- Updated `OracleValueHelper.Resolve` to accept tokens starting with `@` or `:` and to normalize the parameter name before lookup. (`src/DbSqlLikeMem.Oracle/Extensions/OracleValueHelper.cs`).
- Added `TryGetParameterValue(IDataParameterCollection?, string, out object?)` to look up parameter values by unprefixed name, `:name`, or `@name` and return the resolved `OracleParameter.Value` when present. (`src/DbSqlLikeMem.Oracle/Extensions/OracleValueHelper.cs`).
- Replaced direct `pars[name]` access with the resilient lookup and return the found parameter value instead of falling back to literal parsing.
- Added unit tests covering colon-prefixed tokens and parameter collections that store prefixed names to prevent regressions. (`src/DbSqlLikeMem.Oracle.Test/SqlValueHelperTests .cs`).

### Testing

- Attempted to run the Oracle tests with `dotnet test --filter "SqlValueHelperTests"`, but the environment lacks the .NET SDK so tests could not be executed (`dotnet: command not found`).
- Local automated checks in the repository show the changes were committed and the new tests were added, but their execution was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f409daebc832cabd85a6c79659e90)