### PR TITLE
Support dialect-specific zero-arg temporal identifiers vs call-style functions and add tests

### DIFF
--- a/docs/features-backlog/index.md
+++ b/docs/features-backlog/index.md
@@ -67,10 +67,17 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - Parser agora sinaliza explicitamente `WITHIN GROUP` (ordered-set aggregates) como não suportado com mensagem acionável por dialeto.
 
 #### 1.2.6 Funções de data/hora cross-dialect
-- Implementação estimada: **58%**.
+- Implementação estimada: **68%**.
 - Consolidar no `dialect` o catálogo de funções temporais sem argumento (data, hora e data/hora).
 - Garantir suporte de avaliação tanto para função com parênteses quanto para tokens sem parênteses em `SELECT`, `WHERE`, `HAVING` e expressões de `INSERT/UPSERT`.
 - Cobertura Dapper cross-provider adicionada para funções temporais sem argumento em projeção/filtro `WHERE`, em expressões de `INSERT VALUES` e em `UPDATE ... SET` (MySQL/SQL Server/Oracle/Npgsql/SQLite/DB2).
+- Cobertura Dapper cross-provider expandida para `HAVING` e `ORDER BY` com função temporal sem argumento em consultas agrupadas (MySQL/SQL Server/Oracle/Npgsql/SQLite/DB2).
+- Cobertura Dapper expandida para funções temporais adicionais por dialeto em `WHERE`, `HAVING` e `ORDER BY` (ex.: `CURRENT_DATE`/`CURRENT_TIME` em MySQL/Npgsql/SQLite/DB2; `GETDATE`/`SYSDATETIME` em SQL Server; `CURRENT_DATE`/`SYSTIMESTAMP` em Oracle).
+- Cenário negativo por dialeto adicionado para função temporal de outro dialeto (ex.: `GETDATE()`/`NOW()`) com validação de erro claro por provider.
+- Catálogo temporal por dialeto agora distingue tokens sem parênteses e funções invocáveis com parênteses, com cobertura negativa para chamadas inválidas de token (`CURRENT_TIMESTAMP()`) em MySQL/Npgsql/SQL Server/SQLite/Oracle/DB2.
+- Cenário inverso (função call-only sem parênteses) validado com erro claro em SQL Server (`GETDATE`) e em MySQL/Npgsql (`NOW`).
+- Cobertura positiva adicional para `NOW()` em consulta agrupada com `HAVING`/`ORDER BY` no MySQL, reforçando semântica call-style no dialeto.
+- Cobertura positiva call-style expandida para `NOW()` no Npgsql (`WHERE` e `HAVING`/`ORDER BY`) e para `GETDATE()`/`SYSDATETIME()` em consulta agrupada no SQL Server.
 - Cobrir equivalências por provedor (exemplos):
   - Oracle: `SYSDATE`, `SYSTIMESTAMP`, `CURRENT_DATE`, `CURRENT_TIMESTAMP`.
   - SQL Server: `GETDATE`, `SYSDATETIME`, `CURRENT_TIMESTAMP`.

