### PR TITLE
Add aggregated Execution Plan metadata (PlanRiskScore, summaries, flags, performance band), formatter updates, tests and docs

### DIFF
--- a/docs/execution-plan-advisor-backlog.md
+++ b/docs/execution-plan-advisor-backlog.md
@@ -1,0 +1,111 @@
+# Backlog Completo — Execution Plan Advisor
+
+## Objetivo
+Organizar as próximas evoluções do Execution Plan Advisor em ondas incrementais, preservando:
+- contrato textual interno dos warnings (`Code`, `Message`, `Reason`, `SuggestedAction`, `Severity`, `MetricName`, `ObservedValue`, `Threshold`);
+- `Threshold` técnico parseável;
+- comportamento de `IndexRecommendations`.
+
+## Estado atual (já entregue)
+- [x] `PlanMetadataVersion`
+- [x] `PlanFlags`
+- [x] `PlanPerformanceBand`
+- [x] `PlanRiskScore`
+- [x] `PlanWarningSummary`
+- [x] `PlanWarningCounts`
+- [x] `PlanPrimaryWarning`
+- [x] `IndexRecommendationSummary`
+- [x] `IndexPrimaryRecommendation`
+
+---
+
+## Backlog Priorizado
+
+### Onda 1 — Alto valor / baixo risco
+1. **PlanQualityGrade (A/B/C/D)**
+   - Descrição: adicionar grade qualitativa derivada de `PlanRiskScore` + `PlanPerformanceBand`.
+   - Valor: leitura rápida por humanos e dashboards.
+   - Risco: baixo (aditivo).
+   - Critério de pronto:
+     - campo emitido em formato estável: `PlanQualityGrade: <A|B|C|D>`;
+     - testes de presença/ausência e thresholds.
+
+2. **PlanTopActions (Top 3 ações)**
+   - Descrição: emitir até 3 ações prioritárias derivadas de warnings/recomendações.
+   - Valor: reduz tempo até correção prática.
+   - Risco: baixo/médio (ordenação determinística).
+   - Critério de pronto:
+     - formato parseável: `PlanTopActions: <code>:<actionKey>;...`;
+     - sem alterar `SuggestedAction` original dos warnings.
+
+3. **PlanNoiseScore**
+   - Descrição: score de ruído para quantificar redundância de warnings.
+   - Valor: evitar sobrealerta em cenários com múltiplos sinais semelhantes.
+   - Risco: médio.
+   - Critério de pronto:
+     - fórmula documentada;
+     - testes de regressão com matriz `PW004/PW005`.
+
+### Onda 2 — Automação/observabilidade
+4. **Payload JSON opcional do plano**
+   - Descrição: expor representação estruturada do plano além do texto.
+   - Valor: integração robusta com CI, IDE e observabilidade.
+   - Risco: médio (serialização e compat).
+   - Critério de pronto:
+     - propriedade/retorno opcional JSON;
+     - teste de equivalência texto vs JSON para campos comuns.
+
+5. **CorrelationId por execução de plano**
+   - Descrição: ID único para rastrear plano em logs/pipelines.
+   - Valor: troubleshooting e auditoria.
+   - Risco: baixo.
+   - Critério de pronto:
+     - campo `PlanCorrelationId` estável;
+     - teste de presença e formato.
+
+6. **PlanDelta (comparação entre execuções)**
+   - Descrição: destacar mudança de risco/custo entre última execução e atual.
+   - Valor: alerta de regressão de performance.
+   - Risco: médio/alto (estado histórico).
+   - Critério de pronto:
+     - delta opcional quando histórico existir;
+     - testes com cenários controlados.
+
+### Onda 3 — Inteligência de recomendação
+7. **IndexRecommendationEvidence**
+   - Descrição: evidências por recomendação (colunas de filtro, ordenação, seletividade estimada).
+   - Valor: aumenta confiança do dev ao aplicar índice.
+   - Risco: baixo/médio.
+   - Critério de pronto:
+     - campo técnico parseável com chave fixa;
+     - testes de coerência com query.
+
+8. **PlanPrimaryCauseGroup**
+   - Descrição: agrupar warnings em causa primária (ex.: "ScanWithoutFilter", "SortWithoutLimit").
+   - Valor: reduz complexidade cognitiva.
+   - Risco: médio.
+   - Critério de pronto:
+     - taxonomia estável documentada;
+     - testes de mapeamento por regra.
+
+9. **Hint de severidade escalável por contexto**
+   - Descrição: calibrar pesos/severidade por perfil de ambiente (dev/ci/prod).
+   - Valor: sinal mais aderente ao contexto.
+   - Risco: médio/alto.
+   - Critério de pronto:
+     - configuração opcional sem quebrar defaults;
+     - testes para defaults e overrides.
+
+---
+
+## Itens técnicos transversais
+- [ ] Consolidar padrões parseáveis dos novos agregados em seção única de documentação.
+- [ ] Criar suíte de teste de contrato textual agregados (`Plan*`, `Index*Summary`) com snapshot estável.
+- [ ] Garantir i18n dos novos labels sem traduzir tokens técnicos/canônicos SQL.
+- [ ] Definir política semântica de versionamento para `PlanMetadataVersion`.
+
+## Plano de execução recomendado
+1. Executar Onda 1 em PRs pequenos (1 feature por PR).
+2. Validar contratos textuais + não regressão de `IndexRecommendations` em todos os PRs.
+3. Só iniciar Onda 2 após estabilidade das métricas agregadas em CI.
+4. Revisar Onda 3 com telemetria real da adoção das ações/recomendações.

