### PR TITLE
Track and expose last statement row counts (FOUND_ROWS/ROW_COUNT/@@ROWCOUNT) across dialects

### DIFF
--- a/src/DbSqlLikeMem.Db2.Test/Db2MockTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Db2MockTests.cs
@@ -214,4 +214,42 @@ public sealed class Db2MockTests
         _connection.Dispose();
         base.Dispose(disposing);
     }
+
+    [Fact]
+    [Trait("Category", "Db2Mock")]
+    public void TestSelect_FoundRows_ShouldReturnLastSelectRowCount()
+    {
+        using var command = new Db2CommandMock(_connection);
+        command.CommandText = """
+            INSERT INTO Users (Id, Name, Email) VALUES (101, 'Ana', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (102, 'Bia', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (103, 'Caio', NULL);
+            """;
+        command.ExecuteNonQuery();
+
+        command.CommandText = "SELECT Name FROM Users ORDER BY Id FETCH FIRST 1 ROWS ONLY; SELECT FOUND_ROWS();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal("Ana", reader.GetString(0));
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0)));
+    }
+
+
+    [Fact]
+    [Trait("Category", "Db2Mock")]
+    public void TestSelect_RowCountFunction_ShouldReturnLastSelectRowCount()
+    {
+        using var command = new Db2CommandMock(_connection);
+        command.CommandText = "SELECT Name FROM Users ORDER BY Id FETCH FIRST 1 ROWS ONLY; SELECT ROW_COUNT();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0)));
+    }
+
 }

--- a/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
+++ b/src/DbSqlLikeMem.Db2/Db2CommandMock.cs
@@ -102,18 +102,25 @@ public class Db2CommandMock(
         // 1. Stored Procedure (sem parse SQL)
         if (CommandType == CommandType.StoredProcedure)
         {
-            return connection.ExecuteStoredProcedure(CommandText, Parameters);
+            var affected = connection.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
         }
 
         var sqlRaw = CommandText.Trim();
 
         if (TryExecuteTransactionControlCommand(sqlRaw, out var transactionControlResult))
+        {
+            connection.SetLastFoundRows(transactionControlResult);
             return transactionControlResult;
+        }
 
         // 2. Comandos especiais que talvez o Parser ainda não suporte nativamente (DDL, CALL)
         if (sqlRaw.StartsWith("call ", StringComparison.OrdinalIgnoreCase))
         {
-            return connection.ExecuteCall(sqlRaw, Parameters);
+            var affected = connection.ExecuteCall(sqlRaw, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
         }
 
         if (sqlRaw.StartsWith("create temporary table", StringComparison.OrdinalIgnoreCase) ||
@@ -203,6 +210,7 @@ public class Db2CommandMock(
         if (CommandType == CommandType.StoredProcedure)
         {
             connection.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(0);
             return new Db2DataReaderMock([[]]);
         }
 
@@ -212,6 +220,7 @@ public class Db2CommandMock(
         if (sql.StartsWith("CALL", StringComparison.OrdinalIgnoreCase))
         {
             connection.ExecuteCall(sql, Parameters);
+            connection.SetLastFoundRows(0);
             return new Db2DataReaderMock([[]]);
         }
 

--- a/src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/MySqlMockTests.cs
@@ -543,4 +543,89 @@ public sealed class MySqlMockTests
         _connection.Dispose();
         base.Dispose(disposing);
     }
+
+    [Fact]
+    [Trait("Category", "MySqlMock")]
+    public void TestSelect_SqlCalcFoundRows_ShouldExposeCountInFoundRows()
+    {
+        using var command = new MySqlCommandMock(_connection);
+        command.CommandText = """
+            INSERT INTO Users (Id, Name, Email) VALUES (101, 'Ana', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (102, 'Bia', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (103, 'Caio', NULL);
+            """;
+        command.ExecuteNonQuery();
+
+        command.CommandText = "SELECT SQL_CALC_FOUND_ROWS Name FROM Users ORDER BY Id LIMIT 1; SELECT FOUND_ROWS();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal("Ana", reader.GetString(0));
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(3L, Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture));
+    }
+
+
+    [Fact]
+    [Trait("Category", "MySqlMock")]
+    public void TestSelect_FoundRows_WithArgument_ShouldThrow()
+    {
+        using var command = new MySqlCommandMock(_connection)
+        {
+            CommandText = "SELECT FOUND_ROWS(1)"
+        };
+
+        Assert.Throws<InvalidOperationException>(() => command.ExecuteScalar());
+    }
+
+
+    [Fact]
+    [Trait("Category", "MySqlMock")]
+    public void TestInsert_FoundRows_ShouldReturnAffectedRows()
+    {
+        using var command = new MySqlCommandMock(_connection)
+        {
+            CommandText = "INSERT INTO Users (Id, Name, Email) VALUES (130, 'Rows User', NULL); SELECT FOUND_ROWS();"
+        };
+
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture));
+    }
+
+
+    [Fact]
+    [Trait("Category", "MySqlMock")]
+    public void TestUpdate_RowCountFunction_ShouldReturnAffectedRows()
+    {
+        using var command = new MySqlCommandMock(_connection)
+        {
+            CommandText = "INSERT INTO Users (Id, Name, Email) VALUES (140, 'Row Count User', NULL)"
+        };
+        command.ExecuteNonQuery();
+
+        command.CommandText = "UPDATE Users SET Name = 'Updated User' WHERE Id = 140; SELECT ROW_COUNT();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture));
+    }
+
+
+    [Fact]
+    [Trait("Category", "MySqlMock")]
+    public void TestBeginTransaction_FoundRows_ShouldReturnZero()
+    {
+        using var command = new MySqlCommandMock(_connection)
+        {
+            CommandText = "BEGIN TRANSACTION"
+        };
+        command.ExecuteNonQuery();
+
+        command.CommandText = "SELECT FOUND_ROWS();";
+        Assert.Equal(0L, Convert.ToInt64(command.ExecuteScalar(), CultureInfo.InvariantCulture));
+    }
+
 }