--- a/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AggregationTests.cs
+++ b/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AggregationTests.cs
@@ -117,6 +117,46 @@ public sealed class Db2AggregationTests : AggregationHavingOrdinalTestsBase<Db2D
     }
 
 
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_DATE and CURRENT_TIME tokens work in WHERE filter and projection.
+    /// PT: Garante que tokens CURRENT_DATE e CURRENT_TIME funcionem em filtro WHERE e projeção.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2Aggregation")]
+    public void TemporalFunction_CurrentDateAndTime_InWhere_ShouldWork()
+    {
+        var rows = Query("SELECT CURRENT_DATE AS currentDate, CURRENT_TIME AS currentTime FROM orders WHERE CURRENT_DATE IS NOT NULL AND CURRENT_TIME IS NOT NULL");
+
+        Assert.NotEmpty(rows);
+        Assert.NotNull(rows[0].currentDate);
+        Assert.NotNull(rows[0].currentTime);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_DATE and CURRENT_TIME tokens work in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que tokens CURRENT_DATE e CURRENT_TIME funcionem em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2Aggregation")]
+    public void TemporalFunction_CurrentDateAndTime_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING CURRENT_DATE IS NOT NULL
+            ORDER BY CURRENT_TIME, userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
     /// <summary>
     /// EN: Ensures zero-arg temporal function works in INSERT values and can be read back.
     /// PT: Garante que função temporal sem argumentos funcione em valores de INSERT e possa ser lida depois.
@@ -151,6 +191,59 @@ public sealed class Db2AggregationTests : AggregationHavingOrdinalTestsBase<Db2D
 
         Assert.Single(rows);
         Assert.NotNull(rows[0].updated_at);
+    }
+
+    /// <summary>
+    /// EN: Ensures zero-arg temporal function works in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que função temporal sem argumentos funcione em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2Aggregation")]
+    public void TemporalFunction_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING CURRENT_TIMESTAMP IS NOT NULL
+            ORDER BY CURRENT_TIMESTAMP, userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures unsupported temporal function from another dialect reports a clear error message.
+    /// PT: Garante que função temporal de outro dialeto gere mensagem de erro clara.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2Aggregation")]
+    public void TemporalFunction_UnsupportedFunctionFromOtherDialect_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT GETDATE() AS invalidNow FROM orders"));
+
+        Assert.Contains("GETDATE", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+
+    /// <summary>
+    /// EN: Ensures token-only temporal function called with parentheses reports clear error.
+    /// PT: Garante que função temporal no formato token chamada com parênteses gere erro claro.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2Aggregation")]
+    public void TemporalFunction_TokenCalledAsFunction_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT CURRENT_TIMESTAMP() AS invalidNow FROM orders"));
+
+        Assert.Contains("CURRENT_TIMESTAMP", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 }

--- a/src/DbSqlLikeMem.Db2/Db2Dialect.cs
+++ b/src/DbSqlLikeMem.Db2/Db2Dialect.cs
@@ -119,6 +119,10 @@ internal sealed class Db2Dialect : SqlDialectBase
             ["SYSTEMDATE"] = SqlTemporalFunctionKind.DateTime,
         };
 
+
+    public override IReadOnlyCollection<string> TemporalFunctionCallNames
+        => [];
+
     /// <summary>
     /// EN: Gets or sets allows parser limit offset compatibility.
     /// PT: Obtém ou define allows parser limit offset compatibility.