--- a/docs/execution-plan-advisor-delivery-control.md
+++ b/docs/execution-plan-advisor-delivery-control.md
@@ -1,0 +1,74 @@
+# Controle de Entrega — Execution Plan Advisor
+
+## Objetivo da entrega
+Evoluir incrementalmente o Execution Plan Advisor para aumentar valor ao desenvolvedor sem quebra de contrato textual de `PlanWarnings` e sem regressão em `IndexRecommendations`.
+
+## Itens da entrega (rodadas contínuas)
+- [x] Criar controle de entrega em documento dedicado.  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanRiskScore` agregado quando há warnings.  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanRiskScore` com testes unitários e de integração base.  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanWarningSummary` (resumo determinístico por severidade/código).  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanWarningSummary` com testes unitários e de integração base.  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanPrimaryWarning` (warning mais prioritário por severidade/código).  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanPrimaryWarning` com testes unitários e de integração base.  
+  **Progresso do item:** 100%
+- [x] Implementar `IndexRecommendationSummary` agregado para síntese de recomendações de índice.  
+  **Progresso do item:** 100%
+- [x] Cobrir `IndexRecommendationSummary` com testes unitários e integração base.  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanWarningCounts` para visão agregada por severidade (`high`, `warning`, `info`).  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanWarningCounts` com testes unitários e integração base.  
+  **Progresso do item:** 100%
+- [x] Adicionar `PlanMetadataVersion` para versionamento explícito dos metadados agregados do plano.  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanMetadataVersion` com testes unitários e integração base.  
+  **Progresso do item:** 100%
+- [x] Implementar `IndexPrimaryRecommendation` para destacar a recomendação de índice mais prioritária.  
+  **Progresso do item:** 100%
+- [x] Cobrir `IndexPrimaryRecommendation` com testes unitários e integração base.  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanFlags` para sinalização rápida de presença de warnings e recomendações de índice.  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanFlags` com testes unitários e integração base.  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanPerformanceBand` para categorização rápida de latência do plano (`Fast|Moderate|Slow`).  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanPerformanceBand` com testes unitários e integração base.  
+  **Progresso do item:** 100%
+- [x] Atualizar plano principal (`docs/p7-p10-implementation-plan.md`) com decisões/checklist da rodada atual.  
+  **Progresso do item:** 100%
+
+## Percentual geral da entrega
+- **0%** — planejamento iniciado.
+- **20%** — estrutura de controle criada.
+- **45%** — `PlanRiskScore` implementado.
+- **65%** — cobertura de `PlanRiskScore` adicionada.
+- **80%** — `PlanWarningSummary` implementado.
+- **90%** — cobertura de `PlanWarningSummary` adicionada.
+- **95%** — `PlanPrimaryWarning` implementado.
+- **98%** — cobertura de `PlanPrimaryWarning` adicionada.
+- **99%** — `IndexRecommendationSummary` implementado e coberto.
+- **99.5%** — `PlanWarningCounts` implementado e coberto.
+- **99.8%** — `PlanMetadataVersion` implementado e coberto.
+- **99.9%** — `IndexPrimaryRecommendation` implementado e coberto.
+- **99.95%** — `PlanFlags` implementado e coberto.
+- **99.97%** — `PlanPerformanceBand` implementado e coberto.
+- **100%** — documentação consolidada e plano principal atualizado.
+
+## Escopo e segurança
+- Sem refatoração agressiva.
+- Sem alteração da ordem do contrato textual interno de cada warning (`Code`, `Message`, `Reason`, `SuggestedAction`, `Severity`, `MetricName`, `ObservedValue`, `Threshold`).
+- `Threshold` técnico parseável preservado (`key:value;key:value`).
+- `IndexRecommendations` preservado.
+- Novos campos agregados (`PlanMetadataVersion`, `PlanFlags`, `PlanPerformanceBand`, `PlanRiskScore`, `PlanWarningSummary`, `PlanWarningCounts`, `PlanPrimaryWarning`, `IndexRecommendationSummary`, `IndexPrimaryRecommendation`) adicionados de forma incremental e backward-compatible no output textual.
+
+
+## Referência de backlog
+- Backlog completo de próximas evoluções: `docs/execution-plan-advisor-backlog.md`.

--- a/src/DbSqlLikeMem.Test/ExecutionPlanFormattingAndI18nTests.cs
+++ b/src/DbSqlLikeMem.Test/ExecutionPlanFormattingAndI18nTests.cs
@@ -145,6 +145,347 @@ public sealed class ExecutionPlanFormattingAndI18nTests
         thresholds.Should().OnlyContain(value => TechnicalThresholdPattern.IsMatch(value));
     }
 
+
+    /// <summary>
+    /// EN: Verifies plan risk score is emitted and capped at 100 when warnings are present.
+    /// PT: Verifica que o score de risco do plano é emitido e limitado em 100 quando há alertas.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanRiskScore_WhenWarningsArePresent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.High),
+            new SqlPlanWarning("PW2", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning),
+            new SqlPlanWarning("PW3", "m3", "r3", "a3", SqlPlanWarningSeverity.Warning)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, warnings);
+        plan.Should().Contain("- PlanRiskScore: 100");
+    }
+
+    /// <summary>
+    /// EN: Verifies plan risk score is omitted when warnings are absent.
+    /// PT: Verifica que o score de risco do plano é omitido quando não há alertas.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitPlanRiskScore_WhenNoWarnings()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, []);
+
+        plan.Should().NotContain("PlanRiskScore:");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies warning summary is emitted in deterministic severity/code order.
+    /// PT: Verifica que o resumo de warnings é emitido em ordem determinística por severidade/código.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanWarningSummary_WhenWarningsArePresent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW2", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning),
+            new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.High),
+            new SqlPlanWarning("PW3", "m3", "r3", "a3", SqlPlanWarningSeverity.Warning)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, warnings);
+        plan.Should().Contain("- PlanWarningSummary: PW1:High;PW2:Warning;PW3:Warning");
+    }
+
+    /// <summary>
+    /// EN: Verifies warning summary is omitted when warnings are absent.
+    /// PT: Verifica que o resumo de warnings é omitido quando não há alertas.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitPlanWarningSummary_WhenNoWarnings()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, []);
+
+        plan.Should().NotContain("PlanWarningSummary:");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies primary warning is emitted using deterministic severity/code priority.
+    /// PT: Verifica que o warning primário é emitido com prioridade determinística por severidade/código.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanPrimaryWarning_WhenWarningsArePresent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW2", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning),
+            new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.High),
+            new SqlPlanWarning("PW0", "m0", "r0", "a0", SqlPlanWarningSeverity.High)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, warnings);
+        plan.Should().Contain("- PlanPrimaryWarning: PW0:High");
+    }
+
+    /// <summary>
+    /// EN: Verifies primary warning is omitted when warnings are absent.
+    /// PT: Verifica que o warning primário é omitido quando não há alertas.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitPlanPrimaryWarning_WhenNoWarnings()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, []);
+
+        plan.Should().NotContain("PlanPrimaryWarning:");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies index recommendation summary is emitted in parseable format.
+    /// PT: Verifica que o resumo de recomendação de índice é emitido em formato parseável.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitIndexRecommendationSummary_WhenRecommendationsArePresent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var recommendations = new[]
+        {
+            new SqlIndexRecommendation("users", "CREATE INDEX IX_users_Active ON users (Active);", "reason", 80, 120, 60),
+            new SqlIndexRecommendation("users", "CREATE INDEX IX_users_Id ON users (Id);", "reason", 60, 120, 30)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, recommendations, []);
+        plan.Should().Contain("- IndexRecommendationSummary: count:2;avgConfidence:70.00;maxGainPct:75.00");
+    }
+
+    /// <summary>
+    /// EN: Verifies index recommendation summary is omitted when recommendations are absent.
+    /// PT: Verifica que o resumo de recomendação de índice é omitido quando não há recomendações.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitIndexRecommendationSummary_WhenNoRecommendations()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], []);
+
+        plan.Should().NotContain("IndexRecommendationSummary:");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies warning counts are emitted in parseable fixed-key format.
+    /// PT: Verifica que as contagens de warning são emitidas em formato parseável de chaves fixas.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanWarningCounts_WhenWarningsArePresent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.High),
+            new SqlPlanWarning("PW2", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning),
+            new SqlPlanWarning("PW3", "m3", "r3", "a3", SqlPlanWarningSeverity.Warning),
+            new SqlPlanWarning("PW4", "m4", "r4", "a4", SqlPlanWarningSeverity.Info)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, warnings);
+        plan.Should().Contain("- PlanWarningCounts: high:1;warning:2;info:1");
+    }
+
+    /// <summary>
+    /// EN: Verifies warning counts are omitted when warnings are absent.
+    /// PT: Verifica que as contagens de warning são omitidas quando não há alertas.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitPlanWarningCounts_WhenNoWarnings()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, []);
+
+        plan.Should().NotContain("PlanWarningCounts:");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies metadata version marker is always emitted for SELECT plans.
+    /// PT: Verifica que o marcador de versão de metadados é sempre emitido para planos SELECT.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanMetadataVersion()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 1, 1, 1);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], []);
+
+        plan.Should().Contain("- PlanMetadataVersion: 1");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies primary index recommendation is emitted with deterministic selection.
+    /// PT: Verifica que a recomendação primária de índice é emitida com seleção determinística.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitIndexPrimaryRecommendation_WhenRecommendationsArePresent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var recommendations = new[]
+        {
+            new SqlIndexRecommendation("users", "CREATE INDEX IX_users_Active ON users (Active);", "reason", 80, 120, 60),
+            new SqlIndexRecommendation("users", "CREATE INDEX IX_users_Id ON users (Id);", "reason", 80, 120, 30),
+            new SqlIndexRecommendation("accounts", "CREATE INDEX IX_accounts_Status ON accounts (Status);", "reason", 70, 120, 20)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, recommendations, []);
+        plan.Should().Contain("- IndexPrimaryRecommendation: table:users;confidence:80;gainPct:50.00");
+    }
+
+    /// <summary>
+    /// EN: Verifies primary index recommendation is omitted when recommendations are absent.
+    /// PT: Verifica que a recomendação primária de índice é omitida quando não há recomendações.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitIndexPrimaryRecommendation_WhenNoRecommendations()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], []);
+
+        plan.Should().NotContain("IndexPrimaryRecommendation:");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies plan flags are emitted with stable keys and boolean values.
+    /// PT: Verifica que as flags do plano são emitidas com chaves estáveis e valores booleanos.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanFlags_WithWarningsAndRecommendationsState()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var recommendations = new[]
+        {
+            new SqlIndexRecommendation("users", "CREATE INDEX IX_users_Active ON users (Active);", "reason", 80, 120, 60)
+        };
+        var warnings = new[] { new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.Warning) };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, recommendations, warnings);
+        plan.Should().Contain("- PlanFlags: hasWarnings:true;hasIndexRecommendations:true");
+    }
+
+    /// <summary>
+    /// EN: Verifies plan flags reflect no warnings and no index recommendations.
+    /// PT: Verifica que as flags do plano refletem ausência de alerts e recomendações de índice.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanFlags_WithNoWarningsAndNoRecommendations()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 1, 1, 1);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], []);
+
+        plan.Should().Contain("- PlanFlags: hasWarnings:false;hasIndexRecommendations:false");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies performance band is emitted according to elapsed milliseconds.
+    /// PT: Verifica que a faixa de performance é emitida conforme milissegundos de execução.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanPerformanceBand_ForElapsedMsThresholds()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var fastPlan = SqlExecutionPlanFormatter.FormatSelect(query, new SqlPlanRuntimeMetrics(1, 1, 1, 5), [], []);
+        var moderatePlan = SqlExecutionPlanFormatter.FormatSelect(query, new SqlPlanRuntimeMetrics(1, 1, 1, 30), [], []);
+        var slowPlan = SqlExecutionPlanFormatter.FormatSelect(query, new SqlPlanRuntimeMetrics(1, 1, 1, 31), [], []);
+
+        fastPlan.Should().Contain("- PlanPerformanceBand: Fast");
+        moderatePlan.Should().Contain("- PlanPerformanceBand: Moderate");
+        slowPlan.Should().Contain("- PlanPerformanceBand: Slow");
+    }
+
     private static Dictionary<string, string> LoadResxEntries(string path)
     {
         var doc = XDocument.Load(path);


### PR DESCRIPTION
### Motivation
- Provide compact, deterministic and parseable aggregated metadata for execution plans to aid triage and automation while preserving the existing per-warning textual contract (`Code`, `Message`, `Reason`, `SuggestedAction`, `Severity`, `MetricName`, `ObservedValue`, `Threshold`).
- Document delivery control and roadmap for incremental Execution Plan Advisor improvements to standardize rollout and testing expectations.
- Ensure index recommendations remain active and unchanged while adding low-risk summary signals for consumers and tooling.

### Description
- Extended `SqlExecutionPlanFormatter` to emit new top-level textual metadata: `PlanMetadataVersion`, `PlanFlags`, `PlanPerformanceBand`, `PlanRiskScore`, `PlanWarningSummary`, `PlanWarningCounts`, `PlanPrimaryWarning`, `IndexRecommendationSummary`, and `IndexPrimaryRecommendation`, plus helper methods and deterministic ordering/formatting logic for each aggregate (`CalculatePlanRiskScore`, `GetSeverityWeight`, `Append*` helpers).
- Preserved existing per-warning output and technical `Threshold` formatting and added stable parseable formats for all new aggregates (fixed keys, numeric formatting, ordering rules). 
- Updated tests: added many unit tests in `ExecutionPlanFormattingAndI18nTests.cs` validating emission/omission and formats for the new aggregates and performance bands, and adapted `ExecutionPlanPlanWarningsTestsBase.cs` to assert the new markers and to improve `ExtractWarningBlock` logic.
- Added documentation files: `docs/execution-plan-advisor-backlog.md` and `docs/execution-plan-advisor-delivery-control.md`, and updated `docs/p7-p10-implementation-plan.md` with the implementation decisions and checklist for the PlanWarnings/Execution Plan Advisor work.

### Testing
- Added unit tests covering `FormatSelect` behaviors in `src/DbSqlLikeMem.Test/ExecutionPlanFormattingAndI18nTests.cs` for `PlanRiskScore`, `PlanWarningSummary`, `PlanPrimaryWarning`, `IndexRecommendationSummary`, `IndexPrimaryRecommendation`, `PlanWarningCounts`, `PlanMetadataVersion`, `PlanFlags`, and `PlanPerformanceBand` (new tests included in the PR).
- Updated integration-style tests in `src/DbSqlLikeMem.Test/ExecutionPlanPlanWarningsTestsBase.cs` to assert presence of new aggregates and to preserve `IndexRecommendations` behavior; these tests accompany the formatter changes.
- No full automated test run was executed in this environment due to absence of the .NET SDK (`dotnet`) locally; tests are included and expected to be validated by CI where `dotnet test` will run them.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f9a39e2e4832c92ac571ef2741904)