### PR TITLE
Add aggregated plan metadata, JSON payload and recommendation evidence

### DIFF
--- a/docs/execution-plan-advisor-backlog.md
+++ b/docs/execution-plan-advisor-backlog.md
@@ -47,7 +47,7 @@ Organizar as próximas evoluções do Execution Plan Advisor em ondas incrementa
      - testes de regressão com matriz `PW004/PW005`.
 
 ### Onda 2 — Automação/observabilidade
-4. **Payload JSON opcional do plano**
+4. **Payload JSON opcional do plano** ✅
    - Descrição: expor representação estruturada do plano além do texto.
    - Valor: integração robusta com CI, IDE e observabilidade.
    - Risco: médio (serialização e compat).
@@ -55,7 +55,7 @@ Organizar as próximas evoluções do Execution Plan Advisor em ondas incrementa
      - propriedade/retorno opcional JSON;
      - teste de equivalência texto vs JSON para campos comuns.
 
-5. **CorrelationId por execução de plano**
+5. **CorrelationId por execução de plano** ✅
    - Descrição: ID único para rastrear plano em logs/pipelines.
    - Valor: troubleshooting e auditoria.
    - Risco: baixo.
@@ -63,7 +63,7 @@ Organizar as próximas evoluções do Execution Plan Advisor em ondas incrementa
      - campo `PlanCorrelationId` estável;
      - teste de presença e formato.
 
-6. **PlanDelta (comparação entre execuções)**
+6. **PlanDelta (comparação entre execuções)** ✅
    - Descrição: destacar mudança de risco/custo entre última execução e atual.
    - Valor: alerta de regressão de performance.
    - Risco: médio/alto (estado histórico).
@@ -72,7 +72,7 @@ Organizar as próximas evoluções do Execution Plan Advisor em ondas incrementa
      - testes com cenários controlados.
 
 ### Onda 3 — Inteligência de recomendação
-7. **IndexRecommendationEvidence**
+7. **IndexRecommendationEvidence** ✅
    - Descrição: evidências por recomendação (colunas de filtro, ordenação, seletividade estimada).
    - Valor: aumenta confiança do dev ao aplicar índice.
    - Risco: baixo/médio.
@@ -80,7 +80,7 @@ Organizar as próximas evoluções do Execution Plan Advisor em ondas incrementa
      - campo técnico parseável com chave fixa;
      - testes de coerência com query.
 
-8. **PlanPrimaryCauseGroup**
+8. **PlanPrimaryCauseGroup** ✅
    - Descrição: agrupar warnings em causa primária (ex.: "ScanWithoutFilter", "SortWithoutLimit").
    - Valor: reduz complexidade cognitiva.
    - Risco: médio.
@@ -88,7 +88,7 @@ Organizar as próximas evoluções do Execution Plan Advisor em ondas incrementa
      - taxonomia estável documentada;
      - testes de mapeamento por regra.
 
-9. **Hint de severidade escalável por contexto**
+9. **Hint de severidade escalável por contexto** ✅
    - Descrição: calibrar pesos/severidade por perfil de ambiente (dev/ci/prod).
    - Valor: sinal mais aderente ao contexto.
    - Risco: médio/alto.
@@ -99,10 +99,10 @@ Organizar as próximas evoluções do Execution Plan Advisor em ondas incrementa
 ---
 
 ## Itens técnicos transversais
-- [ ] Consolidar padrões parseáveis dos novos agregados em seção única de documentação.
-- [ ] Criar suíte de teste de contrato textual agregados (`Plan*`, `Index*Summary`) com snapshot estável.
-- [ ] Garantir i18n dos novos labels sem traduzir tokens técnicos/canônicos SQL.
-- [ ] Definir política semântica de versionamento para `PlanMetadataVersion`.
+- [x] Consolidar padrões parseáveis dos novos agregados em seção única de documentação.
+- [x] Criar suíte de teste de contrato textual agregados (`Plan*`, `Index*Summary`) com snapshot estável.
+- [x] Garantir i18n dos novos labels sem traduzir tokens técnicos/canônicos SQL.
+- [x] Definir política semântica de versionamento para `PlanMetadataVersion`.
 
 ## Plano de execução recomendado
 1. Executar Onda 1 em PRs pequenos (1 feature por PR).

--- a/docs/execution-plan-advisor-delivery-control.md
+++ b/docs/execution-plan-advisor-delivery-control.md
@@ -42,6 +42,46 @@ Evoluir incrementalmente o Execution Plan Advisor para aumentar valor ao desenvo
   **Progresso do item:** 100%
 - [x] Cobrir `PlanPerformanceBand` com testes unitários e integração base.  
   **Progresso do item:** 100%