--- a/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlCommandMock.cs
@@ -200,18 +200,25 @@ public class MySqlCommandMock(
         // 1. Stored Procedure (sem parse SQL)
         if (CommandType == CommandType.StoredProcedure)
         {
-            return connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            var affected = connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
         }
 
         var sqlRaw = CommandText.Trim();
 
         if (TryExecuteTransactionControlCommand(sqlRaw, out var transactionControlResult))
+        {
+            connection.SetLastFoundRows(transactionControlResult);
             return transactionControlResult;
+        }
 
         // 2. Comandos especiais que talvez o Parser ainda não suporte nativamente (DDL, CALL)
         if (sqlRaw.StartsWith("call ", StringComparison.OrdinalIgnoreCase))
         {
-            return connection!.ExecuteCall(sqlRaw, Parameters);
+            var affected = connection!.ExecuteCall(sqlRaw, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
         }
 
         if (sqlRaw.StartsWith("create temporary table", StringComparison.OrdinalIgnoreCase) ||
@@ -372,6 +379,7 @@ public class MySqlCommandMock(
         if (CommandType == CommandType.StoredProcedure)
         {
             connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(0);
             return new MySqlDataReaderMock([[]]);
         }
 
@@ -381,6 +389,7 @@ public class MySqlCommandMock(
         if (sql.StartsWith("CALL", StringComparison.OrdinalIgnoreCase))
         {
             connection!.ExecuteCall(sql, Parameters);
+            connection.SetLastFoundRows(0);
             return new MySqlDataReaderMock([[]]);
         }
 

--- a/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlMockTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/PostgreSqlMockTests.cs
@@ -194,4 +194,72 @@ public sealed class PostgreSqlMockTests
         _connection.Dispose();
         base.Dispose(disposing);
     }
+
+    [Fact]
+    [Trait("Category", "PostgreSqlMock")]
+    public void TestSelect_FoundRows_ShouldReturnLastSelectRowCount()
+    {
+        using var command = new NpgsqlCommandMock(_connection);
+        command.CommandText = """
+            INSERT INTO Users (Id, Name, Email) VALUES (101, 'Ana', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (102, 'Bia', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (103, 'Caio', NULL);
+            """;
+        command.ExecuteNonQuery();
+
+        command.CommandText = "SELECT Name FROM Users ORDER BY Id LIMIT 1; SELECT FOUND_ROWS();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal("Ana", reader.GetString(0));
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0)));
+    }
+
+
+    [Fact]
+    [Trait("Category", "PostgreSqlMock")]
+    public void TestSelect_RowCountFunction_ShouldReturnLastSelectRowCount()
+    {
+        using var command = new NpgsqlCommandMock(_connection);
+        command.CommandText = "SELECT Name FROM Users ORDER BY Id LIMIT 1; SELECT ROW_COUNT();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0)));
+    }
+
+    [Fact]
+    [Trait("Category", "PostgreSqlMock")]
+    public void TestSelect_SqlCalcFoundRows_ShouldThrow_NotSupported()
+    {
+        using var command = new NpgsqlCommandMock(_connection)
+        {
+            CommandText = "SELECT SQL_CALC_FOUND_ROWS Name FROM Users LIMIT 1"
+        };
+
+        Assert.Throws<NotSupportedException>(() => command.ExecuteReader());
+    }
+
+
+    [Fact]
+    [Trait("Category", "PostgreSqlMock")]
+    public void TestUpdate_RowCountFunction_ShouldReturnAffectedRows()
+    {
+        using var command = new NpgsqlCommandMock(_connection)
+        {
+            CommandText = "INSERT INTO Users (Id, Name, Email) VALUES (120, 'Row Count User', NULL)"
+        };
+        command.ExecuteNonQuery();
+
+        command.CommandText = "UPDATE Users SET Name = 'Updated User' WHERE Id = 120; SELECT ROW_COUNT();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0)));
+    }
+
 }

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlCommandMock.cs
@@ -105,16 +105,27 @@ public class NpgsqlCommandMock(
         ArgumentExceptionCompatible.ThrowIfNullOrWhiteSpace(CommandText, nameof(CommandText));
 
         if (CommandType == CommandType.StoredProcedure)
-            return connection!.ExecuteStoredProcedure(CommandText, Parameters);
+        {
+            var affected = connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
+        }
 
         var sqlRaw = CommandText.Trim();
 
         if (TryExecuteTransactionControlCommand(sqlRaw, out var transactionControlResult))
+        {
+            connection.SetLastFoundRows(transactionControlResult);
             return transactionControlResult;
+        }
 
         // Mantém atalhos existentes (CALL / CREATE TABLE AS SELECT) por compatibilidade do engine atual
         if (sqlRaw.StartsWith("call ", StringComparison.OrdinalIgnoreCase))
-            return connection!.ExecuteCall(sqlRaw, Parameters);
+        {
+            var affected = connection!.ExecuteCall(sqlRaw, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
+        }
 
         if (sqlRaw.StartsWith("create table", StringComparison.OrdinalIgnoreCase))
             return connection!.ExecuteCreateTableAsSelect(sqlRaw, Parameters, connection!.Db.Dialect);
@@ -148,6 +159,7 @@ public class NpgsqlCommandMock(
         if (CommandType == CommandType.StoredProcedure)
         {
             connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(0);
             return new NpgsqlDataReaderMock([[]]);
         }
 
@@ -156,6 +168,7 @@ public class NpgsqlCommandMock(
         if (sql.StartsWith("CALL", StringComparison.OrdinalIgnoreCase))
         {
             connection!.ExecuteCall(sql, Parameters);
+            connection.SetLastFoundRows(0);
             return new NpgsqlDataReaderMock([[]]);
         }
 

--- a/src/DbSqlLikeMem.Oracle.Test/OracleMockTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/OracleMockTests.cs
@@ -219,4 +219,42 @@ public sealed class OracleMockTests
         _connection.Dispose();
         base.Dispose(disposing);
     }
+
+    [Fact]
+    [Trait("Category", "OracleMock")]
+    public void TestSelect_FoundRows_ShouldReturnLastSelectRowCount()
+    {
+        using var command = new OracleCommandMock(_connection);
+        command.CommandText = """
+            INSERT INTO Users (Id, Name, Email) VALUES (101, 'Ana', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (102, 'Bia', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (103, 'Caio', NULL);
+            """;
+        command.ExecuteNonQuery();
+
+        command.CommandText = "SELECT Name FROM Users ORDER BY Id FETCH FIRST 1 ROWS ONLY; SELECT FOUND_ROWS();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal("Ana", reader.GetString(0));
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0)));
+    }
+
+
+    [Fact]
+    [Trait("Category", "OracleMock")]
+    public void TestSelect_RowCountFunction_ShouldReturnLastSelectRowCount()
+    {
+        using var command = new OracleCommandMock(_connection);
+        command.CommandText = "SELECT Name FROM Users ORDER BY Id FETCH FIRST 1 ROWS ONLY; SELECT ROW_COUNT();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0)));
+    }
+
 }

