### PR TITLE
Unify string-aggregation tests into shared assertions, add SqlNotSupportedAssert, and update backlog docs

### DIFF
--- a/docs/features-backlog/index.md
+++ b/docs/features-backlog/index.md
@@ -659,10 +659,25 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - Verificação automatizada já adicionada ao CI via `scripts/check_slnx_project_coverage.py` para detectar drift entre árvore `src` e conteúdo da solução.
 
 #### 6.3.2 Matriz compartilhada de testes por capability
-- Implementação estimada: **62%**.
+- Implementação estimada: **92%**.
 - Priorizar base compartilhada para cenários repetitivos cross-dialect (ex.: agregação textual, `DISTINCT`, `NULL`, ordered-set).
 - Reduzir duplicação de testes específicos por provider movendo contratos comuns para fixtures parametrizadas.
 - Facilita evolução coordenada do parser/executor sem espalhar ajustes em múltiplos projetos de teste.
+- Entregas recentes na trilha:
+  - suíte compartilhada de agregação/having/ordinal já consolidada e reutilizada por MySQL, SQL Server, Oracle, Npgsql, SQLite e DB2;
+  - normalização de nomenclatura dos testes cross-provider para reduzir variação entre cenários equivalentes;
+  - alinhamento da base de smoke para manter mesma ordem de validação entre providers e simplificar diagnóstico de regressão.
+  - camada compartilhada `SqlNotSupportedAssert` + helper base `AssertWithinGroupNotSupported(...)` adotados nos testes de agregação para padronizar validação de erro `NotSupported` com token da feature em SQL Server, Oracle, Npgsql, DB2, MySQL e SQLite.
+  - contratos compartilhados para agregação textual com separador e `DISTINCT` + `NULL` extraídos para a base comum `AggregationHavingOrdinalTestsBase` e reutilizados por MySQL/SQL Server/Oracle/Npgsql/SQLite/DB2.
+  - bloco comum de projeção mista (`agregação textual + NULL literal`) implementado na base compartilhada e validado nos seis providers Dapper principais, reduzindo risco de regressão em mapeamentos dinâmicos de resultado.
+  - cobertura compartilhada expandida para projeção `CASE ... THEN NULL` combinada com agregação textual agrupada nos seis providers, reforçando previsibilidade para cenários de relatório com colunas calculadas nulas.
+  - cobertura compartilhada ampliada para `CASE` com ramos mistos (`texto`/`NULL`) sobre agregação textual, validando estabilidade de ordem e coercão básica de saída por provider.
+  - cobertura avançou para `CASE` de múltiplos ramos (`primary`/`secondary`/`NULL`) com agregação textual e ordenação estável, reduzindo risco de divergência em relatórios agrupados cross-provider.
+  - cobertura evoluiu para `CASE` numérico multibranch (`100`/`200`/`0`) junto de agregação textual, validando estabilidade de coerção e leitura de tipos numéricos por provider.
+- Próximos incrementos da capability matrix:
+  - ampliar contratos compartilhados para cenários de ordenação dentro da agregação textual quando habilitados por dialeto;
+  - expandir bloco comum para cenários de `CASE` com literais textuais e numéricos mistos no mesmo campo (coerção implícita cross-dialect);
+  - consolidar assertions de mensagens de erro para `NotSupported` em uma camada única reutilizável.
 
 #### 6.3.3 Entrada única de execução (build/test)
 - Implementação estimada: **88%**.
@@ -672,10 +687,14 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - Vincular categorias/traits para habilitar execução seletiva por domínio de regressão.
 
 #### 6.3.4 Governança do backlog de documentação
-- Implementação estimada: **66%**.
+- Implementação estimada: **72%**.
 - Separar visão arquitetural estável e status operacional de sprint para reduzir conflito de merge em percentuais.
 - Padronizar update de progresso com checklist de evidência mínima (teste, provider afetado, limitação conhecida).
 - Alinhar PR template para exigir vínculo entre mudança de código, teste e atualização de backlog.
+- Convenção operacional adotada para os próximos ciclos:
+  - toda atualização de percentual deve registrar evidência objetiva (arquivo de teste, comando executado e resultado);
+  - itens com escopo multi-provider devem indicar explicitamente onde houve cobertura total e onde permanece gap;
+  - quando houver apenas atualização documental, incluir seção de risco de descompasso com o código e ação de mitigação planejada.
 
 ### 6.4 Política sugerida de versionamento
 

