### PR TITLE
Fix tuple member usage in SQL Server parser test

### DIFF
--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
@@ -771,7 +771,7 @@ WHERE u.id > 0";
 
         Assert.NotNull(parsed.UpdateFromSelect);
         Assert.Single(parsed.Set);
-        Assert.Contains("SELECT SUM(o.amount) FROM orders", parsed.Set[0].Value, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("SELECT SUM(o.amount) FROM orders", parsed.Set[0].ExprRaw, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("u.id > 0", parsed.WhereRaw, StringComparison.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
### Motivation
- Fix a compile error (`CS1061`) in the SQL Server parser tests by using the correct tuple member for `Set` entries.

### Description
- Replace `parsed.Set[0].Value` with `parsed.Set[0].ExprRaw` in `src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs` to assert against the actual tuple field.

### Testing
- Attempted to run the targeted test `ParseUpdate_WithSubqueryInSetAndFromJoin_ShouldKeepSetAndWhereBoundaries` with `dotnet test`, but the `.NET SDK` is unavailable in the environment (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fd1d6effc832ca00585fcf3c68b86)