### PR TITLE
Validate RANGE offset ORDER BY, improve RANGE error messages and add window/plan cost tests

### DIFF
--- a/docs/old/core-parser-executor-roadmap.md
+++ b/docs/old/core-parser-executor-roadmap.md
@@ -28,7 +28,7 @@ Para evitar duplicação de código e problemas de build:
 | Item | Progresso atual | Tendência | Resumo consolidado |
 | --- | --- | --- | --- |
 | 1) CTE avançada | **75%** | ⬆️ | Gates principais já cobrem o core e houve avanço por versão/dialeto; faltam bordas específicas de cobertura. |
-| 2) Window functions além de `ROW_NUMBER` | **100%** | ✅ | Gating por nome/versão, validação de aridade/`ORDER BY`, parser com suporte a frames `ROWS`/`RANGE`/`GROUPS` e runtime já implementado para ranking/distribution/value functions (incluindo `FIRST_VALUE`/`LAST_VALUE`/`NTH_VALUE`/`LAG`/`LEAD`/`RANK`/`DENSE_RANK`/`PERCENT_RANK`/`CUME_DIST`/`NTILE`), com hardening de limites e fail-fast para casos inválidos. Sem pendências abertas neste item no core parser/executor. |
+| 2) Window functions além de `ROW_NUMBER` | **100%** | ✅ | Gating por nome/versão, validação de aridade/`ORDER BY`, parser com suporte a frames `ROWS`/`RANGE`/`GROUPS` e runtime consolidado para ranking/distribution/value functions (incluindo `FIRST_VALUE`/`LAST_VALUE`/`NTH_VALUE`/`LAG`/`LEAD`/`RANK`/`DENSE_RANK`/`PERCENT_RANK`/`CUME_DIST`/`NTILE`), com hardening semântico para peers, ORDER BY composto em cenários válidos e mensagens fail-fast objetivas para combinações inválidas. Sem pendências abertas neste item no core parser/executor. |
 | 3) UPSERT por família de banco | **65%** | ⬆️ | `ON DUPLICATE`/`ON CONFLICT` e subset de `MERGE` avançaram; pendem harmonizações finais de semântica no executor. |
 | 4) Tipos/literais/coerção | **50%** | ⬆️ | Base central em `SqlExtensions` evoluiu, porém ainda faltam regras finas por dialeto/versão. |
 | 5) JSON cross-dialect | **68%** | ⬆️ | Runtime/cobertura evoluíram nos caminhos suportados, com fallback padronizado para não suportado. |

--- a/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AdvancedSqlGapTests.cs
@@ -35,6 +35,13 @@ public sealed class Db2AdvancedSqlGapTests : XUnitTestBase
         orders.Add(new Dictionary<int, object?> { [0] = 11, [1] = 1, [2] = 5m });
         orders.Add(new Dictionary<int, object?> { [0] = 12, [1] = 2, [2] = 7m });
 
+        var eventsTable = db.AddTable("events");
+        eventsTable.AddColumn("id", DbType.Int32, false);
+        eventsTable.AddColumn("occurred", DbType.DateTime, false);
+        eventsTable.Add(new Dictionary<int, object?> { [0] = 1, [1] = new DateTime(2020, 1, 1, 12, 0, 0, DateTimeKind.Local) });
+        eventsTable.Add(new Dictionary<int, object?> { [0] = 2, [1] = new DateTime(2020, 1, 1, 12, 1, 0, DateTimeKind.Local) });
+        eventsTable.Add(new Dictionary<int, object?> { [0] = 3, [1] = new DateTime(2020, 1, 1, 12, 2, 0, DateTimeKind.Local) });
+
         _cnn = new Db2ConnectionMock(db);
         _cnn.Open();
     }
@@ -332,6 +339,115 @@ ORDER BY id").ToList();
         Assert.Equal([null, null, null], [.. rows.Select(r => (double?)r.pr_excluded)]);
         Assert.Equal([null, null, null], [.. rows.Select(r => (double?)r.cd_excluded)]);
         Assert.Equal([null, null, null], [.. rows.Select(r => (int?)r.ntile_excluded)]);