--- a/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleCommandMock.cs
@@ -103,16 +103,27 @@ public class OracleCommandMock(
         ArgumentExceptionCompatible.ThrowIfNullOrWhiteSpace(CommandText, nameof(CommandText));
 
         if (CommandType == CommandType.StoredProcedure)
-            return connection!.ExecuteStoredProcedure(CommandText, Parameters);
+        {
+            var affected = connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
+        }
 
         var sqlRaw = CommandText.Trim();
 
         if (TryExecuteTransactionControlCommand(sqlRaw, out var transactionControlResult))
+        {
+            connection.SetLastFoundRows(transactionControlResult);
             return transactionControlResult;
+        }
 
         // Mantém atalhos existentes (CALL / CREATE TABLE AS SELECT) por compatibilidade do engine atual
         if (sqlRaw.StartsWith("call ", StringComparison.OrdinalIgnoreCase))
-            return connection!.ExecuteCall(sqlRaw, Parameters);
+        {
+            var affected = connection!.ExecuteCall(sqlRaw, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
+        }
 
         if (sqlRaw.StartsWith("create table", StringComparison.OrdinalIgnoreCase))
             return connection!.ExecuteCreateTableAsSelect(sqlRaw, Parameters, connection!.Db.Dialect);
@@ -145,6 +156,7 @@ public class OracleCommandMock(
         if (CommandType == CommandType.StoredProcedure)
         {
             connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(0);
             return new OracleDataReaderMock([[]]);
         }
 
@@ -153,6 +165,7 @@ public class OracleCommandMock(
         if (sql.StartsWith("CALL", StringComparison.OrdinalIgnoreCase))
         {
             connection!.ExecuteCall(sql, Parameters);
+            connection.SetLastFoundRows(0);
             return new OracleDataReaderMock([[]]);
         }
 

--- a/src/DbSqlLikeMem.SqlServer.Test/SqlServerMockTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/SqlServerMockTests.cs
@@ -215,4 +215,106 @@ public sealed class SqlServerMockTests
         _connection.Dispose();
         base.Dispose(disposing);
     }
+
+    [Fact]
+    [Trait("Category", "SqlServerMock")]
+    public void TestSelect_FoundRows_ShouldReturnLastSelectRowCount()
+    {
+        using var command = new SqlServerCommandMock(_connection);
+        command.CommandText = """
+            INSERT INTO Users (Id, Name, Email) VALUES (101, 'Ana', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (102, 'Bia', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (103, 'Caio', NULL);
+            """;
+        command.ExecuteNonQuery();
+
+        command.CommandText = "SELECT Name FROM Users ORDER BY Id OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY; SELECT FOUND_ROWS();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal("Ana", reader.GetString(0));
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture));
+    }
+
+
+    [Fact]
+    [Trait("Category", "SqlServerMock")]
+    public void TestSelect_RowCountFunction_ShouldReturnLastSelectRowCount()
+    {
+        using var command = new SqlServerCommandMock(_connection);
+        command.CommandText = "SELECT Name FROM Users ORDER BY Id OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY; SELECT ROWCOUNT();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture));
+    }
+
+
+    [Fact]
+    [Trait("Category", "SqlServerMock")]
+    public void TestSelect_SystemRowCountVariable_ShouldReturnLastSelectRowCount()
+    {
+        using var command = new SqlServerCommandMock(_connection);
+        command.CommandText = "SELECT Name FROM Users ORDER BY Id OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY; SELECT @@ROWCOUNT;";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture));
+    }
+
+
+    [Fact]
+    [Trait("Category", "SqlServerMock")]
+    public void TestUpdate_SystemRowCountVariable_ShouldReturnAffectedRows()
+    {
+        using var command = new SqlServerCommandMock(_connection)
+        {
+            CommandText = "INSERT INTO Users (Id, Name, Email) VALUES (120, 'Row Count User', NULL)"
+        };
+        command.ExecuteNonQuery();
+
+        command.CommandText = "UPDATE Users SET Name = 'Updated User' WHERE Id = 120; SELECT @@ROWCOUNT;";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture));
+    }
+
+
+    [Fact]
+    [Trait("Category", "SqlServerMock")]
+    public void TestCreateView_SystemRowCountVariable_ShouldReturnZero()
+    {
+        using var command = new SqlServerCommandMock(_connection)
+        {
+            CommandText = "CREATE VIEW vw_users_rowcount AS SELECT Id FROM Users; SELECT @@ROWCOUNT;"
+        };
+
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal(0L, Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture));
+    }
+
+
+    [Fact]
+    [Trait("Category", "SqlServerMock")]
+    public void TestBeginTransaction_SystemRowCountVariable_ShouldReturnZero()
+    {
+        using var command = new SqlServerCommandMock(_connection)
+        {
+            CommandText = "BEGIN TRANSACTION"
+        };
+        command.ExecuteNonQuery();
+
+        command.CommandText = "SELECT @@ROWCOUNT";
+        Assert.Equal(0L, Convert.ToInt64(command.ExecuteScalar(), CultureInfo.InvariantCulture));
+    }
+
 }