--- a/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AggregationTests.cs
+++ b/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AggregationTests.cs
@@ -50,16 +50,112 @@ public sealed class Db2AggregationTests : AggregationHavingOrdinalTestsBase<Db2D
                   ORDER BY userId
                   """;
 
-        var rows = Query(sql);
-        Assert.Equal(2, rows.Count);
+        AssertStringAggregationWithCustomSeparator(sql);
+    }
 
-        var first = Convert.ToString(rows[0].joined) ?? string.Empty;
-        var second = Convert.ToString(rows[1].joined) ?? string.Empty;
 
-        Assert.Contains("|", first);
-        Assert.Contains("10", first, StringComparison.Ordinal);
-        Assert.Contains("30", first, StringComparison.Ordinal);
-        Assert.Contains("5", second, StringComparison.Ordinal);
+    /// <summary>
+    /// EN: Ensures mixed projection with string aggregation and NULL literal works consistently.
+    /// PT: Garante que projeção mista com agregação textual e literal NULL funcione de forma consistente.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2Aggregation")]
+    public void StringAggregation_WithNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, LISTAGG(amount, '|') AS joined, NULL AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection returning NULL stays stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE retornando NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2Aggregation")]
+    public void StringAggregation_WithCaseNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, LISTAGG(amount, '|') AS joined,
+                         CASE WHEN userId > 0 THEN NULL ELSE 'unexpected' END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection with mixed text/NULL branches remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE com ramos mistos texto/NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2Aggregation")]
+    public void StringAggregation_WithCaseMixedProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, LISTAGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'ok' ELSE NULL END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMixedProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE de múltiplos ramos permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2Aggregation")]
+    public void StringAggregation_WithCaseMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, LISTAGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'primary'
+                              WHEN userId = 2 THEN 'secondary'
+                              ELSE NULL
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMultiBranchProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures numeric multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE numérica multibranch permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Db2Aggregation")]
+    public void StringAggregation_WithCaseNumericMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, LISTAGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 100
+                              WHEN userId = 2 THEN 200
+                              ELSE 0
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNumericMultiBranchProjection(sql);
     }
 
 
@@ -71,19 +167,7 @@ public sealed class Db2AggregationTests : AggregationHavingOrdinalTestsBase<Db2D
     [Trait("Category", "Db2Aggregation")]
     public void StringAggregation_Distinct_ShouldIgnoreNullValues()
     {
-        Connection.Execute("CREATE TABLE textagg_data (grp INT, val VARCHAR(20) NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'b')");
-
-        var rows = Query("SELECT LISTAGG(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
-        Assert.Single(rows);
-
-        var joined = Convert.ToString(rows[0].joined) ?? string.Empty;
-        Assert.Contains("a", joined, StringComparison.Ordinal);
-        Assert.Contains("b", joined, StringComparison.Ordinal);
-        Assert.Contains("|", joined, StringComparison.Ordinal);
+        AssertStringAggregationDistinctIgnoresNullValues("SELECT LISTAGG(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
     }
 
 
@@ -95,10 +179,7 @@ public sealed class Db2AggregationTests : AggregationHavingOrdinalTestsBase<Db2D
     [Trait("Category", "Aggregation")]
     public void StringAggregation_WithinGroup_ShouldThrowNotSupported()
     {
-        var ex = Assert.Throws<NotSupportedException>(() =>
-            Query("SELECT LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders"));
-
-        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+        AssertWithinGroupNotSupported("SELECT LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders");
     }
 
 

--- a/src/DbSqlLikeMem.MySql.Dapper.Test/MySqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.MySql.Dapper.Test/MySqlAggregationTests.cs
@@ -50,15 +50,112 @@ public sealed class MySqlAggregationTests : AggregationHavingOrdinalTestsBase<My
                   ORDER BY userId
                   """;
 
-        var rows = Query(sql);
-        Assert.Equal(2, rows.Count);
-        var first = Convert.ToString(rows[0].joined) ?? string.Empty;
-        var second = Convert.ToString(rows[1].joined) ?? string.Empty;
+        AssertStringAggregationWithCustomSeparator(sql);
+    }
 
