### PR TITLE
docs: revalidar percentuais do roadmap core parser/executor

### DIFF
--- a/docs/core-parser-executor-roadmap.md
+++ b/docs/core-parser-executor-roadmap.md
@@ -23,20 +23,27 @@ Para evitar duplicação de código e problemas de build:
 
 ## Status de implementação (estimado)
 
-> Percentuais estimados com base no que já foi entregue no parser/executor e nos testes por provider/versão.
+> Revalidação de progresso feita com base no estado atual de documentação técnica e suites de regressão por provider/versão (known gaps, global evolution plan e trackers dedicados).
 
 | Item | Progresso | Observações rápidas |
 | --- | --- | --- |
-| 1) CTE avançada | **70%** | Gates principais já existem; faltam cenários/versionamento mais fino em cobertura. |
-| 2) Window functions além de `ROW_NUMBER` | **93%** | Gating por nome/versão, validação de aridade/`ORDER BY`, parser com suporte de leitura para frame `ROWS` (com `RANGE/GROUPS` gateados), validação semântica de limites de frame (`start <= end`) e execução de frame `ROWS` para `FIRST_VALUE`/`LAST_VALUE`/`NTH_VALUE`/`LAG`/`LEAD`/`RANK`/`DENSE_RANK`/`PERCENT_RANK`/`CUME_DIST`/`NTILE` já implementadas (incluindo cenários de frame current/sliding/forward por linha e validações com ORDER BY DESC (incluindo peers/ranking distribution) no runtime). Fail-fast para função desconhecida e hardening de aridade/ranges literais (`NTILE`/`LAG`/`LEAD`/`NTH_VALUE`) também entregues. Pendências: unidades adicionais de frame (`RANGE`/`GROUPS`) no runtime. |
-| 3) UPSERT por família de banco | **55%** | Parser com capacidades base; ainda há execução/semântica por provider a consolidar. |
-| 4) Tipos/literais/coerção | **45%** | Base central em `SqlExtensions`; falta extrair mais regras específicas por dialect/version. |
-| 5) JSON cross-dialect | **50%** | Gates e parte do parser prontos; falta ampliar cobertura de execução por provider. |
-| 6) Plano físico com custo | **15%** | Ainda não iniciado como motor dedicado; apenas evolução incremental do executor atual. |
-| 7) JOIN/subquery com heurística | **30%** | Há caminhos funcionais; faltam heurísticas/caching explícitos com meta de custo. |
-| 8) Semântica transacional por isolamento | **25%** | Suporte parcial por cenários; falta modelagem mais completa por provider/version. |
-| 9) `RETURNING`/`OUTPUT`/`RETURNING INTO` | **35%** | Capabilities e parser base; falta payload consistente no executor multi-provider. |
-| 10) Collation/null ordering | **40%** | Parte da comparação textual já centralizada; faltam regras completas de `NULLS FIRST/LAST` e collation. |
+| 1) CTE avançada | **75%** ⬆️ | Gates principais permanecem sólidos e houve avanço de cobertura por versão/dialeto, mas ainda existem bordas específicas para fechar. |
+| 2) Window functions além de `ROW_NUMBER` | **93%** ➡️ | Mantido: parser/runtime já cobrem ranking/distribution/value functions e frame `ROWS`; pendência principal segue em `RANGE/GROUPS` no runtime. |
+| 3) UPSERT por família de banco | **65%** ⬆️ | Evoluiu com consolidação de `ON DUPLICATE`/`ON CONFLICT` e `MERGE` em subset seguro; faltam harmonizações finais de semântica de execução. |
+| 4) Tipos/literais/coerção | **50%** ⬆️ | Base central continua em `SqlExtensions`; houve evolução incremental, mas ainda faltam regras finas por dialeto/versão. |
+| 5) JSON cross-dialect | **68%** ⬆️ | Evoluiu com reforço de runtime/cobertura para caminhos suportados e fallback padronizado para não suportado. |
+| 6) Plano físico com custo | **15%** ➡️ | Sem mudança estrutural: continua como backlog de maior risco e menor prioridade imediata. |
+| 7) JOIN/subquery com heurística | **40%** ⬆️ | Evoluiu em execução multi-tabela e padronização de não suportado; heurística de custo/caching explícito segue pendente. |
+| 8) Semântica transacional por isolamento | **35%** ⬆️ | Evoluiu no hardening base/confiabilidade, mas isolamento completo por provider/version ainda está em fase inicial. |
+| 9) `RETURNING`/`OUTPUT`/`RETURNING INTO` | **40%** ⬆️ | Evolução em parser/capabilities e subset por provider; payload homogêneo multi-provider no executor ainda é gap principal. |
+| 10) Collation/null ordering | **50%** ⬆️ | Avanço com gates de `NULLS FIRST/LAST` em parte dos dialetos, mantendo pendências de collation detalhada cross-provider. |
+
+
+### Leitura rápida da revalidação
+
+- **Mantidos:** item 2 (window) e item 6 (plano físico com custo).
+- **Evoluíram:** itens 1, 3, 4, 5, 7, 8, 9 e 10, com maior impacto recente em JSON/runtime, UPSERT subset e confiabilidade transacional.
+- **Observação:** os percentuais seguem como referência executiva (não métrica automática); a confirmação final continua dependente da execução da suíte local/CI no corte de release.
 
 ## Reavaliação das propostas (válido x ajustar x adiar)
 


### PR DESCRIPTION
### Motivation

- Revalidar e alinhar os percentuais do roadmap do core (parser/executor) com o estado atual de documentação técnica e suites de regressão por provider/versão para evitar divergência entre roadmaps e trackers. 
- Deixar explícito no documento que os percentuais são uma reavaliação baseada em artefatos de acompanhamento (known gaps, global evolution plan e trackers dedicados). 

### Description

- Atualiza `docs/core-parser-executor-roadmap.md` ajustando a frase introdutória da seção de status para referenciar a revalidação e os artefatos usados como base. 
- Atualiza os percentuais e observações dos 10 itens (CTE, Window, UPSERT, Tipos/Literais, JSON, Plano físico, JOIN/subquery, Transações, RETURNING, Collation) e adiciona marcação visual de evolução (⬆️/➡️). 
- Adiciona uma nova seção "Leitura rápida da revalidação" resumindo o que foi mantido e o que evoluiu e aplica commit com a mensagem `docs: revalidar percentuais do roadmap core parser/executor`.

### Testing

- Verificações de arquivo e diff realizadas com `sed -n '1,260p' docs/core-parser-executor-roadmap.md`, `rg -n "CTE avançada|Window functions|UPSERT|Progresso|%" docs -g"*.md"`, `git diff -- docs/core-parser-executor-roadmap.md` e `nl -ba docs/core-parser-executor-roadmap.md | sed -n '20,90p'`, todas concluídas com saída esperada. 
- Commit foi aplicado localmente com sucesso (1 file changed) e foi preparada a descrição do PR correspondente. 
- A alteração é puramente documental e não impacta build/runtime de código-fonte.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fa0d61700832cb8ef30708d512fe7)