### PR TITLE
Fix test compile errors in plan correlation-id assertion

### DIFF
--- a/src/DbSqlLikeMem.Test/ExecutionPlanFormattingAndI18nTests.cs
+++ b/src/DbSqlLikeMem.Test/ExecutionPlanFormattingAndI18nTests.cs
@@ -15,6 +15,10 @@ public sealed class ExecutionPlanFormattingAndI18nTests
         @"^[a-zA-Z]+:\d+(\.\d+)?(?:;[a-zA-Z]+:\d+(\.\d+)?)*$",
         RegexOptions.CultureInvariant);
 
+    private static readonly Regex CorrelationIdPattern = new(
+        @"^[0-9a-f]{32}$",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     /// <summary>
     /// EN: Verifies warning metadata is rendered in deterministic key order.
     /// PT: Verifica que os metadados de alerta são renderizados em ordem determinística de chaves.
@@ -775,7 +779,7 @@ public sealed class ExecutionPlanFormattingAndI18nTests
         var correlationId = plan
             .Split(new[] { Environment.NewLine }, StringSplitOptions.None)
             .First(line => line.StartsWith("- PlanCorrelationId:", StringComparison.Ordinal))
-            .Split(':', 2)[1]
+            .Split([':'], 2)[1]
             .Trim();
 
         CorrelationIdPattern.IsMatch(correlationId).Should().BeTrue();


### PR DESCRIPTION
### Motivation
- Fix compile errors in `ExecutionPlanFormattingAndI18nTests` caused by a missing `CorrelationIdPattern` symbol and an invalid `Split` overload usage that produced `CS1503` and `CS0103` errors.

### Description
- Add a `CorrelationIdPattern` `Regex` constant validating 32-hex-digit correlation IDs (`^[0-9a-f]{32}$`) with `RegexOptions.CultureInvariant | RegexOptions.IgnoreCase` in `src/DbSqlLikeMem.Test/ExecutionPlanFormattingAndI18nTests.cs`.
- Change the correlation-id extraction to split using an explicit separator array (`.Split([':'], 2)`) so the correct `Split` overload is used and the previous type-conversion error is avoided.

### Testing
- Attempted to run the targeted tests with `dotnet test src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj --filter "FullyQualifiedName~ExecutionPlanFormattingAndI18nTests"`, but the environment lacks the .NET CLI (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fd0cead80832c8e55bdc6f16b6602)