### PR TITLE
Add bilingual XML summaries to Db2 transaction reliability tests

### DIFF
--- a/src/DbSqlLikeMem.Db2.Dapper.Test/Db2TransactionReliabilityTests.cs
+++ b/src/DbSqlLikeMem.Db2.Dapper.Test/Db2TransactionReliabilityTests.cs
@@ -20,32 +20,56 @@ public sealed class Db2TransactionReliabilityTests : DapperTransactionConcurrenc
         };
     }
 
+    /// <summary>
+    /// EN: Verifies that rolling back to a savepoint restores the intermediate transactional state.
+    /// PT: Verifica se o rollback para um savepoint restaura o estado transacional intermediário.
+    /// </summary>
     [Fact]
     [Trait("Category", "Db2TransactionReliability")]
     public void SavepointRollbackShouldRestoreIntermediateState()
         => AssertSavepointRollbackRestoresIntermediateState();
 
+    /// <summary>
+    /// EN: Verifies that the transaction isolation level is exposed in a deterministic way.
+    /// PT: Verifica se o nível de isolamento da transação é exposto de forma determinística.
+    /// </summary>
     [Fact]
     [Trait("Category", "Db2TransactionReliability")]
     public void IsolationLevelShouldBeExposedDeterministically()
         => AssertIsolationLevelExposedDeterministically();
 
+    /// <summary>
+    /// EN: Verifies that savepoint release compatibility follows provider-specific behavior.
+    /// PT: Verifica se a compatibilidade de liberação de savepoint segue o comportamento específico do provedor.
+    /// </summary>
     [Fact]
     [Trait("Category", "Db2TransactionReliability")]
     public void ReleaseSavepointCompatibilityShouldBeProviderSpecific()
         => AssertReleaseSavepointCompatibilityIsProviderSpecific();
 
+    /// <summary>
+    /// EN: Verifies that concurrent inserts remain consistent when thread-safe mode is enabled.
+    /// PT: Verifica se inserções concorrentes permanecem consistentes quando o modo thread-safe está habilitado.
+    /// </summary>
     [Fact]
     [Trait("Category", "Db2TransactionReliability")]
     public void ConcurrentInsertsShouldRemainConsistentWhenThreadSafeEnabled()
         => AssertConcurrentInsertsRemainConsistentWhenThreadSafeEnabled();
 
+    /// <summary>
+    /// EN: Verifies that concurrent commit and rollback operations keep the expected state across Db2 versions.
+    /// PT: Verifica se operações concorrentes de commit e rollback mantêm o estado esperado entre versões do Db2.
+    /// </summary>
     [Theory]
     [Trait("Category", "Db2TransactionReliability")]
     [MemberDataDb2Version]
     public void ConcurrentCommitAndRollback_ShouldKeepExpectedStateAcrossVersions(int version)
         => AssertConcurrentCommitAndRollbackKeepsExpectedState(version);
 
+    /// <summary>
+    /// EN: Verifies that concurrent commits persist combined writes across Db2 versions.
+    /// PT: Verifica se commits concorrentes persistem gravações combinadas entre versões do Db2.
+    /// </summary>
     [Theory]
     [Trait("Category", "Db2TransactionReliability")]
     [MemberDataDb2Version]


### PR DESCRIPTION
### Motivation
- Silence CS1591 warnings by providing XML documentation for publicly visible test methods and clarify their intent for readers and documentation generators.
- Follow the requested bilingual pattern with English first and Portuguese second so summaries are consistent across the codebase.

### Description
- Added XML `<summary>` comments to six public test methods in `Db2TransactionReliabilityTests` describing what each test validates, with English first and Portuguese second.
- Kept the existing test attributes and method signatures unchanged to preserve behavior.
- Changes are confined to `src/DbSqlLikeMem.Db2.Dapper.Test/Db2TransactionReliabilityTests.cs`.

### Testing
- Attempted to run `dotnet build src/DbSqlLikeMem.Db2.Dapper.Test/DbSqlLikeMem.Db2.Dapper.Test.csproj`, but the build could not be executed because `dotnet` is not available in the execution environment (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fe964f0e0832c8b0c490ca7522044)