--- a/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerCommandMock.cs
@@ -103,16 +103,27 @@ public class SqlServerCommandMock(
         ArgumentExceptionCompatible.ThrowIfNullOrWhiteSpace(CommandText, nameof(CommandText));
 
         if (CommandType == CommandType.StoredProcedure)
-            return connection!.ExecuteStoredProcedure(CommandText, Parameters);
+        {
+            var affected = connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
+        }
 
         var sqlRaw = CommandText.Trim();
 
         if (TryExecuteTransactionControlCommand(sqlRaw, out var transactionControlResult))
+        {
+            connection.SetLastFoundRows(transactionControlResult);
             return transactionControlResult;
+        }
 
         // Mantém atalhos existentes (CALL / CREATE TABLE AS SELECT) por compatibilidade do engine atual
         if (sqlRaw.StartsWith("call ", StringComparison.OrdinalIgnoreCase))
-            return connection!.ExecuteCall(sqlRaw, Parameters);
+        {
+            var affected = connection!.ExecuteCall(sqlRaw, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
+        }
 
         if (sqlRaw.StartsWith("create table", StringComparison.OrdinalIgnoreCase))
             return connection!.ExecuteCreateTableAsSelect(sqlRaw, Parameters, connection!.Db.Dialect);
@@ -146,6 +157,7 @@ public class SqlServerCommandMock(
         if (CommandType == CommandType.StoredProcedure)
         {
             connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(0);
             return new SqlServerDataReaderMock([[]]);
         }
 
@@ -154,6 +166,7 @@ public class SqlServerCommandMock(
         if (sql.StartsWith("CALL", StringComparison.OrdinalIgnoreCase))
         {
             connection!.ExecuteCall(sql, Parameters);
+            connection.SetLastFoundRows(0);
             return new SqlServerDataReaderMock([[]]);
         }
 

--- a/src/DbSqlLikeMem.Sqlite.Test/SqliteMockTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/SqliteMockTests.cs
@@ -195,4 +195,60 @@ public sealed class SqliteMockTests
         _connection.Dispose();
         base.Dispose(disposing);
     }
+
+    [Fact]
+    [Trait("Category", "SqliteMock")]
+    public void TestSelect_FoundRows_ShouldReturnLastSelectRowCount()
+    {
+        using var command = new SqliteCommandMock(_connection);
+        command.CommandText = """
+            INSERT INTO Users (Id, Name, Email) VALUES (101, 'Ana', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (102, 'Bia', NULL);
+            INSERT INTO Users (Id, Name, Email) VALUES (103, 'Caio', NULL);
+            """;
+        command.ExecuteNonQuery();
+
+        command.CommandText = "SELECT Name FROM Users ORDER BY Id LIMIT 1; SELECT FOUND_ROWS();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal("Ana", reader.GetString(0));
+        Assert.True(reader.NextResult());
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0), CultureInfo.InvariantCulture));
+    }
+
+
+    [Fact]
+    [Trait("Category", "SqliteMock")]
+    public void TestUpdate_ChangesFunction_ShouldReturnAffectedRows()
+    {
+        using var command = new SqliteCommandMock(_connection)
+        {
+            CommandText = "INSERT INTO Users (Id, Name, Email) VALUES (150, 'Changes User', NULL)"
+        };
+        command.ExecuteNonQuery();
+
+        command.CommandText = "UPDATE Users SET Name = 'Updated User' WHERE Id = 150; SELECT CHANGES();";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Equal(1L, Convert.ToInt64(reader.GetValue(0)));
+    }
+
+
+    [Fact]
+    [Trait("Category", "SqliteMock")]
+    public void TestBeginTransaction_ChangesFunction_ShouldReturnZero()
+    {
+        using var command = new SqliteCommandMock(_connection)
+        {
+            CommandText = "BEGIN TRANSACTION"
+        };
+        command.ExecuteNonQuery();
+
+        command.CommandText = "SELECT CHANGES();";
+        Assert.Equal(0L, Convert.ToInt64(command.ExecuteScalar()));
+    }
+
 }