-        Assert.Contains("|", first);
-        Assert.Contains("10", first, StringComparison.Ordinal);
-        Assert.Contains("30", first, StringComparison.Ordinal);
-        Assert.Contains("5", second, StringComparison.Ordinal);
+
+    /// <summary>
+    /// EN: Ensures mixed projection with string aggregation and NULL literal works consistently.
+    /// PT: Garante que projeção mista com agregação textual e literal NULL funcione de forma consistente.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void StringAggregation_WithNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, GROUP_CONCAT(amount, '|') AS joined, NULL AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection returning NULL stays stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE retornando NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void StringAggregation_WithCaseNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, GROUP_CONCAT(amount, '|') AS joined,
+                         CASE WHEN userId > 0 THEN NULL ELSE 'unexpected' END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection with mixed text/NULL branches remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE com ramos mistos texto/NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void StringAggregation_WithCaseMixedProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, GROUP_CONCAT(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'ok' ELSE NULL END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMixedProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE de múltiplos ramos permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void StringAggregation_WithCaseMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, GROUP_CONCAT(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'primary'
+                              WHEN userId = 2 THEN 'secondary'
+                              ELSE NULL
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMultiBranchProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures numeric multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE numérica multibranch permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void StringAggregation_WithCaseNumericMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, GROUP_CONCAT(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 100
+                              WHEN userId = 2 THEN 200
+                              ELSE 0
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNumericMultiBranchProjection(sql);
     }
 
     /// <summary>
@@ -69,19 +166,18 @@ public sealed class MySqlAggregationTests : AggregationHavingOrdinalTestsBase<My
     [Trait("Category", "MySqlAggregation")]
     public void StringAggregation_Distinct_ShouldIgnoreNullValues()
     {
-        Connection.Execute("CREATE TABLE textagg_data (grp INT, val VARCHAR(20) NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'b')");
+        AssertStringAggregationDistinctIgnoresNullValues("SELECT GROUP_CONCAT(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
+    }
 
-        var rows = Query("SELECT GROUP_CONCAT(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
-        Assert.Single(rows);
-
-        var joined = Convert.ToString(rows[0].joined) ?? string.Empty;
-        Assert.Contains("a", joined, StringComparison.Ordinal);
-        Assert.Contains("b", joined, StringComparison.Ordinal);
-        Assert.Contains("|", joined, StringComparison.Ordinal);
+    /// <summary>
+    /// EN: Ensures ordered-set syntax WITHIN GROUP produces actionable not-supported error.
+    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP gere erro claro de não suportado.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "MySqlAggregation")]
+    public void StringAggregation_WithinGroup_ShouldThrowNotSupported()
+    {
+        AssertWithinGroupNotSupported("SELECT GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders");
     }
 
 

--- a/src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlAggregationTests.cs
@@ -50,16 +50,112 @@ public sealed class PostgreSqlAggregationTests : AggregationHavingOrdinalTestsBa
                   ORDER BY userId
                   """;
 
-        var rows = Query(sql);
-        Assert.Equal(2, rows.Count);
+        AssertStringAggregationWithCustomSeparator(sql);
+    }
 
-        var first = Convert.ToString(rows[0].joined) ?? string.Empty;
-        var second = Convert.ToString(rows[1].joined) ?? string.Empty;
 
-        Assert.Contains("|", first);
-        Assert.Contains("10", first, StringComparison.Ordinal);
-        Assert.Contains("30", first, StringComparison.Ordinal);
-        Assert.Contains("5", second, StringComparison.Ordinal);
+    /// <summary>
+    /// EN: Ensures mixed projection with string aggregation and NULL literal works consistently.
+    /// PT: Garante que projeção mista com agregação textual e literal NULL funcione de forma consistente.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void StringAggregation_WithNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, STRING_AGG(amount, '|') AS joined, NULL AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection returning NULL stays stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE retornando NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void StringAggregation_WithCaseNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, STRING_AGG(amount, '|') AS joined,
+                         CASE WHEN userId > 0 THEN NULL ELSE 'unexpected' END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection with mixed text/NULL branches remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE com ramos mistos texto/NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void StringAggregation_WithCaseMixedProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, STRING_AGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'ok' ELSE NULL END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMixedProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE de múltiplos ramos permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void StringAggregation_WithCaseMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, STRING_AGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'primary'
+                              WHEN userId = 2 THEN 'secondary'
+                              ELSE NULL
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMultiBranchProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures numeric multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE numérica multibranch permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "PostgreSqlAggregation")]
+    public void StringAggregation_WithCaseNumericMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, STRING_AGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 100
+                              WHEN userId = 2 THEN 200
+                              ELSE 0
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNumericMultiBranchProjection(sql);
     }
 
 
@@ -71,19 +167,7 @@ public sealed class PostgreSqlAggregationTests : AggregationHavingOrdinalTestsBa
     [Trait("Category", "PostgreSqlAggregation")]
     public void StringAggregation_Distinct_ShouldIgnoreNullValues()
     {
-        Connection.Execute("CREATE TABLE textagg_data (grp INT, val VARCHAR(20) NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'b')");
-
-        var rows = Query("SELECT STRING_AGG(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
-        Assert.Single(rows);
-
-        var joined = Convert.ToString(rows[0].joined) ?? string.Empty;
-        Assert.Contains("a", joined, StringComparison.Ordinal);
-        Assert.Contains("b", joined, StringComparison.Ordinal);
-        Assert.Contains("|", joined, StringComparison.Ordinal);
+        AssertStringAggregationDistinctIgnoresNullValues("SELECT STRING_AGG(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
     }
 
 
@@ -95,10 +179,7 @@ public sealed class PostgreSqlAggregationTests : AggregationHavingOrdinalTestsBa
     [Trait("Category", "Aggregation")]
     public void StringAggregation_WithinGroup_ShouldThrowNotSupported()
     {
-        var ex = Assert.Throws<NotSupportedException>(() =>
-            Query("SELECT STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders"));
-
-        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+        AssertWithinGroupNotSupported("SELECT STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders");
     }
 
 

--- a/src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAggregationTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAggregationTests.cs
@@ -50,15 +50,112 @@ public sealed class OracleAggregationTests : AggregationHavingOrdinalTestsBase<O
                   ORDER BY userId
                   """;
 
-        var rows = Query(sql);
-        Assert.Equal(2, rows.Count);
-        var first = Convert.ToString(rows[0].joined) ?? string.Empty;
-        var second = Convert.ToString(rows[1].joined) ?? string.Empty;
+        AssertStringAggregationWithCustomSeparator(sql);
+    }
 
-        Assert.Contains("|", first);
-        Assert.Contains("10", first, StringComparison.Ordinal);
-        Assert.Contains("30", first, StringComparison.Ordinal);
-        Assert.Contains("5", second, StringComparison.Ordinal);
+
+    /// <summary>
+    /// EN: Ensures mixed projection with string aggregation and NULL literal works consistently.
+    /// PT: Garante que projeção mista com agregação textual e literal NULL funcione de forma consistente.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAggregation")]
+    public void StringAggregation_WithNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, LISTAGG(amount, '|') AS joined, NULL AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection returning NULL stays stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE retornando NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAggregation")]
+    public void StringAggregation_WithCaseNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, LISTAGG(amount, '|') AS joined,
+                         CASE WHEN userId > 0 THEN NULL ELSE 'unexpected' END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection with mixed text/NULL branches remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE com ramos mistos texto/NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAggregation")]
+    public void StringAggregation_WithCaseMixedProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, LISTAGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'ok' ELSE NULL END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMixedProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE de múltiplos ramos permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAggregation")]
+    public void StringAggregation_WithCaseMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, LISTAGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'primary'
+                              WHEN userId = 2 THEN 'secondary'
+                              ELSE NULL
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMultiBranchProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures numeric multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE numérica multibranch permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "OracleAggregation")]
+    public void StringAggregation_WithCaseNumericMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, LISTAGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 100
+                              WHEN userId = 2 THEN 200
+                              ELSE 0
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNumericMultiBranchProjection(sql);
     }
 
 