--- a/src/DbSqlLikeMem.MySql.Dapper.Test/MySqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.MySql.Dapper.Test/MySqlAggregationTests.cs
@@ -100,6 +100,62 @@ public sealed class MySqlAggregationTests : AggregationHavingOrdinalTestsBase<My
     }
 
 
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_TIMESTAMP token (without parentheses) works in WHERE filter and projection for MySQL.
+    /// PT: Garante que token CURRENT_TIMESTAMP (sem parênteses) funcione em filtro WHERE e projeção no MySQL.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void TemporalFunction_CurrentTimestampToken_InWhere_ShouldWork()
+    {
+        var rows = Query("SELECT CURRENT_TIMESTAMP AS nowValue FROM orders WHERE CURRENT_TIMESTAMP IS NOT NULL");
+
+        Assert.NotEmpty(rows);
+        Assert.NotNull(rows[0].nowValue);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_DATE and CURRENT_TIME tokens work in WHERE filter and projection.
+    /// PT: Garante que tokens CURRENT_DATE e CURRENT_TIME funcionem em filtro WHERE e projeção.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void TemporalFunction_CurrentDateAndTime_InWhere_ShouldWork()
+    {
+        var rows = Query("SELECT CURRENT_DATE AS currentDate, CURRENT_TIME AS currentTime FROM orders WHERE CURRENT_DATE IS NOT NULL AND CURRENT_TIME IS NOT NULL");
+
+        Assert.NotEmpty(rows);
+        Assert.NotNull(rows[0].currentDate);
+        Assert.NotNull(rows[0].currentTime);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_DATE and CURRENT_TIME tokens work in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que tokens CURRENT_DATE e CURRENT_TIME funcionem em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void TemporalFunction_CurrentDateAndTime_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING CURRENT_DATE IS NOT NULL
+            ORDER BY CURRENT_TIME, userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
     /// <summary>
     /// EN: Ensures zero-arg temporal function works in INSERT values and can be read back.
     /// PT: Garante que função temporal sem argumentos funcione em valores de INSERT e possa ser lida depois.
@@ -134,6 +190,98 @@ public sealed class MySqlAggregationTests : AggregationHavingOrdinalTestsBase<My
 
         Assert.Single(rows);
         Assert.NotNull(rows[0].updated_at);
+    }
+
+    /// <summary>
+    /// EN: Ensures zero-arg temporal function works in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que função temporal sem argumentos funcione em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void TemporalFunction_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING CURRENT_TIMESTAMP IS NOT NULL
+            ORDER BY CURRENT_TIMESTAMP, userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
+
+
+
+    /// <summary>
+    /// EN: Ensures NOW() call-style temporal function works in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que função temporal NOW() (call-style) funcione em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void TemporalFunction_NowCall_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING NOW() IS NOT NULL
+            ORDER BY NOW(), userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
+    /// <summary>
+    /// EN: Ensures unsupported temporal function from another dialect reports a clear error message.
+    /// PT: Garante que função temporal de outro dialeto gere mensagem de erro clara.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void TemporalFunction_UnsupportedFunctionFromOtherDialect_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT GETDATE() AS invalidNow FROM orders"));
+
+        Assert.Contains("GETDATE", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+
+    /// <summary>
+    /// EN: Ensures token-only temporal function called with parentheses reports clear error.
+    /// PT: Garante que função temporal no formato token chamada com parênteses gere erro claro.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void TemporalFunction_TokenCalledAsFunction_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT CURRENT_TIMESTAMP() AS invalidNow FROM orders"));
+
+        Assert.Contains("CURRENT_TIMESTAMP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures call-only temporal function used without parentheses reports clear error.
+    /// PT: Garante que função temporal apenas-invocável usada sem parênteses gere erro claro.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void TemporalFunction_CallOnlyIdentifierWithoutParentheses_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT NOW AS invalidNow FROM orders"));
+
+        Assert.Contains("NOW", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 }

--- a/src/DbSqlLikeMem.MySql/MySqlDialect.cs
+++ b/src/DbSqlLikeMem.MySql/MySqlDialect.cs
@@ -160,6 +160,13 @@ internal sealed class MySqlDialect : SqlDialectBase
             ["SYSTEMDATE"] = SqlTemporalFunctionKind.DateTime,
         };
 
+
+    public override IReadOnlyCollection<string> TemporalFunctionIdentifierNames
+        => ["CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "SYSTEMDATE"];
+
+    public override IReadOnlyCollection<string> TemporalFunctionCallNames
+        => ["NOW", "SYSDATE"];
+
     /// <summary>
     /// EN: Indicates whether string concatenation returns <c>NULL</c> when any operand is <c>NULL</c>.
     /// PT: Indica se a concatenação de strings retorna <c>NULL</c> quando qualquer operando é <c>NULL</c>.

--- a/src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlAggregationTests.cs
@@ -117,6 +117,62 @@ public sealed class PostgreSqlAggregationTests : AggregationHavingOrdinalTestsBa
     }
 
 
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_DATE and CURRENT_TIME tokens work in WHERE filter and projection.
+    /// PT: Garante que tokens CURRENT_DATE e CURRENT_TIME funcionem em filtro WHERE e projeção.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void TemporalFunction_CurrentDateAndTime_InWhere_ShouldWork()
+    {
+        var rows = Query("SELECT CURRENT_DATE AS currentDate, CURRENT_TIME AS currentTime FROM orders WHERE CURRENT_DATE IS NOT NULL AND CURRENT_TIME IS NOT NULL");
+
+        Assert.NotEmpty(rows);
+        Assert.NotNull(rows[0].currentDate);
+        Assert.NotNull(rows[0].currentTime);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_DATE and CURRENT_TIME tokens work in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que tokens CURRENT_DATE e CURRENT_TIME funcionem em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void TemporalFunction_CurrentDateAndTime_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING CURRENT_DATE IS NOT NULL
+            ORDER BY CURRENT_TIME, userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures NOW() call-style temporal function works in WHERE filter and projection.
+    /// PT: Garante que função temporal NOW() (call-style) funcione em filtro WHERE e projeção.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void TemporalFunction_NowCall_InWhere_ShouldWork()
+    {
+        var rows = Query("SELECT NOW() AS nowValue FROM orders WHERE NOW() IS NOT NULL");
+
+        Assert.NotEmpty(rows);
+        Assert.NotNull(rows[0].nowValue);
+    }
+
     /// <summary>
     /// EN: Ensures zero-arg temporal function works in INSERT values and can be read back.
     /// PT: Garante que função temporal sem argumentos funcione em valores de INSERT e possa ser lida depois.
@@ -151,6 +207,98 @@ public sealed class PostgreSqlAggregationTests : AggregationHavingOrdinalTestsBa
 
         Assert.Single(rows);
         Assert.NotNull(rows[0].updated_at);
+    }
+
+    /// <summary>
+    /// EN: Ensures zero-arg temporal function works in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que função temporal sem argumentos funcione em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void TemporalFunction_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING NOW() IS NOT NULL
+            ORDER BY NOW(), userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
+
+
+
+    /// <summary>
+    /// EN: Ensures NOW() call-style temporal function works in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que função temporal NOW() (call-style) funcione em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void TemporalFunction_NowCall_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING NOW() IS NOT NULL
+            ORDER BY NOW(), userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
+    /// <summary>
+    /// EN: Ensures unsupported temporal function from another dialect reports a clear error message.
+    /// PT: Garante que função temporal de outro dialeto gere mensagem de erro clara.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void TemporalFunction_UnsupportedFunctionFromOtherDialect_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT GETDATE() AS invalidNow FROM orders"));
+
+        Assert.Contains("GETDATE", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+
+    /// <summary>
+    /// EN: Ensures token-only temporal function called with parentheses reports clear error.
+    /// PT: Garante que função temporal no formato token chamada com parênteses gere erro claro.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void TemporalFunction_TokenCalledAsFunction_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT CURRENT_TIMESTAMP() AS invalidNow FROM orders"));
+
+        Assert.Contains("CURRENT_TIMESTAMP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures call-only temporal function used without parentheses reports clear error.
+    /// PT: Garante que função temporal apenas-invocável usada sem parênteses gere erro claro.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void TemporalFunction_CallOnlyIdentifierWithoutParentheses_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT NOW AS invalidNow FROM orders"));
+
+        Assert.Contains("NOW", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 }

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
@@ -150,6 +150,13 @@ internal sealed class NpgsqlDialect : SqlDialectBase
             ["SYSTEMDATE"] = SqlTemporalFunctionKind.DateTime,
         };
 
+
+    public override IReadOnlyCollection<string> TemporalFunctionIdentifierNames
+        => ["CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "SYSTEMDATE"];
+
+    public override IReadOnlyCollection<string> TemporalFunctionCallNames
+        => ["NOW"];
+
     /// <summary>
     /// EN: Gets or sets concat returns null on null input.
     /// PT: Obtém ou define concat returns null on null input.

--- a/src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAggregationTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAggregationTests.cs
@@ -139,6 +139,46 @@ public sealed class OracleAggregationTests : AggregationHavingOrdinalTestsBase<O
     }
 
 
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_DATE and SYSTIMESTAMP tokens work in WHERE filter and projection.
+    /// PT: Garante que tokens CURRENT_DATE e SYSTIMESTAMP funcionem em filtro WHERE e projeção.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAggregation")]
+    public void TemporalFunction_CurrentDateAndSysTimestamp_InWhere_ShouldWork()
+    {
+        var rows = Query("SELECT CURRENT_DATE AS currentDate, SYSTIMESTAMP AS currentTime FROM orders WHERE CURRENT_DATE IS NOT NULL AND SYSTIMESTAMP IS NOT NULL");
+
+        Assert.NotEmpty(rows);
+        Assert.NotNull(rows[0].currentDate);
+        Assert.NotNull(rows[0].currentTime);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_DATE and SYSTIMESTAMP tokens work in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que tokens CURRENT_DATE e SYSTIMESTAMP funcionem em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAggregation")]
+    public void TemporalFunction_CurrentDateAndSysTimestamp_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING CURRENT_DATE IS NOT NULL
+            ORDER BY SYSTIMESTAMP, userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
     /// <summary>
     /// EN: Ensures zero-arg temporal function works in INSERT values and can be read back.
     /// PT: Garante que função temporal sem argumentos funcione em valores de INSERT e possa ser lida depois.
@@ -173,6 +213,59 @@ public sealed class OracleAggregationTests : AggregationHavingOrdinalTestsBase<O
 
         Assert.Single(rows);
         Assert.NotNull(rows[0].updated_at);
+    }
+
+    /// <summary>
+    /// EN: Ensures zero-arg temporal function works in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que função temporal sem argumentos funcione em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAggregation")]
+    public void TemporalFunction_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING SYSDATE IS NOT NULL
+            ORDER BY SYSDATE, userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures unsupported temporal function from another dialect reports a clear error message.
+    /// PT: Garante que função temporal de outro dialeto gere mensagem de erro clara.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAggregation")]
+    public void TemporalFunction_UnsupportedFunctionFromOtherDialect_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT GETDATE() AS invalidNow FROM orders"));
+
+        Assert.Contains("GETDATE", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+
+    /// <summary>
+    /// EN: Ensures token-only temporal function called with parentheses reports clear error.
+    /// PT: Garante que função temporal no formato token chamada com parênteses gere erro claro.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAggregation")]
+    public void TemporalFunction_TokenCalledAsFunction_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT CURRENT_TIMESTAMP() AS invalidNow FROM orders"));
+
+        Assert.Contains("CURRENT_TIMESTAMP", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 }

--- a/src/DbSqlLikeMem.Oracle/OracleDialect.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDialect.cs
@@ -129,6 +129,8 @@ internal sealed class OracleDialect : SqlDialectBase
             ["SYSTIMESTAMP"] = SqlTemporalFunctionKind.DateTime,
             ["SYSTEMDATE"] = SqlTemporalFunctionKind.DateTime,
         };
+
+
     /// <summary>
     /// EN: Gets or sets concat returns null on null input.
     /// PT: Obtém ou define concat returns null on null input.

--- a/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAggregationTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAggregationTests.cs
@@ -115,6 +115,46 @@ public sealed class SqlServerAggregationTests : AggregationHavingOrdinalTestsBas
     }
 
 
+
+
+    /// <summary>
+    /// EN: Ensures GETDATE and SYSDATETIME functions work in WHERE filter and projection.
+    /// PT: Garante que funções GETDATE e SYSDATETIME funcionem em filtro WHERE e projeção.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void TemporalFunction_GetDateAndSysDateTime_InWhere_ShouldWork()
+    {
+        var rows = Query("SELECT GETDATE() AS currentDate, SYSDATETIME() AS currentTime FROM orders WHERE GETDATE() IS NOT NULL AND SYSDATETIME() IS NOT NULL");
+
+        Assert.NotEmpty(rows);
+        Assert.NotNull(rows[0].currentDate);
+        Assert.NotNull(rows[0].currentTime);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures GETDATE and SYSDATETIME functions work in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que funções GETDATE e SYSDATETIME funcionem em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void TemporalFunction_GetDateAndSysDateTime_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING GETDATE() IS NOT NULL
+            ORDER BY SYSDATETIME(), userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
     /// <summary>
     /// EN: Ensures zero-arg temporal function works in INSERT values and can be read back.
     /// PT: Garante que função temporal sem argumentos funcione em valores de INSERT e possa ser lida depois.
@@ -149,6 +189,98 @@ public sealed class SqlServerAggregationTests : AggregationHavingOrdinalTestsBas
 
         Assert.Single(rows);
         Assert.NotNull(rows[0].updated_at);
+    }
+
+    /// <summary>
+    /// EN: Ensures zero-arg temporal function works in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que função temporal sem argumentos funcione em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void TemporalFunction_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING CURRENT_TIMESTAMP IS NOT NULL
+            ORDER BY CURRENT_TIMESTAMP, userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
+
+
+
+    /// <summary>
+    /// EN: Ensures GETDATE()/SYSDATETIME() call-style temporal functions work in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que funções temporais GETDATE()/SYSDATETIME() (call-style) funcionem em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void TemporalFunction_GetDateAndSysDateTimeCall_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING GETDATE() IS NOT NULL
+            ORDER BY SYSDATETIME(), userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
+    /// <summary>
+    /// EN: Ensures unsupported temporal function from another dialect reports a clear error message.
+    /// PT: Garante que função temporal de outro dialeto gere mensagem de erro clara.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void TemporalFunction_UnsupportedFunctionFromOtherDialect_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT NOW() AS invalidNow FROM orders"));
+
+        Assert.Contains("NOW", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+
+    /// <summary>
+    /// EN: Ensures token-only temporal function called with parentheses reports clear error.
+    /// PT: Garante que função temporal no formato token chamada com parênteses gere erro claro.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void TemporalFunction_TokenCalledAsFunction_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT CURRENT_TIMESTAMP() AS invalidNow FROM orders"));
+
+        Assert.Contains("CURRENT_TIMESTAMP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures call-only temporal function used without parentheses reports clear error.
+    /// PT: Garante que função temporal apenas-invocável usada sem parênteses gere erro claro.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void TemporalFunction_CallOnlyIdentifierWithoutParentheses_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT GETDATE AS invalidNow FROM orders"));
+
+        Assert.Contains("GETDATE", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 }

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
@@ -156,6 +156,13 @@ internal sealed class SqlServerDialect : SqlDialectBase
             ["SYSDATETIME"] = SqlTemporalFunctionKind.DateTime,
             ["SYSTEMDATE"] = SqlTemporalFunctionKind.DateTime,
         };
+
+    public override IReadOnlyCollection<string> TemporalFunctionIdentifierNames
+        => ["CURRENT_TIMESTAMP"];
+
+    public override IReadOnlyCollection<string> TemporalFunctionCallNames
+        => ["GETDATE", "SYSDATETIME"];
+
     /// <summary>
     /// EN: Gets or sets concat returns null on null input.
     /// PT: Obtém ou define concat returns null on null input.

--- a/src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAggregationTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAggregationTests.cs
@@ -102,6 +102,46 @@ public sealed class SqliteAggregationTests : AggregationHavingOrdinalTestsBase<S
     }
 
 
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_DATE and CURRENT_TIME tokens work in WHERE filter and projection.
+    /// PT: Garante que tokens CURRENT_DATE e CURRENT_TIME funcionem em filtro WHERE e projeção.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void TemporalFunction_CurrentDateAndTime_InWhere_ShouldWork()
+    {
+        var rows = Query("SELECT CURRENT_DATE AS currentDate, CURRENT_TIME AS currentTime FROM orders WHERE CURRENT_DATE IS NOT NULL AND CURRENT_TIME IS NOT NULL");
+
+        Assert.NotEmpty(rows);
+        Assert.NotNull(rows[0].currentDate);
+        Assert.NotNull(rows[0].currentTime);
+    }
+
+
+
+    /// <summary>
+    /// EN: Ensures CURRENT_DATE and CURRENT_TIME tokens work in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que tokens CURRENT_DATE e CURRENT_TIME funcionem em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void TemporalFunction_CurrentDateAndTime_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING CURRENT_DATE IS NOT NULL
+            ORDER BY CURRENT_TIME, userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
     /// <summary>
     /// EN: Ensures zero-arg temporal function works in INSERT values and can be read back.
     /// PT: Garante que função temporal sem argumentos funcione em valores de INSERT e possa ser lida depois.
@@ -136,6 +176,59 @@ public sealed class SqliteAggregationTests : AggregationHavingOrdinalTestsBase<S
 
         Assert.Single(rows);
         Assert.NotNull(rows[0].updated_at);
+    }
+
+    /// <summary>
+    /// EN: Ensures zero-arg temporal function works in HAVING and ORDER BY grouped queries.
+    /// PT: Garante que função temporal sem argumentos funcione em HAVING e ORDER BY com agrupamento.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void TemporalFunction_InHavingAndOrderBy_ShouldWork()
+    {
+        var rows = Query("""
+            SELECT userId, COUNT(*) AS total
+            FROM orders
+            GROUP BY userId
+            HAVING CURRENT_TIMESTAMP IS NOT NULL
+            ORDER BY CURRENT_TIMESTAMP, userId
+            """);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1, Convert.ToInt32(rows[0].userId));
+        Assert.Equal(2, Convert.ToInt32(rows[1].userId));
+    }
+
+
+    /// <summary>
+    /// EN: Ensures unsupported temporal function from another dialect reports a clear error message.
+    /// PT: Garante que função temporal de outro dialeto gere mensagem de erro clara.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void TemporalFunction_UnsupportedFunctionFromOtherDialect_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT GETDATE() AS invalidNow FROM orders"));
+
+        Assert.Contains("GETDATE", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+
+    /// <summary>
+    /// EN: Ensures token-only temporal function called with parentheses reports clear error.
+    /// PT: Garante que função temporal no formato token chamada com parênteses gere erro claro.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void TemporalFunction_TokenCalledAsFunction_ShouldThrowClearError()
+    {
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            Query("SELECT CURRENT_TIMESTAMP() AS invalidNow FROM orders"));
+
+        Assert.Contains("CURRENT_TIMESTAMP", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 }

--- a/src/DbSqlLikeMem.Sqlite/SqliteDialect.cs
+++ b/src/DbSqlLikeMem.Sqlite/SqliteDialect.cs
@@ -131,6 +131,10 @@ internal sealed class SqliteDialect : SqlDialectBase
             ["NOW"] = SqlTemporalFunctionKind.DateTime,
             ["SYSTEMDATE"] = SqlTemporalFunctionKind.DateTime,
         };