--- a/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteCommandMock.cs
@@ -105,18 +105,25 @@ public class SqliteCommandMock(
         // 1. Stored Procedure (sem parse SQL)
         if (CommandType == CommandType.StoredProcedure)
         {
-            return connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            var affected = connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
         }
 
         var sqlRaw = CommandText.Trim();
 
         if (TryExecuteTransactionControlCommand(sqlRaw, out var transactionControlResult))
+        {
+            connection.SetLastFoundRows(transactionControlResult);
             return transactionControlResult;
+        }
 
         // 2. Comandos especiais que talvez o Parser ainda não suporte nativamente (DDL, CALL)
         if (sqlRaw.StartsWith("call ", StringComparison.OrdinalIgnoreCase))
         {
-            return connection!.ExecuteCall(sqlRaw, Parameters);
+            var affected = connection!.ExecuteCall(sqlRaw, Parameters);
+            connection.SetLastFoundRows(affected);
+            return affected;
         }
 
         if (sqlRaw.StartsWith("create temporary table", StringComparison.OrdinalIgnoreCase) ||
@@ -171,6 +178,7 @@ public class SqliteCommandMock(
         if (CommandType == CommandType.StoredProcedure)
         {
             connection!.ExecuteStoredProcedure(CommandText, Parameters);
+            connection.SetLastFoundRows(0);
             return new SqliteDataReaderMock([[]]);
         }
 
@@ -180,6 +188,7 @@ public class SqliteCommandMock(
         if (sql.StartsWith("CALL", StringComparison.OrdinalIgnoreCase))
         {
             connection!.ExecuteCall(sql, Parameters);
+            connection.SetLastFoundRows(0);
             return new SqliteDataReaderMock([[]]);
         }
 

--- a/src/DbSqlLikeMem/Base/DbConnectionMockBase.cs
+++ b/src/DbSqlLikeMem/Base/DbConnectionMockBase.cs
@@ -57,6 +57,7 @@ public abstract class DbConnectionMockBase(
     public IReadOnlyList<string> LastExecutionPlans => _lastExecutionPlans;
 
     private readonly List<string> _lastExecutionPlans = [];
+    private long _lastFoundRows;
 
     internal void ClearExecutionPlans()
     {
@@ -72,6 +73,12 @@ public abstract class DbConnectionMockBase(
         LastExecutionPlan = executionPlan;
         _lastExecutionPlans.Add(executionPlan);
     }
+
+    internal void SetLastFoundRows(long value)
+        => _lastFoundRows = Math.Max(0, value);
+
+    internal long GetLastFoundRows()
+        => _lastFoundRows;
 
     /// <summary>
     /// EN: Simulated latency in milliseconds for each operation.

--- a/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
@@ -774,6 +774,7 @@ internal sealed class SqlQueryParser
             throw new InvalidOperationException("invalid: duplicated SELECT keyword");
         var distinct = TryParseDistinct();
         var top = TryParseTop();
+        TryParseSelectModifiers();
         var selectItems = ParseSelectItemsWithValidation();
         var table = ParseFromOrDual();
         var joins = ParseJoins(table);
@@ -824,6 +825,17 @@ internal sealed class SqlQueryParser
         {
             Table = table
         };
+    }
+
+    private void TryParseSelectModifiers()
+    {
+        while (IsWord(Peek(), "SQL_CALC_FOUND_ROWS"))
+        {
+            if (!string.Equals(_dialect.Name, "mysql", StringComparison.OrdinalIgnoreCase))
+                throw SqlUnsupported.ForDialect(_dialect, "SELECT modifier SQL_CALC_FOUND_ROWS");
+
+            Consume();
+        }
     }
 
     // ------------------------------------------------------------

--- a/src/DbSqlLikeMem/Parser/SqlTokenizer.cs
+++ b/src/DbSqlLikeMem/Parser/SqlTokenizer.cs
@@ -56,6 +56,12 @@ internal sealed class SqlTokenizer
                 continue;
             }
 
+            if (TryReadSqlServerSystemVariable(out var systemVariable))
+            {
+                tokens.Add(systemVariable);
+                continue;
+            }
+
             if (_dialect.IsParameterPrefix(ch))
             {
                 tokens.Add(ReadParameter());
@@ -130,6 +136,28 @@ internal sealed class SqlTokenizer
 
         pair = default;
         return false;
+    }
+
+
+    private bool TryReadSqlServerSystemVariable(out SqlToken token)
+    {
+        token = default;
+
+        if (!string.Equals(_dialect.Name, "sqlserver", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (Peek() != '@' || Peek(1) != '@' || !IsIdentStart(Peek(2)))
+            return false;
+
+        var startPos = _pos;
+        Read(); // @
+        Read(); // @
+
+        while (!Eof && IsIdentChar(Peek()))
+            Read();
+
+        token = new SqlToken(SqlTokenKind.Identifier, _sql[startPos.._pos], startPos);
+        return true;
     }
 
     private SqlToken ReadString()

--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -18,6 +18,9 @@ internal abstract class AstQueryExecutorBase(
     : IAstQueryExecutor
 {
     private static readonly ConcurrentDictionary<Type, Func<string, object, SqlExpr>> _parseWhereDelegateCache = new();
+    private static readonly Regex _sqlCalcFoundRowsRegex = new(
+        @"\bSQL_CALC_FOUND_ROWS\b",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     private readonly DbConnectionMockBase _cnn = cnn ?? throw new ArgumentNullException(nameof(cnn));
     private readonly IDataParameterCollection _pars = pars ?? throw new ArgumentNullException(nameof(pars));
@@ -203,6 +206,7 @@ internal abstract class AstQueryExecutorBase(
             unionMetrics);
         result.ExecutionPlan = plan;
         _cnn.RegisterExecutionPlan(plan);
+        _cnn.SetLastFoundRows(result.Count);
 
         return result;
     }
@@ -343,6 +347,9 @@ internal abstract class AstQueryExecutorBase(
         var sw = Stopwatch.StartNew();
         var result = ExecuteSelect(q, null, null);
         sw.Stop();
+
+        if (!HasSqlCalcFoundRows(q))
+            _cnn.SetLastFoundRows(result.Count);
 
         var metrics = BuildPlanRuntimeMetrics(q, result.Count, sw.ElapsedMilliseconds);
         var indexRecommendations = BuildIndexRecommendations(q, metrics);
@@ -978,6 +985,9 @@ internal abstract class AstQueryExecutorBase(
         // 6) DISTINCT
         if (selectQuery.Distinct)
             projected = ApplyDistinct(projected, Dialect);
+
+        if (HasSqlCalcFoundRows(selectQuery))
+            _cnn.SetLastFoundRows(projected.Count);
 
         // 7) ORDER BY / LIMIT
         projected = ApplyOrderAndLimit(projected, selectQuery, ctes);
@@ -2096,6 +2106,9 @@ internal abstract class AstQueryExecutorBase(
 
         if (q.Distinct)
             res = ApplyDistinct(res, Dialect);
+
+        if (HasSqlCalcFoundRows(q))
+            _cnn.SetLastFoundRows(res.Count);
 
         // ORDER / LIMIT
         res = ApplyOrderAndLimit(res, q, ctes);
@@ -3724,6 +3737,9 @@ private void FillPercentRankOrCumeDist(
                     out var temporalIdentifierValue))
                     return temporalIdentifierValue;
 
+                if (IsSqlServerRowCountIdentifier(id.Name, Dialect))
+                    return _cnn.GetLastFoundRows();
+
                 return ResolveIdentifier(id.Name, row);
 
             case ColumnExpr col:
@@ -4052,6 +4068,14 @@ private void FillPercentRankOrCumeDist(
             var parts = hay.Split(',').Select(_=>_.Trim()).ToArray();
             var idx = Array.FindIndex(parts, p => string.Equals(p, needle, StringComparison.OrdinalIgnoreCase));
             return idx >= 0 ? idx + 1 : 0;
+        }
+
+        if (IsFoundRowsEquivalentFunction(fn.Name, dialect))
+        {
+            if (fn.Args.Count != 0)
+                throw new InvalidOperationException($"{fn.Name.ToUpperInvariant()}() não aceita argumentos.");
+
+            return _cnn.GetLastFoundRows();
         }
 
         var isIf = fn.Name.Equals("IF", StringComparison.OrdinalIgnoreCase);
@@ -5476,4 +5500,35 @@ private void FillPercentRankOrCumeDist(
     //        }
     //    }
     //}
+
+
+
+    private static bool IsSqlServerRowCountIdentifier(string identifier, ISqlDialect? dialect)
+        => dialect is not null
+           && string.Equals(dialect.Name, "sqlserver", StringComparison.OrdinalIgnoreCase)
+           && identifier.Equals("@@ROWCOUNT", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsFoundRowsEquivalentFunction(string functionName, ISqlDialect dialect)
+    {
+        if (string.IsNullOrWhiteSpace(functionName))
+            return false;
+
+        if (functionName.Equals("FOUND_ROWS", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return dialect.Name.ToLowerInvariant() switch
+        {
+            "mysql" => functionName.Equals("ROW_COUNT", StringComparison.OrdinalIgnoreCase),
+            "sqlserver" => functionName.Equals("ROWCOUNT", StringComparison.OrdinalIgnoreCase),
+            "postgresql" => functionName.Equals("ROW_COUNT", StringComparison.OrdinalIgnoreCase),
+            "oracle" => functionName.Equals("ROW_COUNT", StringComparison.OrdinalIgnoreCase),
+            "db2" => functionName.Equals("ROW_COUNT", StringComparison.OrdinalIgnoreCase),
+            "sqlite" => functionName.Equals("CHANGES", StringComparison.OrdinalIgnoreCase),
+            _ => false
+        };
+    }
+
+    private static bool HasSqlCalcFoundRows(SqlSelectQuery query)
+        => !string.IsNullOrWhiteSpace(query.RawSql)
+           && _sqlCalcFoundRowsRegex.IsMatch(query.RawSql);
 }

--- a/src/DbSqlLikeMem/Strategies/DbInsertStrategy.cs
+++ b/src/DbSqlLikeMem/Strategies/DbInsertStrategy.cs
@@ -108,11 +108,15 @@ internal static class DbInsertStrategy
         connection.Metrics.Inserts += insertedCount;
         connection.Metrics.Updates += updatedCount;
 
+        int affected;
         if (string.Equals(dialect.Name, "postgresql", StringComparison.OrdinalIgnoreCase))
-            return insertedCount + updatedCount;
+            affected = insertedCount + updatedCount;
+        else
+            // MySQL retorna: 1 para insert, 2 para update em conflito
+            affected = insertedCount + (updatedCount * 2);
 
-        // MySQL retorna: 1 para insert, 2 para update em conflito
-        return insertedCount + (updatedCount * 2);
+        connection.SetLastFoundRows(affected);
+        return affected;
     }
 
     // --- Helpers de Criação de Linhas ---

--- a/src/DbSqlLikeMem/Strategies/DbMergeStrategy.cs
+++ b/src/DbSqlLikeMem/Strategies/DbMergeStrategy.cs
@@ -12,10 +12,17 @@ internal static class DbMergeStrategy
         DbParameterCollection pars,
         ISqlDialect dialect)
     {
+        int affected;
         if (!connection.Db.ThreadSafe)
-            return ExecuteMergeImpl(connection, query, pars, dialect);
-        lock (connection.Db.SyncRoot)
-            return ExecuteMergeImpl(connection, query, pars, dialect);
+            affected = ExecuteMergeImpl(connection, query, pars, dialect);
+        else
+        {
+            lock (connection.Db.SyncRoot)
+                affected = ExecuteMergeImpl(connection, query, pars, dialect);
+        }
+
+        connection.SetLastFoundRows(affected);
+        return affected;
     }
 
     private static int ExecuteMergeImpl(

--- a/src/DbSqlLikeMem/Strategies/DbSelectIntoAndInsertSelectStrategies.cs
+++ b/src/DbSqlLikeMem/Strategies/DbSelectIntoAndInsertSelectStrategies.cs
@@ -14,10 +14,17 @@ internal static class DbSelectIntoAndInsertSelectStrategies
     {
         _ = pars;
         _ = dialect;
+        int affected;
         if (!connection.Db.ThreadSafe)
-            return ExecuteCreateViewImpl(connection, query);
-        lock (connection.Db.SyncRoot)
-            return ExecuteCreateViewImpl(connection, query);
+            affected = ExecuteCreateViewImpl(connection, query);
+        else
+        {
+            lock (connection.Db.SyncRoot)
+                affected = ExecuteCreateViewImpl(connection, query);
+        }
+
+        connection.SetLastFoundRows(affected);
+        return affected;
     }
 
     private static int ExecuteCreateViewImpl(
@@ -41,10 +48,17 @@ internal static class DbSelectIntoAndInsertSelectStrategies
     {
         _ = pars;
         _ = dialect;
+        int affected;
         if (!connection.Db.ThreadSafe)
-            return ExecuteDropViewImpl(connection, query);
-        lock (connection.Db.SyncRoot)
-            return ExecuteDropViewImpl(connection, query);
+            affected = ExecuteDropViewImpl(connection, query);
+        else
+        {
+            lock (connection.Db.SyncRoot)
+                affected = ExecuteDropViewImpl(connection, query);
+        }
+
+        connection.SetLastFoundRows(affected);
+        return affected;
     }
 
     private static int ExecuteDropViewImpl(
@@ -67,12 +81,17 @@ internal static class DbSelectIntoAndInsertSelectStrategies
         DbParameterCollection pars,
         ISqlDialect dialect)
     {
+        int affected;
         if (!connection.Db.ThreadSafe)
-            return ExecuteCreateTableAsSelectImpl(connection, sql, pars, dialect);
-        lock (connection.Db.SyncRoot)
+            affected = ExecuteCreateTableAsSelectImpl(connection, sql, pars, dialect);
+        else
         {
-            return ExecuteCreateTableAsSelectImpl(connection, sql, pars, dialect);
+            lock (connection.Db.SyncRoot)
+                affected = ExecuteCreateTableAsSelectImpl(connection, sql, pars, dialect);
         }
+
+        connection.SetLastFoundRows(affected);
+        return affected;
     }
 
     private static int ExecuteCreateTableAsSelectImpl(
@@ -270,12 +289,17 @@ internal static class DbSelectIntoAndInsertSelectStrategies
         DbParameterCollection pars,
         ISqlDialect dialect)
     {
+        int affected;
         if (!connection.Db.ThreadSafe)
-            return ExecuteCreateTemporaryTableAsSelectImpl(connection, query, pars, dialect);
-        lock (connection.Db.SyncRoot)
+            affected = ExecuteCreateTemporaryTableAsSelectImpl(connection, query, pars, dialect);
+        else
         {
-            return ExecuteCreateTemporaryTableAsSelectImpl(connection, query, pars, dialect);
+            lock (connection.Db.SyncRoot)
+                affected = ExecuteCreateTemporaryTableAsSelectImpl(connection, query, pars, dialect);
         }
+
+        connection.SetLastFoundRows(affected);
+        return affected;
     }
 
     private static int ExecuteCreateTemporaryTableAsSelectImpl(

--- a/src/DbSqlLikeMem/Strategies/DbUpdateDeleteFromSelectStrategies.cs
+++ b/src/DbSqlLikeMem/Strategies/DbUpdateDeleteFromSelectStrategies.cs
@@ -42,9 +42,12 @@ internal static class DbUpdateDeleteFromSelectStrategies
         ISqlDialect dialect)
     {
         // Detect UPDATE ... JOIN/UPDATE ... FROM ... JOIN (SELECT ...)
-        if (IsUpdateFromSelectSql(query.RawSql))
-            return connection.ExecuteUpdateFromSelect(query, pars, dialect);
-        return connection.ExecuteUpdate(query, pars);
+        var affected = IsUpdateFromSelectSql(query.RawSql)
+            ? connection.ExecuteUpdateFromSelect(query, pars, dialect)
+            : connection.ExecuteUpdate(query, pars);
+
+        connection.SetLastFoundRows(affected);
+        return affected;
     }
 
     /// <summary>
@@ -58,9 +61,12 @@ internal static class DbUpdateDeleteFromSelectStrategies
         ISqlDialect dialect)
     {
         // Detect DELETE ... JOIN / DELETE ... USING (SELECT ...)
-        if (IsDeleteFromSelectSql(query.RawSql))
-            return connection.ExecuteDeleteFromSelect(query, pars, dialect);
-        return connection.ExecuteDelete(query, pars);
+        var affected = IsDeleteFromSelectSql(query.RawSql)
+            ? connection.ExecuteDeleteFromSelect(query, pars, dialect)
+            : connection.ExecuteDelete(query, pars);
+
+        connection.SetLastFoundRows(affected);
+        return affected;
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation

- Provide a consistent mechanism to track the number of rows affected/returned by the last statement so functions like `FOUND_ROWS()`, dialect equivalents (`ROW_COUNT()`, `CHANGES()`, `@@ROWCOUNT`, etc.) and `SQL_CALC_FOUND_ROWS` semantics behave correctly in the in-memory DB mock.
- Ensure `SELECT`/DML/DDL/transaction-control and stored procedure paths update the tracked value so subsequent queries can read it.

### Description

- Added a `_lastFoundRows` field and the accessors `SetLastFoundRows` / `GetLastFoundRows` to `DbConnectionMockBase` to store the last statement's row count.
- Updated command mocks (`MySqlCommandMock`, `SqlServerCommandMock`, `NpgsqlCommandMock`, `OracleCommandMock`, `SqliteCommandMock`, `Db2CommandMock`) to call `SetLastFoundRows(...)` in `ExecuteNonQuery` and appropriate places in `ExecuteDbDataReader` (stored procedures, `CALL`, transaction control), and to set `0` for non-row-returning CALL/SP executions.
- Extended the query engine and parser: added `TryParseSelectModifiers` to accept `SQL_CALC_FOUND_ROWS` on MySQL only, added a tokenizer helper to recognize SQL Server `@@ROWCOUNT` system variable, and enhanced `AstQueryExecutorBase` to set `LastFoundRows` after `SELECT`/`UNION`/grouping paths and to expose `FOUND_ROWS`-equivalent functions via `IsFoundRowsEquivalentFunction` and `IsSqlServerRowCountIdentifier` so `FOUND_ROWS()`/`ROW_COUNT()`/`CHANGES()`/`@@ROWCOUNT` return the tracked value (with argument validation).
- Updated many strategy implementations (insert, merge, create/drop view, create table as select, create temporary table, update/delete smart flows) to set the last found rows after they compute affected row counts.
- Added unit tests across dialect test projects to validate the behavior for `FOUND_ROWS`/`ROW_COUNT`/`CHANGES`/`@@ROWCOUNT` and `SQL_CALC_FOUND_ROWS`, and to assert errors where appropriate for unsupported cases.

### Testing

- Added multiple unit tests to the test projects (`MySqlMockTests`, `SqlServerMockTests`, `Npgsql/PostgreSqlMockTests`, `OracleMockTests`, `SqliteMockTests`, `Db2MockTests`) that exercise `FOUND_ROWS`/equivalents and `SQL_CALC_FOUND_ROWS` semantics and verify expected counts, and these tests were executed as part of the test run.
- Ran the full automated test suite with `dotnet test` and the updated tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6efa6a0c8832ca45599bfa2443a60)