@@ -93,19 +190,7 @@ public sealed class OracleAggregationTests : AggregationHavingOrdinalTestsBase<O
     [Trait("Category", "OracleAggregation")]
     public void StringAggregation_Distinct_ShouldIgnoreNullValues()
     {
-        Connection.Execute("CREATE TABLE textagg_data (grp INT, val VARCHAR(20) NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'b')");
-
-        var rows = Query("SELECT LISTAGG(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
-        Assert.Single(rows);
-
-        var joined = Convert.ToString(rows[0].joined) ?? string.Empty;
-        Assert.Contains("a", joined, StringComparison.Ordinal);
-        Assert.Contains("b", joined, StringComparison.Ordinal);
-        Assert.Contains("|", joined, StringComparison.Ordinal);
+        AssertStringAggregationDistinctIgnoresNullValues("SELECT LISTAGG(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
     }
 
 
@@ -117,10 +202,7 @@ public sealed class OracleAggregationTests : AggregationHavingOrdinalTestsBase<O
     [Trait("Category", "Aggregation")]
     public void StringAggregation_WithinGroup_ShouldThrowNotSupported()
     {
-        var ex = Assert.Throws<NotSupportedException>(() =>
-            Query("SELECT LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders"));
-
-        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+        AssertWithinGroupNotSupported("SELECT LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders");
     }
 
 

--- a/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAggregationTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAggregationTests.cs
@@ -50,15 +50,112 @@ public sealed class SqlServerAggregationTests : AggregationHavingOrdinalTestsBas
                   ORDER BY userId
                   """;
 
-        var rows = Query(sql);
-        Assert.Equal(2, rows.Count);
-        var first = Convert.ToString(rows[0].joined) ?? string.Empty;
-        var second = Convert.ToString(rows[1].joined) ?? string.Empty;
+        AssertStringAggregationWithCustomSeparator(sql);
+    }
 
-        Assert.Contains("|", first);
-        Assert.Contains("10", first, StringComparison.Ordinal);
-        Assert.Contains("30", first, StringComparison.Ordinal);
-        Assert.Contains("5", second, StringComparison.Ordinal);
+
+    /// <summary>
+    /// EN: Ensures mixed projection with string aggregation and NULL literal works consistently.
+    /// PT: Garante que projeção mista com agregação textual e literal NULL funcione de forma consistente.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void StringAggregation_WithNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, STRING_AGG(amount, '|') AS joined, NULL AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection returning NULL stays stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE retornando NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void StringAggregation_WithCaseNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, STRING_AGG(amount, '|') AS joined,
+                         CASE WHEN userId > 0 THEN NULL ELSE 'unexpected' END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection with mixed text/NULL branches remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE com ramos mistos texto/NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void StringAggregation_WithCaseMixedProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, STRING_AGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'ok' ELSE NULL END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMixedProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE de múltiplos ramos permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void StringAggregation_WithCaseMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, STRING_AGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'primary'
+                              WHEN userId = 2 THEN 'secondary'
+                              ELSE NULL
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMultiBranchProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures numeric multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE numérica multibranch permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqlServerAggregation")]
+    public void StringAggregation_WithCaseNumericMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, STRING_AGG(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 100
+                              WHEN userId = 2 THEN 200
+                              ELSE 0
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNumericMultiBranchProjection(sql);
     }
 
     /// <summary>
@@ -69,19 +166,7 @@ public sealed class SqlServerAggregationTests : AggregationHavingOrdinalTestsBas
     [Trait("Category", "SqlServerAggregation")]
     public void StringAggregation_Distinct_ShouldIgnoreNullValues()
     {
-        Connection.Execute("CREATE TABLE textagg_data (grp INT, val VARCHAR(20) NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'b')");
-
-        var rows = Query("SELECT STRING_AGG(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
-        Assert.Single(rows);
-
-        var joined = Convert.ToString(rows[0].joined) ?? string.Empty;
-        Assert.Contains("a", joined, StringComparison.Ordinal);
-        Assert.Contains("b", joined, StringComparison.Ordinal);
-        Assert.Contains("|", joined, StringComparison.Ordinal);
+        AssertStringAggregationDistinctIgnoresNullValues("SELECT STRING_AGG(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
     }
 
 
@@ -93,10 +178,7 @@ public sealed class SqlServerAggregationTests : AggregationHavingOrdinalTestsBas
     [Trait("Category", "Aggregation")]
     public void StringAggregation_WithinGroup_ShouldThrowNotSupported()
     {
-        var ex = Assert.Throws<NotSupportedException>(() =>
-            Query("SELECT STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders"));
-
-        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+        AssertWithinGroupNotSupported("SELECT STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders");
     }
 
 

--- a/src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAggregationTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAggregationTests.cs
@@ -50,16 +50,112 @@ public sealed class SqliteAggregationTests : AggregationHavingOrdinalTestsBase<S
                   ORDER BY userId
                   """;
 
-        var rows = Query(sql);
-        Assert.Equal(2, rows.Count);
+        AssertStringAggregationWithCustomSeparator(sql);
+    }
 
-        var first = Convert.ToString(rows[0].joined) ?? string.Empty;
-        var second = Convert.ToString(rows[1].joined) ?? string.Empty;
 
-        Assert.Contains("|", first);
-        Assert.Contains("10", first, StringComparison.Ordinal);
-        Assert.Contains("30", first, StringComparison.Ordinal);
-        Assert.Contains("5", second, StringComparison.Ordinal);
+    /// <summary>
+    /// EN: Ensures mixed projection with string aggregation and NULL literal works consistently.
+    /// PT: Garante que projeção mista com agregação textual e literal NULL funcione de forma consistente.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void StringAggregation_WithNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, GROUP_CONCAT(amount, '|') AS joined, NULL AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection returning NULL stays stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE retornando NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void StringAggregation_WithCaseNullProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, GROUP_CONCAT(amount, '|') AS joined,
+                         CASE WHEN userId > 0 THEN NULL ELSE 'unexpected' END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNullProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures CASE projection with mixed text/NULL branches remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE com ramos mistos texto/NULL permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void StringAggregation_WithCaseMixedProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, GROUP_CONCAT(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'ok' ELSE NULL END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMixedProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE de múltiplos ramos permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void StringAggregation_WithCaseMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, GROUP_CONCAT(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 'primary'
+                              WHEN userId = 2 THEN 'secondary'
+                              ELSE NULL
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseMultiBranchProjection(sql);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures numeric multi-branch CASE projection remains stable with grouped string aggregation.
+    /// PT: Garante que projeção CASE numérica multibranch permaneça estável com agregação textual agrupada.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void StringAggregation_WithCaseNumericMultiBranchProjection_ShouldWork()
+    {
+        const string sql = """
+                  SELECT userId, GROUP_CONCAT(amount, '|') AS joined,
+                         CASE WHEN userId = 1 THEN 100
+                              WHEN userId = 2 THEN 200
+                              ELSE 0
+                         END AS note
+                  FROM orders
+                  GROUP BY userId
+                  ORDER BY userId
+                  """;
+
+        AssertStringAggregationWithCaseNumericMultiBranchProjection(sql);
     }
 
 
@@ -71,19 +167,18 @@ public sealed class SqliteAggregationTests : AggregationHavingOrdinalTestsBase<S
     [Trait("Category", "SqliteAggregation")]
     public void StringAggregation_Distinct_ShouldIgnoreNullValues()
     {
-        Connection.Execute("CREATE TABLE textagg_data (grp INT, val VARCHAR(20) NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, NULL)");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
-        Connection.Execute("INSERT INTO textagg_data (grp, val) VALUES (1, 'b')");
+        AssertStringAggregationDistinctIgnoresNullValues("SELECT GROUP_CONCAT(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
+    }
 
-        var rows = Query("SELECT GROUP_CONCAT(DISTINCT val, '|') AS joined FROM textagg_data WHERE grp = 1");
-        Assert.Single(rows);
-
-        var joined = Convert.ToString(rows[0].joined) ?? string.Empty;
-        Assert.Contains("a", joined, StringComparison.Ordinal);
-        Assert.Contains("b", joined, StringComparison.Ordinal);
-        Assert.Contains("|", joined, StringComparison.Ordinal);
+    /// <summary>
+    /// EN: Ensures ordered-set syntax WITHIN GROUP produces actionable not-supported error.
+    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP gere erro claro de não suportado.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "SqliteAggregation")]
+    public void StringAggregation_WithinGroup_ShouldThrowNotSupported()
+    {
+        AssertWithinGroupNotSupported("SELECT GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders");
     }
 
 

--- a/src/DbSqlLikeMem.Test/AggregationHavingOrdinalTestsBase.cs
+++ b/src/DbSqlLikeMem.Test/AggregationHavingOrdinalTestsBase.cs
@@ -84,6 +84,219 @@ public abstract class AggregationHavingOrdinalTestsBase<TDbMock, TConnection> : 
         Assert.Equal(2, (int)rows[0].userId);
     }
 
+
+    /// <summary>
+    /// EN: Validates grouped string aggregation with custom separator and stable ordering by user id.
+    /// PT: Valida agregação textual agrupada com separador customizado e ordenação estável por user id.
+    /// </summary>
+    /// <param name="sql">EN: Provider-specific SQL using string aggregation. PT: SQL específico do provedor usando agregação textual.</param>
+    protected void AssertStringAggregationWithCustomSeparator(string sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new ArgumentException("SQL cannot be null, empty, or whitespace.", nameof(sql));
+        }
+
+        var rows = Query(sql);
+        Assert.Equal(2, rows.Count);
+
+        var first = Convert.ToString(rows[0].joined) ?? string.Empty;
+        var second = Convert.ToString(rows[1].joined) ?? string.Empty;
+
+        Assert.Contains("|", first, StringComparison.Ordinal);
+        Assert.Contains("10", first, StringComparison.Ordinal);
+        Assert.Contains("30", first, StringComparison.Ordinal);
+        Assert.Contains("5", second, StringComparison.Ordinal);
+    }
+
+
+
+
+
+    /// <summary>
+    /// EN: Validates mixed projection with string aggregation and explicit NULL literal remains stable.
+    /// PT: Valida que projeção mista com agregação textual e literal NULL explícito permaneça estável.
+    /// </summary>
+    /// <param name="sql">EN: Provider-specific SQL that projects aggregation + NULL literal. PT: SQL específico do provedor que projeta agregação + literal NULL.</param>
+    protected void AssertStringAggregationWithNullProjection(string sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new ArgumentException("SQL cannot be null, empty, or whitespace.", nameof(sql));
+        }
+
+        var rows = Query(sql);
+        Assert.Equal(2, rows.Count);
+
+        Assert.Null(rows[0].note);
+        Assert.Null(rows[1].note);
+
+        var firstJoined = Convert.ToString(rows[0].joined) ?? string.Empty;
+        var secondJoined = Convert.ToString(rows[1].joined) ?? string.Empty;
+
+        Assert.NotEmpty(firstJoined);
+        Assert.NotEmpty(secondJoined);
+    }
+
+
+
+    /// <summary>
+    /// EN: Validates CASE expression that returns NULL in grouped projection remains consistent with string aggregation.
+    /// PT: Valida que expressão CASE retornando NULL em projeção agrupada permaneça consistente com agregação textual.
+    /// </summary>
+    /// <param name="sql">EN: Provider-specific SQL that projects aggregation + CASE NULL expression. PT: SQL específico do provedor que projeta agregação + expressão CASE NULL.</param>
+    protected void AssertStringAggregationWithCaseNullProjection(string sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new ArgumentException("SQL cannot be null, empty, or whitespace.", nameof(sql));
+        }
+
+        var rows = Query(sql);
+        Assert.Equal(2, rows.Count);
+
+        Assert.Null(rows[0].note);
+        Assert.Null(rows[1].note);
+
+        var firstJoined = Convert.ToString(rows[0].joined) ?? string.Empty;
+        var secondJoined = Convert.ToString(rows[1].joined) ?? string.Empty;
+
+        Assert.NotEmpty(firstJoined);
+        Assert.NotEmpty(secondJoined);
+    }
+
+
+
+    /// <summary>
+    /// EN: Validates CASE expression with mixed text/NULL branches in grouped projection stays deterministic.
+    /// PT: Valida que expressão CASE com ramos mistos texto/NULL em projeção agrupada permaneça determinística.
+    /// </summary>
+    /// <param name="sql">EN: Provider-specific SQL that projects aggregation + CASE mixed branches. PT: SQL específico do provedor com agregação + CASE de ramos mistos.</param>
+    protected void AssertStringAggregationWithCaseMixedProjection(string sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new ArgumentException("SQL cannot be null, empty, or whitespace.", nameof(sql));
+        }
+
+        var rows = Query(sql);
+        Assert.Equal(2, rows.Count);
+
+        Assert.Equal("ok", Convert.ToString(rows[0].note));
+        Assert.Null(rows[1].note);
+
+        var firstJoined = Convert.ToString(rows[0].joined) ?? string.Empty;
+        var secondJoined = Convert.ToString(rows[1].joined) ?? string.Empty;
+
+        Assert.NotEmpty(firstJoined);
+        Assert.NotEmpty(secondJoined);
+    }
+
+
+
+    /// <summary>
+    /// EN: Validates multi-branch CASE projection (text/text) remains stable with grouped string aggregation.
+    /// PT: Valida que projeção CASE de múltiplos ramos (texto/texto) permaneça estável com agregação textual agrupada.
+    /// </summary>
+    /// <param name="sql">EN: Provider-specific SQL with aggregation + multi-branch CASE projection. PT: SQL específico do provedor com agregação + projeção CASE de múltiplos ramos.</param>
+    protected void AssertStringAggregationWithCaseMultiBranchProjection(string sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new ArgumentException("SQL cannot be null, empty, or whitespace.", nameof(sql));
+        }
+
+        var rows = Query(sql);
+        Assert.Equal(2, rows.Count);
+
+        Assert.Equal("primary", Convert.ToString(rows[0].note));
+        Assert.Equal("secondary", Convert.ToString(rows[1].note));
+
+        var firstJoined = Convert.ToString(rows[0].joined) ?? string.Empty;
+        var secondJoined = Convert.ToString(rows[1].joined) ?? string.Empty;
+
+        Assert.NotEmpty(firstJoined);
+        Assert.NotEmpty(secondJoined);
+    }
+
+
+
+    /// <summary>
+    /// EN: Validates numeric CASE multi-branch projection remains stable with grouped string aggregation.
+    /// PT: Valida que projeção CASE numérica de múltiplos ramos permaneça estável com agregação textual agrupada.
+    /// </summary>
+    /// <param name="sql">EN: Provider-specific SQL with aggregation + numeric CASE multi-branch projection. PT: SQL específico do provedor com agregação + projeção CASE numérica multibranch.</param>
+    protected void AssertStringAggregationWithCaseNumericMultiBranchProjection(string sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new ArgumentException("SQL cannot be null, empty, or whitespace.", nameof(sql));
+        }
+
+        var rows = Query(sql);
+        Assert.Equal(2, rows.Count);
+
+        Assert.Equal(100, Convert.ToInt32(rows[0].note));
+        Assert.Equal(200, Convert.ToInt32(rows[1].note));
+
+        var firstJoined = Convert.ToString(rows[0].joined) ?? string.Empty;
+        var secondJoined = Convert.ToString(rows[1].joined) ?? string.Empty;
+
+        Assert.NotEmpty(firstJoined);
+        Assert.NotEmpty(secondJoined);
+    }
+
+    /// <summary>
+    /// EN: Validates ordered-set aggregate syntax WITHIN GROUP is rejected with an actionable message.
+    /// PT: Valida que a sintaxe de agregação ordered-set WITHIN GROUP seja rejeitada com mensagem acionável.
+    /// </summary>
+    /// <param name="sql">EN: Provider-specific SQL using WITHIN GROUP. PT: SQL específico do provedor usando WITHIN GROUP.</param>
+    protected void AssertWithinGroupNotSupported(string sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new ArgumentException("SQL cannot be null, empty, or whitespace.", nameof(sql));
+        }
+
+        SqlNotSupportedAssert.ThrowsWithFeature(() => Query(sql), "WITHIN GROUP");
+    }
+
+    /// <summary>
+    /// EN: Validates DISTINCT string aggregation ignores NULL values and preserves expected tokens.
+    /// PT: Valida que agregação textual com DISTINCT ignore valores NULL e preserve os tokens esperados.
+    /// </summary>
+    /// <param name="querySql">EN: Provider-specific aggregate query over textagg_data. PT: Query agregada específica do provedor sobre textagg_data.</param>
+    protected void AssertStringAggregationDistinctIgnoresNullValues(string querySql)
+    {
+        if (string.IsNullOrWhiteSpace(querySql))
+        {
+            throw new ArgumentException("Query SQL cannot be null, empty, or whitespace.", nameof(querySql));
+        }
+
+        ExecuteNonQuery("CREATE TABLE textagg_data (grp INT, val VARCHAR(20) NULL)");
+        ExecuteNonQuery("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
+        ExecuteNonQuery("INSERT INTO textagg_data (grp, val) VALUES (1, NULL)");
+        ExecuteNonQuery("INSERT INTO textagg_data (grp, val) VALUES (1, 'a')");
+        ExecuteNonQuery("INSERT INTO textagg_data (grp, val) VALUES (1, 'b')");
+
+        var rows = Query(querySql);
+        Assert.Single(rows);
+
+        var joined = Convert.ToString(rows[0].joined) ?? string.Empty;
+        Assert.Contains("a", joined, StringComparison.Ordinal);
+        Assert.Contains("b", joined, StringComparison.Ordinal);
+        Assert.Contains("|", joined, StringComparison.Ordinal);
+    }
+
+
+
+    private void ExecuteNonQuery(string sql)
+    {
+        using var command = Connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
     private static void SeedOrders(TDbMock db)
     {
         var orders = db.AddTable("orders");

--- a/src/DbSqlLikeMem.Test/SqlNotSupportedAssert.cs
+++ b/src/DbSqlLikeMem.Test/SqlNotSupportedAssert.cs
@@ -1,0 +1,22 @@
+namespace DbSqlLikeMem.Test;
+
+/// <summary>
+/// EN: Provides shared assertions for dialect not-supported errors.
+/// PT: Fornece asserções compartilhadas para erros de funcionalidade não suportada por dialeto.
+/// </summary>
+public static class SqlNotSupportedAssert
+{
+    /// <summary>
+    /// EN: Asserts the action throws <see cref="NotSupportedException"/> containing the expected feature token.
+    /// PT: Garante que a ação lance <see cref="NotSupportedException"/> contendo o token de funcionalidade esperado.
+    /// </summary>
+    /// <param name="action">EN: Action expected to throw. PT: Ação esperada para lançar exceção.</param>
+    /// <param name="expectedFeatureToken">EN: Feature token expected in the message. PT: Token da funcionalidade esperado na mensagem.</param>
+    /// <returns>EN: Captured exception instance. PT: Instância da exceção capturada.</returns>
+    public static NotSupportedException ThrowsWithFeature(Action action, string expectedFeatureToken)
+    {
+        var ex = Assert.Throws<NotSupportedException>(action);
+        Assert.Contains(expectedFeatureToken, ex.Message, StringComparison.OrdinalIgnoreCase);
+        return ex;
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce duplication across provider-specific aggregation tests by centralizing common assertions and fixtures. 
- Standardize the handling and validation of unsupported SQL features (ordered-set `WITHIN GROUP`) across dialects. 
- Improve traceability of cross-provider coverage in the documentation backlog.

### Description
- Added `SqlNotSupportedAssert` helper to `src/DbSqlLikeMem.Test` to assert `NotSupportedException` messages contain expected feature tokens via `ThrowsWithFeature(...)`.
- Extended `AggregationHavingOrdinalTestsBase` with multiple shared assertion methods: `AssertStringAggregationWithCustomSeparator`, `AssertStringAggregationWithNullProjection`, `AssertStringAggregationWithCaseNullProjection`, `AssertStringAggregationWithCaseMixedProjection`, `AssertStringAggregationWithCaseMultiBranchProjection`, `AssertStringAggregationWithCaseNumericMultiBranchProjection`, `AssertWithinGroupNotSupported`, and `AssertStringAggregationDistinctIgnoresNullValues`, plus an `ExecuteNonQuery` helper for setup.
- Refactored provider-specific aggregation test classes (`Db2`, `MySql`, `Npgsql`, `Oracle`, `SqlServer`, `Sqlite`) to call the new shared assertion methods instead of duplicating query, setup and assertion logic.
- Updated `docs/features-backlog/index.md` with revised implementation percentages and expanded delivery/next-step notes in the capability matrix and governance sections.

### Testing
- Ran the unit test suite for modified test projects with `dotnet test` targeting the test projects under `src/*/*.Test`, including `DbSqlLikeMem.Test`, `Db2.*.Test`, `MySql.*.Test`, `Npgsql.*.Test`, `Oracle.*.Test`, `SqlServer.*.Test`, and `Sqlite.*.Test`.
- All affected automated tests executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a77ad3db78832ca4746f7817e1c0e9)