+
+    public override IReadOnlyCollection<string> TemporalFunctionCallNames
+        => [];
+
     /// <summary>
     /// EN: Gets or sets concat returns null on null input.
     /// PT: Obtém ou define concat returns null on null input.

--- a/src/DbSqlLikeMem/Compatibility/SqlTemporalFunctionEvaluator.cs
+++ b/src/DbSqlLikeMem/Compatibility/SqlTemporalFunctionEvaluator.cs
@@ -2,15 +2,38 @@ namespace DbSqlLikeMem;
 
 internal static class SqlTemporalFunctionEvaluator
 {
-    public static bool TryEvaluateZeroArgFunction(ISqlDialect dialect, string functionName, out object? value)
+    public static bool TryEvaluateZeroArgIdentifier(ISqlDialect dialect, string functionName, out object? value)
     {
         value = null;
         if (dialect is null || string.IsNullOrWhiteSpace(functionName))
             return false;
 
+        if (!dialect.TemporalFunctionIdentifierNames.Any(n => n.Equals(functionName, StringComparison.OrdinalIgnoreCase)))
+            return false;
+
         if (!dialect.TemporalFunctionNames.TryGetValue(functionName, out var kind))
             return false;
 
+        return TryMapKind(kind, out value);
+    }
+
+    public static bool TryEvaluateZeroArgCall(ISqlDialect dialect, string functionName, out object? value)
+    {
+        value = null;
+        if (dialect is null || string.IsNullOrWhiteSpace(functionName))
+            return false;
+
+        if (!dialect.TemporalFunctionCallNames.Any(n => n.Equals(functionName, StringComparison.OrdinalIgnoreCase)))
+            return false;
+
+        if (!dialect.TemporalFunctionNames.TryGetValue(functionName, out var kind))
+            return false;
+
+        return TryMapKind(kind, out value);
+    }
+
+    private static bool TryMapKind(SqlTemporalFunctionKind kind, out object? value)
+    {
         var utcNow = DateTime.UtcNow;
         value = kind switch
         {

--- a/src/DbSqlLikeMem/Parser/Dialects.cs
+++ b/src/DbSqlLikeMem/Parser/Dialects.cs
@@ -121,6 +121,8 @@ internal interface ISqlDialect
     bool SupportsIifFunction { get; }
     IReadOnlyCollection<string> NullSubstituteFunctionNames { get; }
     IReadOnlyDictionary<string, SqlTemporalFunctionKind> TemporalFunctionNames { get; }
+    IReadOnlyCollection<string> TemporalFunctionIdentifierNames { get; }
+    IReadOnlyCollection<string> TemporalFunctionCallNames { get; }
     bool ConcatReturnsNullOnNullInput { get; }
     // Dialect-specific runtime semantics
     bool RegexInvalidPatternEvaluatesToFalse { get; }
@@ -304,6 +306,12 @@ internal abstract class SqlDialectBase : ISqlDialect
             ["CURRENT_TIMESTAMP"] = SqlTemporalFunctionKind.DateTime,
             ["NOW"] = SqlTemporalFunctionKind.DateTime,
         };
+
+    public virtual IReadOnlyCollection<string> TemporalFunctionIdentifierNames
+        => TemporalFunctionNames.Keys.ToArray();
+
+    public virtual IReadOnlyCollection<string> TemporalFunctionCallNames
+        => [];
     public virtual bool ConcatReturnsNullOnNullInput => true;
 
     public virtual bool RegexInvalidPatternEvaluatesToFalse => false;

--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -3731,7 +3731,7 @@ private void FillPercentRankOrCumeDist(
                 return ResolveParam(p.Name);
 
             case IdentifierExpr id:
-                if (SqlTemporalFunctionEvaluator.TryEvaluateZeroArgFunction(
+                if (SqlTemporalFunctionEvaluator.TryEvaluateZeroArgIdentifier(
                     Dialect ?? throw new InvalidOperationException("Dialeto SQL não disponível para avaliação de função temporal."),
                     id.Name,
                     out var temporalIdentifierValue))
@@ -4058,7 +4058,7 @@ private void FillPercentRankOrCumeDist(
             return EvalAggregate(fn, group, ctes);
 
         // Scalar functions (best-effort)
-        if (fn.Args.Count == 0 && SqlTemporalFunctionEvaluator.TryEvaluateZeroArgFunction(dialect, fn.Name, out var temporalValue))
+        if (fn.Args.Count == 0 && SqlTemporalFunctionEvaluator.TryEvaluateZeroArgCall(dialect, fn.Name, out var temporalValue))
             return temporalValue;
 
         if (fn.Name.Equals("FIND_IN_SET", StringComparison.OrdinalIgnoreCase))

--- a/src/DbSqlLikeMem/Strategies/DbInsertStrategy.cs
+++ b/src/DbSqlLikeMem/Strategies/DbInsertStrategy.cs
@@ -393,7 +393,7 @@ internal static class DbInsertStrategy
                 ParameterExpr p => GetParamValue(p.Name),
                 IdentifierExpr id => TryGetExcludedValueFromName(id.Name, out var excluded)
                     ? excluded
-                    : SqlTemporalFunctionEvaluator.TryEvaluateZeroArgFunction(dialect, id.Name, out var temporalIdentifierValue)
+                    : SqlTemporalFunctionEvaluator.TryEvaluateZeroArgIdentifier(dialect, id.Name, out var temporalIdentifierValue)
                         ? temporalIdentifierValue
                         : GetExistingColumnValue(id.Name.Contains('.') ? id.Name.Split('.').Last() : id.Name),
                 ColumnExpr c => string.Equals(c.Qualifier, "excluded", StringComparison.OrdinalIgnoreCase)
@@ -605,7 +605,7 @@ internal static class DbInsertStrategy
         {
             // compat: alguns parsers usam FunctionCallExpr
             var name = fn.Name;
-            if (fn.Args.Count == 0 && SqlTemporalFunctionEvaluator.TryEvaluateZeroArgFunction(dialect, name, out var temporalValue))
+            if (fn.Args.Count == 0 && SqlTemporalFunctionEvaluator.TryEvaluateZeroArgCall(dialect, name, out var temporalValue))
                 return temporalValue;
 
             // se vier algo simples tipo VALUES(...) cair aqui por engano, tenta tratar:
@@ -645,7 +645,7 @@ internal static class DbInsertStrategy
                 return GetInsertedColumnValue(col!);
             }
 
-            if (call.Args.Count == 0 && SqlTemporalFunctionEvaluator.TryEvaluateZeroArgFunction(dialect, name, out var temporalValue))
+            if (call.Args.Count == 0 && SqlTemporalFunctionEvaluator.TryEvaluateZeroArgCall(dialect, name, out var temporalValue))
                 return temporalValue;
 
             throw new InvalidOperationException($"CALL não suportado no ON DUPLICATE: {call.Name}");


### PR DESCRIPTION
### Motivation
- Different SQL dialects distinguish between zero-argument temporal tokens (identifiers) and call-style temporal functions, and the runtime needed to evaluate and validate them distinctly to provide correct semantics and clearer error messages.
- Tests were expanded to cover cross-dialect behavior for temporal functions in `WHERE`, `HAVING`, `ORDER BY`, `INSERT` and `UPDATE` scenarios and to assert negative/error cases for unsupported or misused temporal forms.

### Description
- Introduced two new `ISqlDialect` properties: `TemporalFunctionIdentifierNames` and `TemporalFunctionCallNames`, and updated `SqlDialectBase` and each concrete dialect (`MySqlDialect`, `NpgsqlDialect`, `SqlServerDialect`, `SqliteDialect`, `OracleDialect`, `Db2Dialect`) to declare which temporal forms are identifiers vs call-style functions.
- Split the temporal evaluation into `SqlTemporalFunctionEvaluator.TryEvaluateZeroArgIdentifier` and `TryEvaluateZeroArgCall` and factored common mapping into `TryMapKind` to return correct `DateTime`/`Date`/`TimeOfDay` values.
- Updated AST evaluation sites to use the proper evaluator: identifier evaluation in `Eval(IdentifierExpr)` now uses `TryEvaluateZeroArgIdentifier`, function calls in `EvalFunction` use `TryEvaluateZeroArgCall`, and insert/upsert paths in `DbInsertStrategy` also use `TryEvaluateZeroArgCall` for call-style temporal functions.
- Added/expanded unit tests across dialect-specific aggregation test suites to validate token vs call-style handling, grouped query behavior (`HAVING`/`ORDER BY`), `INSERT`/`UPDATE` usage, and negative cases for unsupported or mis-invoked temporal forms; and updated docs backlog entries to reflect expanded temporal function coverage.

### Testing
- Ran `dotnet test` for the dialect test projects covering: `DbSqlLikeMem.MySql.Dapper.Test`, `DbSqlLikeMem.Npgsql.Dapper.Test`, `DbSqlLikeMem.Oracle.Dapper.Test`, `DbSqlLikeMem.SqlServer.Dapper.Test`, `DbSqlLikeMem.Sqlite.Dapper.Test`, and `DbSqlLikeMem.Db2.Dapper.Test`, and all tests including the newly added temporal tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7485f35b4832c8af97bf50183e9cb)