+- [x] Implementar `PlanQualityGrade` (A/B/C/D) derivado de `PlanRiskScore` + `PlanPerformanceBand`.  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanQualityGrade` com testes unitários e integração base (presença/ausência + thresholds).  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanTopActions` (Top 3 ações) derivado de warnings/recomendações com ordenação determinística.  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanTopActions` com testes unitários e integração base (presença/ausência + limite de 3).  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanNoiseScore` para quantificação de redundância de warnings.  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanNoiseScore` com testes unitários e integração base (presença/ausência + matriz PW004/PW005).  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanCorrelationId` por execução de plano.  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanCorrelationId` com testes de presença e formato técnico estável.  
+  **Progresso do item:** 100%
+- [x] Criar suíte de contrato textual para agregados (`Plan*`, `Index*Summary`) com assertiva estável em testes de formatter.  
+  **Progresso do item:** 100%
+- [x] Consolidar padrões parseáveis dos agregados em seção única de documentação.  
+  **Progresso do item:** 100%
+- [x] Definir política semântica de versionamento para `PlanMetadataVersion`.  
+  **Progresso do item:** 100%
+- [x] Garantir i18n dos labels agregados `Plan*`/`Index*` sem traduzir tokens técnicos canônicos.  
+  **Progresso do item:** 100%
+- [x] Implementar payload JSON opcional do plano para campos agregados comuns.  
+  **Progresso do item:** 100%
+- [x] Cobrir equivalência texto vs JSON para campos comuns e ausência de campos derivados sem warnings.  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanPrimaryCauseGroup` para agrupamento da causa principal por warning primário.  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanPrimaryCauseGroup` com testes de presença/ausência e equivalência com payload JSON opcional.  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanDelta` para comparação opcional entre execução atual e snapshot anterior.  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanDelta` com testes de presença/ausência e cenário controlado de delta.  
+  **Progresso do item:** 100%
+- [x] Implementar `PlanSeverityHint` com contexto escalável (`dev|ci|prod`) sem quebrar defaults.  
+  **Progresso do item:** 100%
+- [x] Cobrir `PlanSeverityHint` com testes de default e override de contexto.  
+  **Progresso do item:** 100%
 - [x] Atualizar plano principal (`docs/p7-p10-implementation-plan.md`) com decisões/checklist da rodada atual.  
   **Progresso do item:** 100%
 
@@ -60,15 +100,41 @@ Evoluir incrementalmente o Execution Plan Advisor para aumentar valor ao desenvo
 - **99.9%** — `IndexPrimaryRecommendation` implementado e coberto.
 - **99.95%** — `PlanFlags` implementado e coberto.
 - **99.97%** — `PlanPerformanceBand` implementado e coberto.
-- **100%** — documentação consolidada e plano principal atualizado.
+- **99.99%** — `PlanQualityGrade` implementado e coberto.
+- **99.995%** — `PlanTopActions` implementado e coberto.
+- **99.998%** — `PlanNoiseScore` implementado e coberto.
+- **99.999%** — `PlanCorrelationId` implementado e coberto.
+- **100%** — suíte de contrato textual, i18n, payload JSON, deltas/hints contextuais, evidências e governança de contrato consolidados.
 
 ## Escopo e segurança
 - Sem refatoração agressiva.
 - Sem alteração da ordem do contrato textual interno de cada warning (`Code`, `Message`, `Reason`, `SuggestedAction`, `Severity`, `MetricName`, `ObservedValue`, `Threshold`).
 - `Threshold` técnico parseável preservado (`key:value;key:value`).
 - `IndexRecommendations` preservado.
-- Novos campos agregados (`PlanMetadataVersion`, `PlanFlags`, `PlanPerformanceBand`, `PlanRiskScore`, `PlanWarningSummary`, `PlanWarningCounts`, `PlanPrimaryWarning`, `IndexRecommendationSummary`, `IndexPrimaryRecommendation`) adicionados de forma incremental e backward-compatible no output textual.
+- Novos campos agregados (`PlanMetadataVersion`, `PlanCorrelationId`, `PlanFlags`, `PlanPerformanceBand`, `PlanRiskScore`, `PlanQualityGrade`, `PlanWarningSummary`, `PlanWarningCounts`, `PlanNoiseScore`, `PlanTopActions`, `PlanPrimaryWarning`, `PlanPrimaryCauseGroup`, `PlanDelta`, `PlanSeverityHint`, `IndexRecommendationSummary`, `IndexPrimaryRecommendation`, `IndexRecommendationEvidence`) adicionados de forma incremental e backward-compatible no output textual.
 
 
 ## Referência de backlog
 - Backlog completo de próximas evoluções: `docs/execution-plan-advisor-backlog.md`.
+
+
+## Padrões parseáveis consolidados
+- `PlanMetadataVersion: <int>`
+- `PlanCorrelationId: <32hexLower>`
+- `PlanFlags: hasWarnings:<true|false>;hasIndexRecommendations:<true|false>`
+- `PlanPerformanceBand: <Fast|Moderate|Slow>`
+- `PlanRiskScore: <0..100>`
+- `PlanQualityGrade: <A|B|C|D>`
+- `PlanWarningSummary: <Code>:<Severity>[;<Code>:<Severity>...]`
+- `PlanWarningCounts: high:<n>;warning:<n>;info:<n>`
+- `PlanNoiseScore: <0..100>`
+- `PlanTopActions: <code>:<actionKey>[;<code>:<actionKey>...]`
+- `PlanPrimaryWarning: <Code>:<Severity>`
+- `IndexRecommendationSummary: count:<n>;avgConfidence:<n.nn>;maxGainPct:<n.nn>`
+- `IndexPrimaryRecommendation: table:<name>;confidence:<n>;gainPct:<n.nn>`
+
+## Política semântica de versionamento (`PlanMetadataVersion`)
+- Incrementar **major** (ex.: `1 -> 2`) quando houver quebra de parsing esperado para consumidores (remoção/renomeação de chave, mudança de formato canônico).
+- Incrementar **minor** via documentação/checklist quando houver apenas adição backward-compatible de novos agregados sem alterar formato dos existentes.
+- Não alterar retroativamente o significado de chaves canônicas já publicadas.
+- Garantir teste de contrato textual para novos agregados antes de promover versão.

--- a/src/DbSqlLikeMem.Test/ExecutionPlanFormattingAndI18nTests.cs
+++ b/src/DbSqlLikeMem.Test/ExecutionPlanFormattingAndI18nTests.cs
@@ -1,6 +1,7 @@
 using System.Xml.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Text.Json;
 
 namespace DbSqlLikeMem.Test;
 
@@ -190,6 +191,137 @@ public sealed class ExecutionPlanFormattingAndI18nTests
 
 
     /// <summary>
+    /// EN: Verifies quality grade is emitted when warnings are present.
+    /// PT: Verifica que a nota qualitativa do plano é emitida quando há alertas.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanQualityGrade_WhenWarningsArePresent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.Warning)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, warnings);
+        plan.Should().Contain("- PlanQualityGrade: C");
+    }
+
+    /// <summary>
+    /// EN: Verifies quality grade is omitted when warnings are absent.
+    /// PT: Verifica que a nota qualitativa do plano é omitida quando não há alertas.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitPlanQualityGrade_WhenNoWarnings()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, []);
+
+        plan.Should().NotContain("PlanQualityGrade:");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies quality grade thresholds from risk score and performance band remain stable.
+    /// PT: Verifica que os thresholds da nota qualitativa por risco e performance permanecem estáveis.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanQualityGrade_WithStableThresholdRules()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var infoWarning = new[] { new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.Info) };
+        var warningOnly = new[] { new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.Warning) };
+        var highWarning = new[] { new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.High) };
+
+        var gradeA = SqlExecutionPlanFormatter.FormatSelect(query, new SqlPlanRuntimeMetrics(1, 1, 1, 5), null, infoWarning);
+        var gradeB = SqlExecutionPlanFormatter.FormatSelect(query, new SqlPlanRuntimeMetrics(1, 1, 1, 5), null, warningOnly);
+        var gradeC = SqlExecutionPlanFormatter.FormatSelect(query, new SqlPlanRuntimeMetrics(1, 1, 1, 6), null, warningOnly);
+        var gradeD = SqlExecutionPlanFormatter.FormatSelect(query, new SqlPlanRuntimeMetrics(1, 1, 1, 31), null, warningOnly);
+        var gradeCFromHighRiskFastBand = SqlExecutionPlanFormatter.FormatSelect(query, new SqlPlanRuntimeMetrics(1, 1, 1, 5), null, highWarning);
+
+        gradeA.Should().Contain("- PlanQualityGrade: A");
+        gradeB.Should().Contain("- PlanQualityGrade: B");
+        gradeC.Should().Contain("- PlanQualityGrade: C");
+        gradeD.Should().Contain("- PlanQualityGrade: D");
+        gradeCFromHighRiskFastBand.Should().Contain("- PlanQualityGrade: C");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies risk-score boundary mapping for quality grade on fast band.
+    /// PT: Verifica o mapeamento dos limites de score de risco para nota qualitativa na banda Fast.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldMapPlanQualityGrade_ByRiskScoreBoundaries_OnFastBand()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var fastMetrics = new SqlPlanRuntimeMetrics(1, 1, 1, 5);
+
+        var gradeAWarnings = new[]
+        {
+            new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.Info),
+            new SqlPlanWarning("PW2", "m2", "r2", "a2", SqlPlanWarningSeverity.Info)
+        };
+
+        var gradeBWarnings = new[]
+        {
+            new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.Warning),
+            new SqlPlanWarning("PW2", "m2", "r2", "a2", SqlPlanWarningSeverity.Info),
+            new SqlPlanWarning("PW3", "m3", "r3", "a3", SqlPlanWarningSeverity.Info)
+        };
+
+        var gradeCWarnings = new[]
+        {
+            new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.High),
+            new SqlPlanWarning("PW2", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning)
+        };
+
+        var gradeDWarnings = new[]
+        {
+            new SqlPlanWarning("PW1", "m1", "r1", "a1", SqlPlanWarningSeverity.High),
+            new SqlPlanWarning("PW2", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning),
+            new SqlPlanWarning("PW3", "m3", "r3", "a3", SqlPlanWarningSeverity.Info),
+            new SqlPlanWarning("PW4", "m4", "r4", "a4", SqlPlanWarningSeverity.Info)
+        };
+
+        SqlExecutionPlanFormatter.FormatSelect(query, fastMetrics, null, gradeAWarnings)
+            .Should().Contain("- PlanRiskScore: 20")
+            .And.Contain("- PlanQualityGrade: A");
+
+        SqlExecutionPlanFormatter.FormatSelect(query, fastMetrics, null, gradeBWarnings)
+            .Should().Contain("- PlanRiskScore: 50")
+            .And.Contain("- PlanQualityGrade: B");
+
+        SqlExecutionPlanFormatter.FormatSelect(query, fastMetrics, null, gradeCWarnings)
+            .Should().Contain("- PlanRiskScore: 80")
+            .And.Contain("- PlanQualityGrade: C");
+
+        SqlExecutionPlanFormatter.FormatSelect(query, fastMetrics, null, gradeDWarnings)
+            .Should().Contain("- PlanRiskScore: 100")
+            .And.Contain("- PlanQualityGrade: D");
+    }
+
+
+
+    /// <summary>
     /// EN: Verifies warning summary is emitted in deterministic severity/code order.
     /// PT: Verifica que o resumo de warnings é emitido em ordem determinística por severidade/código.
     /// </summary>
@@ -276,6 +408,48 @@ public sealed class ExecutionPlanFormattingAndI18nTests
 
 
     /// <summary>
+    /// EN: Verifies primary cause group is emitted from primary warning mapping.
+    /// PT: Verifica que o grupo de causa primária é emitido a partir do mapeamento do warning primário.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanPrimaryCauseGroup_WhenWarningsArePresent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW002", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning),
+            new SqlPlanWarning("PW001", "m1", "r1", "a1", SqlPlanWarningSeverity.High)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, warnings);
+        plan.Should().Contain("- PlanPrimaryCauseGroup: SortWithoutLimit");
+    }
+
+    /// <summary>
+    /// EN: Verifies primary cause group is omitted when warnings are absent.
+    /// PT: Verifica que o grupo de causa primária é omitido quando não há warnings.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitPlanPrimaryCauseGroup_WhenNoWarnings()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, []);
+
+        plan.Should().NotContain("PlanPrimaryCauseGroup:");
+    }
+
+
+    /// <summary>
     /// EN: Verifies index recommendation summary is emitted in parseable format.
     /// PT: Verifica que o resumo de recomendação de índice é emitido em formato parseável.
     /// </summary>
@@ -314,6 +488,47 @@ public sealed class ExecutionPlanFormattingAndI18nTests
         var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], []);
 
         plan.Should().NotContain("IndexRecommendationSummary:");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies index recommendation evidence is emitted in parseable deterministic format.
+    /// PT: Verifica que a evidência de recomendação de índice é emitida em formato parseável e determinístico.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitIndexRecommendationEvidence_WhenRecommendationsArePresent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var recommendations = new[]
+        {
+            new SqlIndexRecommendation("users", "CREATE INDEX IX_users_Active_Id ON users (Active, Id);", "reason", 80, 120, 60)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, recommendations, []);
+        plan.Should().Contain("- IndexRecommendationEvidence: table:users;indexCols:Active,Id;confidence:80;gainPct:50.00");
+    }
+
+    /// <summary>
+    /// EN: Verifies index recommendation evidence is omitted when recommendations are absent.
+    /// PT: Verifica que a evidência de recomendação de índice é omitida quando não há recomendações.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitIndexRecommendationEvidence_WhenNoRecommendations()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], []);
+
+        plan.Should().NotContain("IndexRecommendationEvidence:");
     }
 
 
@@ -362,9 +577,171 @@ public sealed class ExecutionPlanFormattingAndI18nTests
 
 
     /// <summary>
-    /// EN: Verifies metadata version marker is always emitted for SELECT plans.
-    /// PT: Verifica que o marcador de versão de metadados é sempre emitido para planos SELECT.
+    /// EN: Verifies noise score is emitted when warnings are present.
+    /// PT: Verifica que o score de ruído é emitido quando há warnings.
     /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanNoiseScore_WhenWarningsArePresent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW004", "m1", "r1", "a1", SqlPlanWarningSeverity.Warning, "EstimatedRowsRead", "120", "gte:100;highGte:5000"),
+            new SqlPlanWarning("PW005", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning, "EstimatedRowsRead", "120", "gte:100;highGte:5000")
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, warnings);
+
+        plan.Should().Contain("- PlanNoiseScore: 50");
+    }
+
+    /// <summary>
+    /// EN: Verifies noise score is omitted when warnings are absent.
+    /// PT: Verifica que o score de ruído é omitido quando não há warnings.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitPlanNoiseScore_WhenNoWarnings()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, null, []);
+
+        plan.Should().NotContain("PlanNoiseScore:");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies top actions are emitted in deterministic priority order and capped at 3.
+    /// PT: Verifica que as ações prioritárias são emitidas em ordem determinística e limitadas a 3.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanTopActions_WithDeterministicOrderAndCap()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW003", "m3", "r3", "a3", SqlPlanWarningSeverity.Warning),
+            new SqlPlanWarning("PW001", "m1", "r1", "a1", SqlPlanWarningSeverity.High),
+            new SqlPlanWarning("PW005", "m5", "r5", "a5", SqlPlanWarningSeverity.Warning),
+            new SqlPlanWarning("PW004", "m4", "r4", "a4", SqlPlanWarningSeverity.Info)
+        };
+        var recommendations = new[]
+        {
+            new SqlIndexRecommendation("users", "CREATE INDEX IX_users_Active ON users (Active);", "reason", 80, 120, 60)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, recommendations, warnings);
+        plan.Should().Contain("- PlanTopActions: PW001:AddSelectiveFilter;PW003:ReduceProjectionColumns;PW005:CreateDistinctCoveringIndex");
+    }
+
+    /// <summary>
+    /// EN: Verifies top actions include index recommendation action when warnings are absent.
+    /// PT: Verifica que as ações incluem recomendação de índice quando não há warnings.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanTopActions_FromIndexRecommendations_WhenWarningsAreAbsent()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var recommendations = new[]
+        {
+            new SqlIndexRecommendation("users", "CREATE INDEX IX_users_Active ON users (Active);", "reason", 80, 120, 60)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, recommendations, []);
+
+        plan.Should().Contain("- PlanTopActions: IDX:CreateSuggestedIndex");
+    }
+
+    /// <summary>
+    /// EN: Verifies top actions are omitted when warnings and recommendations are absent.
+    /// PT: Verifica que as ações são omitidas quando não há warnings e nem recomendações.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldNotEmitPlanTopActions_WhenNoWarningsAndNoRecommendations()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], []);
+
+        plan.Should().NotContain("PlanTopActions:");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies plan delta is emitted when previous metrics are provided.
+    /// PT: Verifica que o delta do plano é emitido quando métricas anteriores são fornecidas.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanDelta_WhenPreviousMetricsAreProvided()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var current = new SqlPlanRuntimeMetrics(1, 120, 12, 31);
+        var previous = new SqlPlanRuntimeMetrics(1, 80, 10, 20);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW001", "m1", "r1", "a1", SqlPlanWarningSeverity.High)
+        };
+        var previousWarnings = new[]
+        {
+            new SqlPlanWarning("PW002", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, current, [], warnings, previous, previousWarnings);
+        plan.Should().Contain($"- {SqlExecutionPlanMessages.PlanDeltaLabel()}: riskDelta:+20;elapsedMsDelta:+11");
+    }
+
+    /// <summary>
+    /// EN: Verifies severity hint context can be overridden and reflected in output.
+    /// PT: Verifica que o contexto do hint de severidade pode ser sobrescrito e refletido no output.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanSeverityHint_WithContextOverride()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 10);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW002", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning)
+        };
+
+        var devPlan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], warnings, null, null, SqlPlanSeverityHintContext.Dev);
+        var prodPlan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], warnings, null, null, SqlPlanSeverityHintContext.Prod);
+
+        devPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanSeverityHintLabel()}: context:dev;level:Info");
+        prodPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanSeverityHintLabel()}: context:prod;level:Warning");
+    }
+
     [Fact]
     public void FormatSelect_ShouldEmitPlanMetadataVersion()
     {
@@ -377,6 +754,142 @@ public sealed class ExecutionPlanFormattingAndI18nTests
         var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], []);
 
         plan.Should().Contain("- PlanMetadataVersion: 1");
+    }
+
+
+    /// <summary>
+    /// EN: Verifies plan correlation id is emitted with stable technical format.
+    /// PT: Verifica que o correlation id do plano é emitido em formato técnico estável.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitPlanCorrelationId_WithStableFormat()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 1, 1, 1);
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, [], []);
+
+        var correlationId = plan
+            .Split(new[] { Environment.NewLine }, StringSplitOptions.None)
+            .First(line => line.StartsWith("- PlanCorrelationId:", StringComparison.Ordinal))
+            .Split(':', 2)[1]
+            .Trim();
+
+        CorrelationIdPattern.IsMatch(correlationId).Should().BeTrue();
+    }
+
+
+    /// <summary>
+    /// EN: Verifies optional JSON payload mirrors common aggregated metadata from text output.
+    /// PT: Verifica que o payload JSON opcional espelha metadados agregados comuns do output textual.
+    /// </summary>
+    [Fact]
+    public void FormatSelectJson_ShouldMatchTextOutput_ForCommonAggregatedFields()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 31);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW001", "m1", "r1", "a1", SqlPlanWarningSeverity.High, "EstimatedRowsRead", "120", "gte:100;highGte:5000")
+        };
+        var recommendations = new[]
+        {
+            new SqlIndexRecommendation("users", "CREATE INDEX IX_users_Active ON users (Active);", "reason", 80, 120, 60)
+        };
+
+        var previous = new SqlPlanRuntimeMetrics(1, 100, 10, 20);
+        var previousWarnings = new[] { new SqlPlanWarning("PW002", "m2", "r2", "a2", SqlPlanWarningSeverity.Warning) };
+
+        var textPlan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, recommendations, warnings, previous, previousWarnings, SqlPlanSeverityHintContext.Prod);
+        var json = SqlExecutionPlanFormatter.FormatSelectJson(query, metrics, recommendations, warnings, previous, previousWarnings, SqlPlanSeverityHintContext.Prod);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanMetadataVersionLabel()}: {root.GetProperty("planMetadataVersion").GetInt32()}");
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanFlagsLabel()}: {root.GetProperty("planFlags").GetString()}");
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanPerformanceBandLabel()}: {root.GetProperty("planPerformanceBand").GetString()}");
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanRiskScoreLabel()}: {root.GetProperty("planRiskScore").GetInt32()}");
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanQualityGradeLabel()}: {root.GetProperty("planQualityGrade").GetString()}");
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanTopActionsLabel()}: {root.GetProperty("planTopActions").GetString()}");
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanPrimaryCauseGroupLabel()}: {root.GetProperty("planPrimaryCauseGroup").GetString()}");
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanSeverityHintLabel()}: {root.GetProperty("planSeverityHint").GetString()}");
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.PlanDeltaLabel()}: {root.GetProperty("planDelta").GetString()}");
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.IndexRecommendationSummaryLabel()}: {root.GetProperty("indexRecommendationSummary").GetString()}");
+        textPlan.Should().Contain($"- {SqlExecutionPlanMessages.IndexRecommendationEvidenceLabel()}: {root.GetProperty("indexRecommendationEvidence").GetString()}");
+    }
+
+    /// <summary>
+    /// EN: Verifies optional JSON payload omits warning-derived fields when warnings are absent.
+    /// PT: Verifica que o payload JSON opcional omite campos derivados de warning quando não há warnings.
+    /// </summary>
+    [Fact]
+    public void FormatSelectJson_ShouldOmitWarningDerivedFields_WhenNoWarnings()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 1, 1, 5);
+        var json = SqlExecutionPlanFormatter.FormatSelectJson(query, metrics, [], []);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.TryGetProperty("planRiskScore", out _).Should().BeFalse();
+        root.TryGetProperty("planQualityGrade", out _).Should().BeFalse();
+        root.TryGetProperty("planWarningSummary", out _).Should().BeFalse();
+        root.TryGetProperty("planTopActions", out _).Should().BeFalse();
+        root.TryGetProperty("planPrimaryCauseGroup", out _).Should().BeFalse();
+        root.TryGetProperty("planSeverityHint", out _).Should().BeFalse();
+        root.TryGetProperty("planDelta", out _).Should().BeFalse();
+    }
+
+
+    /// <summary>
+    /// EN: Verifies aggregated metadata contract is emitted with parseable stable prefixes.
+    /// PT: Verifica que o contrato de metadados agregados é emitido com prefixos parseáveis estáveis.
+    /// </summary>
+    [Fact]
+    public void FormatSelect_ShouldEmitStableAggregatedMetadataContract_ForWarningsAndRecommendations()
+    {
+        var query = new SqlSelectQuery([], false, [new SqlSelectItem("Id", null)], [], null, [], null, [], null)
+        {
+            Table = new SqlTableSource(null, "users", null, null, null, null, null)
+        };
+
+        var metrics = new SqlPlanRuntimeMetrics(1, 120, 12, 31);
+        var warnings = new[]
+        {
+            new SqlPlanWarning("PW001", "m1", "r1", "a1", SqlPlanWarningSeverity.High, "EstimatedRowsRead", "120", "gte:100;highGte:5000"),
+            new SqlPlanWarning("PW005", "m5", "r5", "a5", SqlPlanWarningSeverity.Warning, "EstimatedRowsRead", "120", "gte:100;highGte:5000")
+        };
+        var recommendations = new[]
+        {
+            new SqlIndexRecommendation("users", "CREATE INDEX IX_users_Active ON users (Active);", "reason", 80, 120, 60)
+        };
+
+        var plan = SqlExecutionPlanFormatter.FormatSelect(query, metrics, recommendations, warnings);
+
+        plan.Should().Contain("- PlanMetadataVersion: 1");
+        plan.Should().Contain("- PlanCorrelationId:");
+        plan.Should().Contain("- PlanFlags: hasWarnings:true;hasIndexRecommendations:true");
+        plan.Should().Contain("- PlanPerformanceBand: Slow");
+        plan.Should().Contain("- PlanRiskScore: 80");
+        plan.Should().Contain("- PlanQualityGrade: D");
+        plan.Should().Contain("- PlanWarningSummary: PW001:High;PW005:Warning");
+        plan.Should().Contain("- PlanWarningCounts: high:1;warning:1;info:0");
+        plan.Should().Contain("- PlanNoiseScore: 50");
+        plan.Should().Contain("- PlanTopActions: PW001:AddSelectiveFilter;PW005:CreateDistinctCoveringIndex;IDX:CreateSuggestedIndex");
+        plan.Should().Contain("- PlanPrimaryWarning: PW001:High");
+        plan.Should().Contain("- IndexRecommendationSummary: count:1;avgConfidence:80.00;maxGainPct:50.00");
+        plan.Should().Contain("- IndexPrimaryRecommendation: table:users;confidence:80;gainPct:50.00");
     }
 
 

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.cs
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.cs
@@ -47,6 +47,24 @@ internal static class SqlExecutionPlanMessages
     public static string ObservedValueLabel() => Format(nameof(ObservedValueLabel));
     public static string ThresholdLabel() => Format(nameof(ThresholdLabel));
 
+    public static string PlanMetadataVersionLabel() => Format(nameof(PlanMetadataVersionLabel));
+    public static string PlanCorrelationIdLabel() => Format(nameof(PlanCorrelationIdLabel));
+    public static string PlanFlagsLabel() => Format(nameof(PlanFlagsLabel));
+    public static string PlanPerformanceBandLabel() => Format(nameof(PlanPerformanceBandLabel));
+    public static string PlanRiskScoreLabel() => Format(nameof(PlanRiskScoreLabel));
+    public static string PlanQualityGradeLabel() => Format(nameof(PlanQualityGradeLabel));
+    public static string PlanWarningSummaryLabel() => Format(nameof(PlanWarningSummaryLabel));
+    public static string PlanWarningCountsLabel() => Format(nameof(PlanWarningCountsLabel));
+    public static string PlanNoiseScoreLabel() => Format(nameof(PlanNoiseScoreLabel));
+    public static string PlanTopActionsLabel() => Format(nameof(PlanTopActionsLabel));
+    public static string PlanPrimaryWarningLabel() => Format(nameof(PlanPrimaryWarningLabel));
+    public static string PlanPrimaryCauseGroupLabel() => Format(nameof(PlanPrimaryCauseGroupLabel));
+    public static string PlanDeltaLabel() => Format(nameof(PlanDeltaLabel));
+    public static string PlanSeverityHintLabel() => Format(nameof(PlanSeverityHintLabel));
+    public static string IndexRecommendationSummaryLabel() => Format(nameof(IndexRecommendationSummaryLabel));
+    public static string IndexPrimaryRecommendationLabel() => Format(nameof(IndexPrimaryRecommendationLabel));
+    public static string IndexRecommendationEvidenceLabel() => Format(nameof(IndexRecommendationEvidenceLabel));
+
     public static string ReasonFilterAndOrder(string filters, string orders, string key)
         => Format(nameof(ReasonFilterAndOrder), filters, orders, key);
 

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.de.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.de.resx
@@ -207,4 +207,55 @@
   <data name="SeverityHighValue" xml:space="preserve">
     <value>Hoch</value>
   </data>
+  <data name="PlanMetadataVersionLabel" xml:space="preserve">
+    <value>PlanMetadataVersion</value>
+  </data>
+  <data name="PlanCorrelationIdLabel" xml:space="preserve">
+    <value>PlanCorrelationId</value>
+  </data>
+  <data name="PlanFlagsLabel" xml:space="preserve">
+    <value>PlanFlags</value>
+  </data>
+  <data name="PlanPerformanceBandLabel" xml:space="preserve">
+    <value>PlanPerformanceBand</value>
+  </data>
+  <data name="PlanRiskScoreLabel" xml:space="preserve">
+    <value>PlanRiskScore</value>
+  </data>
+  <data name="PlanQualityGradeLabel" xml:space="preserve">
+    <value>PlanQualityGrade</value>
+  </data>
+  <data name="PlanWarningSummaryLabel" xml:space="preserve">
+    <value>PlanWarningSummary</value>
+  </data>
+  <data name="PlanWarningCountsLabel" xml:space="preserve">
+    <value>PlanWarningCounts</value>
+  </data>
+  <data name="PlanNoiseScoreLabel" xml:space="preserve">
+    <value>PlanNoiseScore</value>
+  </data>
+  <data name="PlanTopActionsLabel" xml:space="preserve">
+    <value>PlanTopActions</value>
+  </data>
+  <data name="PlanPrimaryWarningLabel" xml:space="preserve">
+    <value>PlanPrimaryWarning</value>
+  </data>
+  <data name="IndexRecommendationSummaryLabel" xml:space="preserve">
+    <value>IndexRecommendationSummary</value>
+  </data>
+  <data name="IndexPrimaryRecommendationLabel" xml:space="preserve">
+    <value>IndexPrimaryRecommendation</value>
+  </data>
+  <data name="PlanPrimaryCauseGroupLabel" xml:space="preserve">
+    <value>PlanPrimaryCauseGroup</value>
+  </data>
+  <data name="IndexRecommendationEvidenceLabel" xml:space="preserve">
+    <value>IndexRecommendationEvidence</value>
+  </data>
+  <data name="PlanDeltaLabel" xml:space="preserve">
+    <value>PlanDelta</value>
+  </data>
+  <data name="PlanSeverityHintLabel" xml:space="preserve">
+    <value>PlanSeverityHint</value>
+  </data>
 </root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.es.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.es.resx
@@ -207,4 +207,55 @@
   <data name="SeverityHighValue" xml:space="preserve">
     <value>Alta</value>
   </data>
+  <data name="PlanMetadataVersionLabel" xml:space="preserve">
+    <value>PlanMetadataVersion</value>
+  </data>
+  <data name="PlanCorrelationIdLabel" xml:space="preserve">
+    <value>PlanCorrelationId</value>
+  </data>
+  <data name="PlanFlagsLabel" xml:space="preserve">
+    <value>PlanFlags</value>
+  </data>
+  <data name="PlanPerformanceBandLabel" xml:space="preserve">
+    <value>PlanPerformanceBand</value>
+  </data>
+  <data name="PlanRiskScoreLabel" xml:space="preserve">
+    <value>PlanRiskScore</value>
+  </data>
+  <data name="PlanQualityGradeLabel" xml:space="preserve">
+    <value>PlanQualityGrade</value>
+  </data>
+  <data name="PlanWarningSummaryLabel" xml:space="preserve">
+    <value>PlanWarningSummary</value>
+  </data>
+  <data name="PlanWarningCountsLabel" xml:space="preserve">
+    <value>PlanWarningCounts</value>
+  </data>
+  <data name="PlanNoiseScoreLabel" xml:space="preserve">
+    <value>PlanNoiseScore</value>
+  </data>
+  <data name="PlanTopActionsLabel" xml:space="preserve">
+    <value>PlanTopActions</value>
+  </data>
+  <data name="PlanPrimaryWarningLabel" xml:space="preserve">
+    <value>PlanPrimaryWarning</value>
+  </data>
+  <data name="IndexRecommendationSummaryLabel" xml:space="preserve">
+    <value>IndexRecommendationSummary</value>
+  </data>
+  <data name="IndexPrimaryRecommendationLabel" xml:space="preserve">
+    <value>IndexPrimaryRecommendation</value>
+  </data>
+  <data name="PlanPrimaryCauseGroupLabel" xml:space="preserve">
+    <value>PlanPrimaryCauseGroup</value>
+  </data>
+  <data name="IndexRecommendationEvidenceLabel" xml:space="preserve">
+    <value>IndexRecommendationEvidence</value>
+  </data>
+  <data name="PlanDeltaLabel" xml:space="preserve">
+    <value>PlanDelta</value>
+  </data>
+  <data name="PlanSeverityHintLabel" xml:space="preserve">
+    <value>PlanSeverityHint</value>
+  </data>
 </root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.fr.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.fr.resx
@@ -207,4 +207,55 @@
   <data name="SeverityHighValue" xml:space="preserve">
     <value>Elevee</value>
   </data>
+  <data name="PlanMetadataVersionLabel" xml:space="preserve">
+    <value>PlanMetadataVersion</value>
+  </data>
+  <data name="PlanCorrelationIdLabel" xml:space="preserve">
+    <value>PlanCorrelationId</value>
+  </data>
+  <data name="PlanFlagsLabel" xml:space="preserve">
+    <value>PlanFlags</value>
+  </data>
+  <data name="PlanPerformanceBandLabel" xml:space="preserve">
+    <value>PlanPerformanceBand</value>
+  </data>
+  <data name="PlanRiskScoreLabel" xml:space="preserve">
+    <value>PlanRiskScore</value>
+  </data>
+  <data name="PlanQualityGradeLabel" xml:space="preserve">
+    <value>PlanQualityGrade</value>
+  </data>
+  <data name="PlanWarningSummaryLabel" xml:space="preserve">
+    <value>PlanWarningSummary</value>
+  </data>
+  <data name="PlanWarningCountsLabel" xml:space="preserve">
+    <value>PlanWarningCounts</value>
+  </data>
+  <data name="PlanNoiseScoreLabel" xml:space="preserve">
+    <value>PlanNoiseScore</value>
+  </data>
+  <data name="PlanTopActionsLabel" xml:space="preserve">
+    <value>PlanTopActions</value>
+  </data>
+  <data name="PlanPrimaryWarningLabel" xml:space="preserve">
+    <value>PlanPrimaryWarning</value>
+  </data>
+  <data name="IndexRecommendationSummaryLabel" xml:space="preserve">
+    <value>IndexRecommendationSummary</value>
+  </data>
+  <data name="IndexPrimaryRecommendationLabel" xml:space="preserve">
+    <value>IndexPrimaryRecommendation</value>
+  </data>
+  <data name="PlanPrimaryCauseGroupLabel" xml:space="preserve">
+    <value>PlanPrimaryCauseGroup</value>
+  </data>
+  <data name="IndexRecommendationEvidenceLabel" xml:space="preserve">
+    <value>IndexRecommendationEvidence</value>
+  </data>
+  <data name="PlanDeltaLabel" xml:space="preserve">
+    <value>PlanDelta</value>
+  </data>
+  <data name="PlanSeverityHintLabel" xml:space="preserve">
+    <value>PlanSeverityHint</value>
+  </data>
 </root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.it.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.it.resx
@@ -207,4 +207,55 @@
   <data name="SeverityHighValue" xml:space="preserve">
     <value>Alta</value>
   </data>
+  <data name="PlanMetadataVersionLabel" xml:space="preserve">
+    <value>PlanMetadataVersion</value>
+  </data>
+  <data name="PlanCorrelationIdLabel" xml:space="preserve">
+    <value>PlanCorrelationId</value>
+  </data>
+  <data name="PlanFlagsLabel" xml:space="preserve">
+    <value>PlanFlags</value>
+  </data>
+  <data name="PlanPerformanceBandLabel" xml:space="preserve">
+    <value>PlanPerformanceBand</value>
+  </data>
+  <data name="PlanRiskScoreLabel" xml:space="preserve">
+    <value>PlanRiskScore</value>
+  </data>
+  <data name="PlanQualityGradeLabel" xml:space="preserve">
+    <value>PlanQualityGrade</value>
+  </data>
+  <data name="PlanWarningSummaryLabel" xml:space="preserve">
+    <value>PlanWarningSummary</value>
+  </data>
+  <data name="PlanWarningCountsLabel" xml:space="preserve">
+    <value>PlanWarningCounts</value>
+  </data>
+  <data name="PlanNoiseScoreLabel" xml:space="preserve">
+    <value>PlanNoiseScore</value>
+  </data>
+  <data name="PlanTopActionsLabel" xml:space="preserve">
+    <value>PlanTopActions</value>
+  </data>
+  <data name="PlanPrimaryWarningLabel" xml:space="preserve">
+    <value>PlanPrimaryWarning</value>
+  </data>
+  <data name="IndexRecommendationSummaryLabel" xml:space="preserve">
+    <value>IndexRecommendationSummary</value>
+  </data>
+  <data name="IndexPrimaryRecommendationLabel" xml:space="preserve">
+    <value>IndexPrimaryRecommendation</value>
+  </data>
+  <data name="PlanPrimaryCauseGroupLabel" xml:space="preserve">
+    <value>PlanPrimaryCauseGroup</value>
+  </data>
+  <data name="IndexRecommendationEvidenceLabel" xml:space="preserve">
+    <value>IndexRecommendationEvidence</value>
+  </data>
+  <data name="PlanDeltaLabel" xml:space="preserve">
+    <value>PlanDelta</value>
+  </data>
+  <data name="PlanSeverityHintLabel" xml:space="preserve">
+    <value>PlanSeverityHint</value>
+  </data>
 </root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.pt.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.pt.resx
@@ -207,4 +207,55 @@
   <data name="SeverityHighValue" xml:space="preserve">
     <value>Alta</value>
   </data>
+  <data name="PlanMetadataVersionLabel" xml:space="preserve">
+    <value>PlanMetadataVersion</value>
+  </data>
+  <data name="PlanCorrelationIdLabel" xml:space="preserve">
+    <value>PlanCorrelationId</value>
+  </data>
+  <data name="PlanFlagsLabel" xml:space="preserve">
+    <value>PlanFlags</value>
+  </data>
+  <data name="PlanPerformanceBandLabel" xml:space="preserve">
+    <value>PlanPerformanceBand</value>
+  </data>
+  <data name="PlanRiskScoreLabel" xml:space="preserve">
+    <value>PlanRiskScore</value>
+  </data>
+  <data name="PlanQualityGradeLabel" xml:space="preserve">
+    <value>PlanQualityGrade</value>
+  </data>
+  <data name="PlanWarningSummaryLabel" xml:space="preserve">
+    <value>PlanWarningSummary</value>
+  </data>
+  <data name="PlanWarningCountsLabel" xml:space="preserve">
+    <value>PlanWarningCounts</value>
+  </data>
+  <data name="PlanNoiseScoreLabel" xml:space="preserve">
+    <value>PlanNoiseScore</value>
+  </data>
+  <data name="PlanTopActionsLabel" xml:space="preserve">
+    <value>PlanTopActions</value>
+  </data>
+  <data name="PlanPrimaryWarningLabel" xml:space="preserve">
+    <value>PlanPrimaryWarning</value>
+  </data>
+  <data name="IndexRecommendationSummaryLabel" xml:space="preserve">
+    <value>IndexRecommendationSummary</value>
+  </data>
+  <data name="IndexPrimaryRecommendationLabel" xml:space="preserve">
+    <value>IndexPrimaryRecommendation</value>
+  </data>
+  <data name="PlanPrimaryCauseGroupLabel" xml:space="preserve">
+    <value>PlanPrimaryCauseGroup</value>
+  </data>
+  <data name="IndexRecommendationEvidenceLabel" xml:space="preserve">
+    <value>IndexRecommendationEvidence</value>
+  </data>
+  <data name="PlanDeltaLabel" xml:space="preserve">
+    <value>PlanDelta</value>
+  </data>
+  <data name="PlanSeverityHintLabel" xml:space="preserve">
+    <value>PlanSeverityHint</value>
+  </data>
 </root>

--- a/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.resx
+++ b/src/DbSqlLikeMem/Resources/SqlExecutionPlanMessages.resx
@@ -207,4 +207,55 @@
   <data name="SeverityHighValue" xml:space="preserve">
     <value>High</value>
   </data>
+  <data name="PlanMetadataVersionLabel" xml:space="preserve">
+    <value>PlanMetadataVersion</value>
+  </data>
+  <data name="PlanCorrelationIdLabel" xml:space="preserve">
+    <value>PlanCorrelationId</value>
+  </data>
+  <data name="PlanFlagsLabel" xml:space="preserve">
+    <value>PlanFlags</value>
+  </data>
+  <data name="PlanPerformanceBandLabel" xml:space="preserve">
+    <value>PlanPerformanceBand</value>
+  </data>
+  <data name="PlanRiskScoreLabel" xml:space="preserve">
+    <value>PlanRiskScore</value>
+  </data>
+  <data name="PlanQualityGradeLabel" xml:space="preserve">
+    <value>PlanQualityGrade</value>
+  </data>
+  <data name="PlanWarningSummaryLabel" xml:space="preserve">
+    <value>PlanWarningSummary</value>
+  </data>
+  <data name="PlanWarningCountsLabel" xml:space="preserve">
+    <value>PlanWarningCounts</value>
+  </data>
+  <data name="PlanNoiseScoreLabel" xml:space="preserve">
+    <value>PlanNoiseScore</value>
+  </data>
+  <data name="PlanTopActionsLabel" xml:space="preserve">
+    <value>PlanTopActions</value>
+  </data>
+  <data name="PlanPrimaryWarningLabel" xml:space="preserve">
+    <value>PlanPrimaryWarning</value>
+  </data>
+  <data name="IndexRecommendationSummaryLabel" xml:space="preserve">
+    <value>IndexRecommendationSummary</value>
+  </data>
+  <data name="IndexPrimaryRecommendationLabel" xml:space="preserve">
+    <value>IndexPrimaryRecommendation</value>
+  </data>
+  <data name="PlanPrimaryCauseGroupLabel" xml:space="preserve">
+    <value>PlanPrimaryCauseGroup</value>
+  </data>
+  <data name="IndexRecommendationEvidenceLabel" xml:space="preserve">
+    <value>IndexRecommendationEvidence</value>
+  </data>
+  <data name="PlanDeltaLabel" xml:space="preserve">
+    <value>PlanDelta</value>
+  </data>
+  <data name="PlanSeverityHintLabel" xml:space="preserve">
+    <value>PlanSeverityHint</value>
+  </data>
 </root>


### PR DESCRIPTION
### Motivation
- Provide richer, parseable aggregated metadata for execution plans to improve tooling, CI/IDE integration and observability. 
- Surface deterministic, human- and machine-readable signals (quality grade, top actions, noise score, deltas, evidence, correlation id, severity hints) to reduce time-to-fix and enable regression detection. 
- Keep changes additive and backward-compatible while consolidating parsing patterns and i18n labels for multi-locale consumers. 

### Description
- Implemented multiple new aggregated plan fields in `SqlExecutionPlanFormatter`: `PlanQualityGrade`, `PlanTopActions`, `PlanNoiseScore`, `PlanCorrelationId`, `PlanDelta`, `PlanPrimaryCauseGroup`, `PlanSeverityHint`, and `IndexRecommendationEvidence`. 
- Added structured JSON output via `FormatSelectJson` that mirrors common aggregated textual fields and is optional; introduced `System.Text.Json` usage for serialization. 
- Added deterministic algorithms: quality grade calculation (`CalculatePlanQualityGrade`), noise score calculation (`CalculatePlanNoiseScore`), top-actions prioritization (`BuildTopActions`/`MapWarningActionKey`), primary-cause mapping (`MapPrimaryCauseGroup`) and delta computation. 
- Extended resources and i18n keys in `SqlExecutionPlanMessages.*.resx` for all new labels and kept canonical tokens untranslated; introduced `SqlPlanSeverityHintContext` enum to support contextual hinting. 
- Updated and expanded test suite (`DbSqlLikeMem.Test`) with many new `Fact` tests covering presence/absence, thresholds, JSON/text equivalence, deterministic ordering and contract assertions, and added integration-style checks that validate emitted plan text. 

### Testing
- Ran the unit/integration test suite under `src/DbSqlLikeMem.Test` which includes new `ExecutionPlanFormattingAndI18nTests` and `ExecutionPlanPlanWarningsTestsBase` cases exercising the new fields and JSON payload. 
- Tests cover presence/absence of new fields, quality-grade thresholds, noise-score matrix `PW004/PW005`, top-actions order/capping, index-evidence formatting, delta calculation and JSON vs text equivalence. 
- All automated tests were executed and completed successfully (`dotnet test ./src/DbSqlLikeMem.Test` reported passing tests). 
- Contract/assertion tests for parseable prefixes and i18n label registration were included and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fad81b6fc832ca1a96fe393e1b01a)