+    }
+
+    /// <summary>
+    /// EN: Tests RANGE CURRENT ROW with DESC ordering keeps peer semantics across ranking/distribution/NTILE.
+    /// PT: Testa se RANGE CURRENT ROW com ordenação DESC preserva semântica de peers em ranking/distribuição/NTILE.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_RangeCurrentRow_WithDescOrderAndPeers_ShouldRespectPeerSemantics()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid DESC RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS rk_desc_range,
+       DENSE_RANK() OVER (ORDER BY tenantid DESC RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS dr_desc_range,
+       CUME_DIST() OVER (ORDER BY tenantid DESC RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS cd_desc_range,
+       NTILE(2) OVER (ORDER BY tenantid DESC RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS ntile_desc_range
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 1], [.. rows.Select(r => (int)r.rk_desc_range)]);
+        Assert.Equal([1, 1, 1], [.. rows.Select(r => (int)r.dr_desc_range)]);
+        Assert.Equal([1d, 1d, 1d], [.. rows.Select(r => Convert.ToDouble(r.cd_desc_range))]);
+        Assert.Equal([1, 2, 1], [.. rows.Select(r => (int)r.ntile_desc_range)]);
+    }
+
+    /// <summary>
+    /// EN: Tests RANGE offset with DateTime ORDER BY values using tick-based offsets.
+    /// PT: Testa RANGE com offset em ORDER BY DateTime usando offsets baseados em ticks.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_RangeOffset_WithDateTimeOrder_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(id) OVER (ORDER BY occurred RANGE BETWEEN 900000000 PRECEDING AND CURRENT ROW) AS first_id_90s,
+       LAST_VALUE(id) OVER (ORDER BY occurred RANGE BETWEEN 900000000 PRECEDING AND CURRENT ROW) AS last_id_90s
+FROM events
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.first_id_90s)]);
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.last_id_90s)]);
+    }
+
+    /// <summary>
+    /// EN: Tests GROUPS frame with composite mixed-direction ORDER BY preserves peer-group boundaries.
+    /// PT: Testa frame GROUPS com ORDER BY composto e direções mistas preservando limites de grupos de peers.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_GroupsFrame_WithCompositeMixedDirectionOrder_ShouldRespectPeerGroups()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid DESC, tenantid ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW) AS rk_groups_mix,
+       NTILE(2) OVER (ORDER BY tenantid DESC, tenantid ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW) AS ntile_groups_mix
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 1], [.. rows.Select(r => (int)r.rk_groups_mix)]);
+        Assert.Equal([1, 2, 1], [.. rows.Select(r => (int)r.ntile_groups_mix)]);
+    }
+
+    /// <summary>
+    /// EN: Tests RANGE frame that excludes current row yields NULL ranking/distribution/NTILE and applies LAG/LEAD defaults.
+    /// PT: Testa se frame RANGE que exclui a linha atual retorna NULL em ranking/distribuição/NTILE e aplica defaults de LAG/LEAD.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_RangeFrame_ExcludingCurrentRow_ShouldReturnNullOrDefault()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS rk_excluded_range,
+       DENSE_RANK() OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS dr_excluded_range,
+       PERCENT_RANK() OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS pr_excluded_range,
+       CUME_DIST() OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS cd_excluded_range,
+       NTILE(2) OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS ntile_excluded_range,
+       LAG(id, 1, -1) OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS lag_excluded_range,
+       LEAD(id, 1, 99) OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS lead_excluded_range
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([null, null, null], [.. rows.Select(r => (int?)r.rk_excluded_range)]);
+        Assert.Equal([null, null, null], [.. rows.Select(r => (int?)r.dr_excluded_range)]);
+        Assert.Equal([null, null, null], [.. rows.Select(r => (double?)r.pr_excluded_range)]);
+        Assert.Equal([null, null, null], [.. rows.Select(r => (double?)r.cd_excluded_range)]);
+        Assert.Equal([null, null, null], [.. rows.Select(r => (int?)r.ntile_excluded_range)]);
+        Assert.Equal([-1, -1, -1], [.. rows.Select(r => (int)r.lag_excluded_range)]);
+        Assert.Equal([99, 99, 99], [.. rows.Select(r => (int)r.lead_excluded_range)]);
+    }
+
+    /// <summary>
+    /// EN: Tests RANGE offset with non-numeric ORDER BY throws a clear runtime type message.
+    /// PT: Testa se RANGE com offset e ORDER BY não numérico lança mensagem clara com tipo em runtime.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2AdvancedSqlGap")]
+    public void Window_RangeOffset_WithTextOrder_ShouldThrowClearTypeError()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY name RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) AS rk_bad_type
+FROM users
+ORDER BY id").ToList());
+
+        Assert.Contains("numeric/date ORDER BY values", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("String", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 

--- a/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAdvancedSqlGapTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAdvancedSqlGapTests.cs
@@ -35,6 +35,13 @@ public sealed class SqlServerAdvancedSqlGapTests : XUnitTestBase
         orders.Add(new Dictionary<int, object?> { [0] = 11, [1] = 1, [2] = 5m });
         orders.Add(new Dictionary<int, object?> { [0] = 12, [1] = 2, [2] = 7m });
 
+        var eventsTable = db.AddTable("events");
+        eventsTable.AddColumn("id", DbType.Int32, false);
+        eventsTable.AddColumn("occurred", DbType.DateTime, false);
+        eventsTable.Add(new Dictionary<int, object?> { [0] = 1, [1] = new DateTime(2020, 1, 1, 12, 0, 0, DateTimeKind.Local) });
+        eventsTable.Add(new Dictionary<int, object?> { [0] = 2, [1] = new DateTime(2020, 1, 1, 12, 1, 0, DateTimeKind.Local) });
+        eventsTable.Add(new Dictionary<int, object?> { [0] = 3, [1] = new DateTime(2020, 1, 1, 12, 2, 0, DateTimeKind.Local) });
+
         _cnn = new SqlServerConnectionMock(db);
         _cnn.Open();
     }
@@ -332,7 +339,26 @@ SELECT id,
 FROM users
 ORDER BY id").ToList());
 
-        Assert.Contains("single ORDER BY expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("exactly one ORDER BY expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Tests RANGE offset with non-numeric ORDER BY throws a clear runtime type message.
+    /// PT: Testa se RANGE com offset e ORDER BY não numérico lança mensagem clara com tipo em runtime.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_RangeOffset_WithTextOrder_ShouldThrowClearTypeError()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY name RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) AS rk_bad_type
+FROM users
+ORDER BY id").ToList());
+
+        Assert.Contains("numeric/date ORDER BY values", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("String", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 
@@ -377,6 +403,96 @@ ORDER BY id").ToList();
         Assert.Equal([1, 1, 1], [.. rows.Select(r => (int)r.rk_name_range)]);
         Assert.Equal([1, 1, 1], [.. rows.Select(r => (int)r.dr_name_range)]);
         Assert.Equal([1, 1, 1], [.. rows.Select(r => (int)r.ntile_name_range)]);
+    }
+
+    /// <summary>
+    /// EN: Tests RANGE CURRENT ROW with DESC ordering keeps peer semantics across ranking/distribution/NTILE.
+    /// PT: Testa se RANGE CURRENT ROW com ordenação DESC preserva semântica de peers em ranking/distribuição/NTILE.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_RangeCurrentRow_WithDescOrderAndPeers_ShouldRespectPeerSemantics()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid DESC RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS rk_desc_range,
+       DENSE_RANK() OVER (ORDER BY tenantid DESC RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS dr_desc_range,
+       CUME_DIST() OVER (ORDER BY tenantid DESC RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS cd_desc_range,
+       NTILE(2) OVER (ORDER BY tenantid DESC RANGE BETWEEN CURRENT ROW AND CURRENT ROW) AS ntile_desc_range
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 1], [.. rows.Select(r => (int)r.rk_desc_range)]);
+        Assert.Equal([1, 1, 1], [.. rows.Select(r => (int)r.dr_desc_range)]);
+        Assert.Equal([1d, 1d, 1d], [.. rows.Select(r => Convert.ToDouble(r.cd_desc_range))]);
+        Assert.Equal([1, 2, 1], [.. rows.Select(r => (int)r.ntile_desc_range)]);
+    }
+
+    /// <summary>
+    /// EN: Tests RANGE offset with DateTime ORDER BY values using tick-based offsets.
+    /// PT: Testa RANGE com offset em ORDER BY DateTime usando offsets baseados em ticks.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_RangeOffset_WithDateTimeOrder_ShouldWork()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       FIRST_VALUE(id) OVER (ORDER BY occurred RANGE BETWEEN 900000000 PRECEDING AND CURRENT ROW) AS first_id_90s,
+       LAST_VALUE(id) OVER (ORDER BY occurred RANGE BETWEEN 900000000 PRECEDING AND CURRENT ROW) AS last_id_90s
+FROM events
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 2], [.. rows.Select(r => (int)r.first_id_90s)]);
+        Assert.Equal([1, 2, 3], [.. rows.Select(r => (int)r.last_id_90s)]);
+    }
+
+    /// <summary>
+    /// EN: Tests GROUPS frame with composite mixed-direction ORDER BY preserves peer-group boundaries.
+    /// PT: Testa frame GROUPS com ORDER BY composto e direções mistas preservando limites de grupos de peers.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_GroupsFrame_WithCompositeMixedDirectionOrder_ShouldRespectPeerGroups()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid DESC, tenantid ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW) AS rk_groups_mix,
+       NTILE(2) OVER (ORDER BY tenantid DESC, tenantid ASC GROUPS BETWEEN CURRENT ROW AND CURRENT ROW) AS ntile_groups_mix
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([1, 1, 1], [.. rows.Select(r => (int)r.rk_groups_mix)]);
+        Assert.Equal([1, 2, 1], [.. rows.Select(r => (int)r.ntile_groups_mix)]);
+    }
+
+    /// <summary>
+    /// EN: Tests RANGE frame that excludes current row yields NULL ranking/distribution/NTILE and applies LAG/LEAD defaults.
+    /// PT: Testa se frame RANGE que exclui a linha atual retorna NULL em ranking/distribuição/NTILE e aplica defaults de LAG/LEAD.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAdvancedSqlGap")]
+    public void Window_RangeFrame_ExcludingCurrentRow_ShouldReturnNullOrDefault()
+    {
+        var rows = _cnn.Query<dynamic>(@"
+SELECT id,
+       RANK() OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS rk_excluded_range,
+       DENSE_RANK() OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS dr_excluded_range,
+       PERCENT_RANK() OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS pr_excluded_range,
+       CUME_DIST() OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS cd_excluded_range,
+       NTILE(2) OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS ntile_excluded_range,
+       LAG(id, 1, -1) OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS lag_excluded_range,
+       LEAD(id, 1, 99) OVER (ORDER BY tenantid DESC RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING) AS lead_excluded_range
+FROM users
+ORDER BY id").ToList();
+
+        Assert.Equal([null, null, null], [.. rows.Select(r => (int?)r.rk_excluded_range)]);
+        Assert.Equal([null, null, null], [.. rows.Select(r => (int?)r.dr_excluded_range)]);
+        Assert.Equal([null, null, null], [.. rows.Select(r => (double?)r.pr_excluded_range)]);
+        Assert.Equal([null, null, null], [.. rows.Select(r => (double?)r.cd_excluded_range)]);
+        Assert.Equal([null, null, null], [.. rows.Select(r => (int?)r.ntile_excluded_range)]);
+        Assert.Equal([-1, -1, -1], [.. rows.Select(r => (int)r.lag_excluded_range)]);
+        Assert.Equal([99, 99, 99], [.. rows.Select(r => (int)r.lead_excluded_range)]);
     }
 
 


### PR DESCRIPTION
### Motivation

- Clarify and harden RANGE frame semantics for window functions when PRECEDING/FOLLOWING offsets are used to avoid ambiguous ORDER BY shapes and opaque runtime errors. 
- Improve execution-plan estimated-cost heuristics so that planner warnings better reflect query shape and complexity. 
- Expand test coverage for window frames (RANGE/ROWS/GROUPS), DateTime offsets and plan-cost behavior across DB2/SqlServer mocks and plan formatting tests. 

### Description

- Add `ValidateRangeOffsetOrderBy` and more informative runtime messages in `AstQueryExecutorBase` to require exactly one ORDER BY expression for RANGE offsets and to include actual ORDER BY value type when conversion fails for offsets; update range scalar conversion to accept `DateTime`, `DateTimeOffset`, and `TimeSpan` as tick-based values. 
- Enhance `SqlExecutionPlanFormatter` cost model by adding `EstimateJoinTypeCost`, `EstimatePredicateComplexityCost`, `EstimateSourceCost`, and `EstimateProjectionCost`, apply additional penalties for ORDER BY without limit and include predicate/source/projection contributions in `EstimateSelectCost`. 
- Add many new unit tests to `Db2AdvancedSqlGapTests` and `SqlServerAdvancedSqlGapTests` that introduce an `events` table and exercise RANGE/CURRENT ROW with DESC ordering, RANGE offsets with DateTime-order, GROUPS frames with mixed-direction ORDER BY, frames excluding current row, and clear error message assertions for invalid RANGE uses. 
- Extend `ExecutionPlanFormattingAndI18nTests` with multiple tests asserting estimated-cost increases for window projections, derived sources, outer joins, ORDER BY without limit, predicate/join complexity, and add helper `ExtractEstimatedCost` plus `using System.Globalization`. 
- Minor documentation wording tweak in `docs/old/core-parser-executor-roadmap.md` to consolidate window function status text. 

### Testing

- Ran the solution unit test suite via `dotnet test` (xUnit) covering modified and new tests in `DbSqlLikeMem.*` projects. 
- New/modified window tests for DB2 and SqlServer and the execution-plan formatting tests executed and passed locally. 
- No automated test failures observed in the changed test classes after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a026527e14832c8aa36493d4727e47)