### PR TITLE
Add WITHIN GROUP ordered-set support for string aggregates with dialect gating and tests

### DIFF
--- a/docs/features-backlog/index.md
+++ b/docs/features-backlog/index.md
@@ -48,7 +48,7 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - Preservação da experiência de uso próxima ao fluxo SQL tradicional.
 
 #### 1.2.3 Regras por dialeto e versão
-- Implementação estimada: **70%**.
+- Implementação estimada: **76%**.
 - Ativa/desativa construções sintáticas por provedor e versão.
 - Trata incompatibilidades históricas entre bancos diferentes.
 - Direciona comportamento esperado em testes de compatibilidade.
@@ -63,8 +63,10 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - Backlog operacional segue cadência priorizada P0→P14 para reduzir dispersão de implementação entre parser/executor/docs.
 
 #### 1.2.5 Funções SQL agregadoras e de composição de texto
-- Implementação estimada: **82%**.
-- Parser agora sinaliza explicitamente `WITHIN GROUP` (ordered-set aggregates) como não suportado com mensagem acionável por dialeto.
+- Implementação estimada: **91%**.
+- Parser e AST agora suportam `WITHIN GROUP (ORDER BY ...)` para agregações textuais com gate explícito por dialeto/função.
+- Cobertura atual inclui parsing de ordenação simples e composta, validação de cláusula malformada (`WITHIN GROUP requires ORDER BY`) e cenários negativos por função não nativa no dialeto.
+- Runtime aplica a ordenação de `WITHIN GROUP` antes da agregação, incluindo combinações com `DISTINCT` e separador customizado.
 
 #### 1.2.6 Funções de data/hora cross-dialect
 - Implementação estimada: **93%**.
@@ -115,7 +117,7 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 ### 1.3 Executor SQL
 
 #### 1.3.1 Pipeline de execução
-- Implementação estimada: **62%**.
+- Implementação estimada: **69%**.
 - Fluxo macro: parse → validação → execução no estado em memória → materialização de resultado.
 - Track global de alinhamento de runtime estimado em ~55%, com evolução incremental por contracts de dialeto.
 - Recalibrado por evidências de código: executor AST, estratégias de mutação por dialeto e ampla suíte `*StrategyTests`/`*GapTests` por provider.
@@ -123,7 +125,7 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - Retorno previsível para facilitar asserts em testes.
 
 #### 1.3.2 Operações comuns suportadas
-- Implementação estimada: **82%**.
+- Implementação estimada: **86%**.
 - Fluxos DDL/DML de uso frequente em aplicações corporativas .NET.
 - Cenários com múltiplos comandos por contexto de teste.
 - Execução orientada a simulação funcional (não benchmark de banco real).
@@ -148,12 +150,13 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
     - manter suíte de rowcount por dialeto atualizada conforme expansão de parser/executor.
 
 #### 1.3.3 Resultados e consistência
-- Implementação estimada: **84%**.
+- Implementação estimada: **88%**.
 - Entrega de resultados em formatos esperados por consumidores ADO.NET.
 - Coerência entre operação executada e estado final da base simulada.
 - Comportamento determinístico para repetição do mesmo script.
 - Hardening recente reforçou previsibilidade de regressão com foco em mensagens de erro não suportado e consistência de diagnóstico.
 - Checklist operacional confirma padronização de `SqlUnsupported.ForDialect(...)` no runtime para fluxos não suportados.
+- Hardening recente também consolidou semântica ordered-set para agregações textuais com cobertura de ordenação `ASC/DESC`, ordenação composta e `DISTINCT + WITHIN GROUP` nos dialetos suportados.
 
 #### 1.3.4 Particionamento de tabelas (avaliação)
 - Implementação estimada: **8%**.

--- a/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AggregationTests.cs
+++ b/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AggregationTests.cs
@@ -172,14 +172,47 @@ public sealed class Db2AggregationTests : AggregationHavingOrdinalTestsBase<Db2D
 
 
     /// <summary>
-    /// EN: Ensures ordered-set syntax WITHIN GROUP produces actionable not-supported error.
-    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP gere erro claro de não suportado.
+    /// EN: Ensures ordered-set syntax WITHIN GROUP applies ORDER BY to string aggregation output.
+    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP aplique ORDER BY na saída da agregação textual.
     /// </summary>
     [Fact]
     [Trait("Category", "Aggregation")]
-    public void StringAggregation_WithinGroup_ShouldThrowNotSupported()
+    public void StringAggregation_WithinGroup_ShouldApplyOrderBy()
     {
-        AssertWithinGroupNotSupported("SELECT LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders");
+        AssertWithinGroupOrdersAggregation("SELECT LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders", "30|10|5");
+    }
+
+    /// <summary>
+    /// EN: Ensures WITHIN GROUP ascending order is applied by string aggregation.
+    /// PT: Garante que a ordenação ascendente do WITHIN GROUP seja aplicada na agregação textual.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_WithinGroupAscending_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupOrdersAggregation("SELECT LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount ASC) AS joined FROM orders", "5|10|30");
+    }
+
+    /// <summary>
+    /// EN: Ensures WITHIN GROUP supports composite ORDER BY expressions.
+    /// PT: Garante que WITHIN GROUP suporte expressões compostas no ORDER BY.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_WithinGroupCompositeOrder_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupCompositeOrdering("SELECT LISTAGG(val, '|') WITHIN GROUP (ORDER BY ord1 ASC, ord2 ASC) AS joined FROM textagg_order WHERE grp = 1", "b|a|c");
+    }
+
+    /// <summary>
+    /// EN: Ensures DISTINCT respects WITHIN GROUP ordering semantics.
+    /// PT: Garante que DISTINCT respeite a semântica de ordenação do WITHIN GROUP.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_DistinctWithinGroupCompositeOrder_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupDistinctOrdering("SELECT LISTAGG(DISTINCT val, '|') WITHIN GROUP (ORDER BY ord1 ASC, ord2 ASC) AS joined FROM textagg_distinct_order WHERE grp = 1", "b|a");
     }
 
 

--- a/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
@@ -659,4 +659,58 @@ public sealed class Db2DialectFeatureParserTests
         Assert.IsType<WindowFunctionExpr>(groupsExpr);
     }
 
+    /// <summary>
+    /// EN: Ensures Db2 parser accepts ordered-set WITHIN GROUP for LISTAGG.
+    /// PT: Garante que o parser Db2 aceite ordered-set WITHIN GROUP para LISTAGG.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_ListAggWithinGroup_ShouldParse(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var expr = SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC)", dialect);
+        var call = Assert.IsType<CallExpr>(expr);
+
+        Assert.Equal("LISTAGG", call.Name, StringComparer.OrdinalIgnoreCase);
+        Assert.NotNull(call.WithinGroupOrderBy);
+        Assert.Single(call.WithinGroupOrderBy!);
+        Assert.True(call.WithinGroupOrderBy![0].Desc);
+    }
+
+    /// <summary>
+    /// EN: Ensures Db2 parser blocks non-native ordered-set aggregate names with WITHIN GROUP.
+    /// PT: Garante que o parser Db2 bloqueie nomes não nativos de agregação ordered-set com WITHIN GROUP.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_StringAggWithinGroup_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures malformed WITHIN GROUP clause fails with actionable ORDER BY message.
+    /// PT: Garante que cláusula WITHIN GROUP malformada falhe com mensagem acionável de ORDER BY.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_ListAggWithinGroupWithoutOrderBy_ShouldThrowActionableError(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.Db2/Db2Dialect.cs
+++ b/src/DbSqlLikeMem.Db2/Db2Dialect.cs
@@ -83,6 +83,11 @@ internal sealed class Db2Dialect : SqlDialectBase
     /// </summary>
     public override bool SupportsWindowFrameClause => Version >= WindowFunctionsMinVersion;
 
+    public override bool SupportsWithinGroupForStringAggregates => true;
+
+    public override bool SupportsWithinGroupStringAggregateFunction(string functionName)
+        => functionName.Equals("LISTAGG", StringComparison.OrdinalIgnoreCase);
+
     /// <summary>
     /// EN: Gets whether delete target alias is supported.
     /// PT: Obtém se há suporte a delete target alias.

--- a/src/DbSqlLikeMem.MySql.Dapper.Test/MySqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.MySql.Dapper.Test/MySqlAggregationTests.cs
@@ -170,8 +170,8 @@ public sealed class MySqlAggregationTests : AggregationHavingOrdinalTestsBase<My
     }
 
     /// <summary>
-    /// EN: Ensures ordered-set syntax WITHIN GROUP produces actionable not-supported error.
-    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP gere erro claro de não suportado.
+    /// EN: Ensures ordered-set syntax WITHIN GROUP remains blocked for MySQL string aggregation.
+    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP continue bloqueada para agregação textual no MySQL.
     /// </summary>
     [Fact]
     [Trait("Category", "MySqlAggregation")]

--- a/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
@@ -659,4 +659,38 @@ public sealed class MySqlDialectFeatureParserTests
         Assert.Contains("start bound cannot be greater", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Ensures WITHIN GROUP ordered-set syntax remains unsupported for MySQL aggregates.
+    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP continue não suportada para agregações MySQL.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_StringAggregateWithinGroup_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures malformed WITHIN GROUP syntax in MySQL still fails as not-supported (dialect gate precedence).
+    /// PT: Garante que sintaxe malformada de WITHIN GROUP no MySQL continue falhando como não suportada (precedência do gate de dialeto).
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_StringAggregateWithinGroupMalformed_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlAggregationTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Dapper.Test/PostgreSqlAggregationTests.cs
@@ -172,14 +172,47 @@ public sealed class PostgreSqlAggregationTests : AggregationHavingOrdinalTestsBa
 
 
     /// <summary>
-    /// EN: Ensures ordered-set syntax WITHIN GROUP produces actionable not-supported error.
-    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP gere erro claro de não suportado.
+    /// EN: Ensures ordered-set syntax WITHIN GROUP applies ORDER BY to string aggregation output.
+    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP aplique ORDER BY na saída da agregação textual.
     /// </summary>
     [Fact]
     [Trait("Category", "Aggregation")]
-    public void StringAggregation_WithinGroup_ShouldThrowNotSupported()
+    public void StringAggregation_WithinGroup_ShouldApplyOrderBy()
     {
-        AssertWithinGroupNotSupported("SELECT STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders");
+        AssertWithinGroupOrdersAggregation("SELECT STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders", "30|10|5");
+    }
+
+    /// <summary>
+    /// EN: Ensures WITHIN GROUP ascending order is applied by string aggregation.
+    /// PT: Garante que a ordenação ascendente do WITHIN GROUP seja aplicada na agregação textual.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_WithinGroupAscending_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupOrdersAggregation("SELECT STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount ASC) AS joined FROM orders", "5|10|30");
+    }
+
+    /// <summary>
+    /// EN: Ensures WITHIN GROUP supports composite ORDER BY expressions.
+    /// PT: Garante que WITHIN GROUP suporte expressões compostas no ORDER BY.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_WithinGroupCompositeOrder_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupCompositeOrdering("SELECT STRING_AGG(val, '|') WITHIN GROUP (ORDER BY ord1 ASC, ord2 ASC) AS joined FROM textagg_order WHERE grp = 1", "b|a|c");
+    }
+
+    /// <summary>
+    /// EN: Ensures DISTINCT respects WITHIN GROUP ordering semantics.
+    /// PT: Garante que DISTINCT respeite a semântica de ordenação do WITHIN GROUP.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_DistinctWithinGroupCompositeOrder_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupDistinctOrdering("SELECT STRING_AGG(DISTINCT val, '|') WITHIN GROUP (ORDER BY ord1 ASC, ord2 ASC) AS joined FROM textagg_distinct_order WHERE grp = 1", "b|a");
     }
 
 

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
@@ -573,4 +573,58 @@ RETURNING id";
         Assert.Contains("start bound cannot be greater", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Ensures Npgsql parser accepts ordered-set WITHIN GROUP for STRING_AGG.
+    /// PT: Garante que o parser Npgsql aceite ordered-set WITHIN GROUP para STRING_AGG.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseScalar_StringAggWithinGroup_ShouldParse(int version)
+    {
+        var dialect = new NpgsqlDialect(version);
+
+        var expr = SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC)", dialect);
+        var call = Assert.IsType<CallExpr>(expr);
+
+        Assert.Equal("STRING_AGG", call.Name, StringComparer.OrdinalIgnoreCase);
+        Assert.NotNull(call.WithinGroupOrderBy);
+        Assert.Single(call.WithinGroupOrderBy!);
+        Assert.True(call.WithinGroupOrderBy![0].Desc);
+    }
+
+    /// <summary>
+    /// EN: Ensures Npgsql parser blocks non-native ordered-set aggregate names with WITHIN GROUP.
+    /// PT: Garante que o parser Npgsql bloqueie nomes não nativos de agregação ordered-set com WITHIN GROUP.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseScalar_ListAggWithinGroup_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new NpgsqlDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures malformed WITHIN GROUP clause fails with actionable ORDER BY message.
+    /// PT: Garante que cláusula WITHIN GROUP malformada falhe com mensagem acionável de ORDER BY.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseScalar_StringAggWithinGroupWithoutOrderBy_ShouldThrowActionableError(int version)
+    {
+        var dialect = new NpgsqlDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
+++ b/src/DbSqlLikeMem.Npgsql/NpgsqlDialect.cs
@@ -64,6 +64,11 @@ internal sealed class NpgsqlDialect : SqlDialectBase
     /// </summary>
     public override bool SupportsWindowFrameClause => Version >= WindowFunctionsMinVersion;
 
+    public override bool SupportsWithinGroupForStringAggregates => true;
+
+    public override bool SupportsWithinGroupStringAggregateFunction(string functionName)
+        => functionName.Equals("STRING_AGG", StringComparison.OrdinalIgnoreCase);
+
     /// <summary>
     /// EN: Gets whether fetch first is supported.
     /// PT: Obtém se há suporte a fetch first.

--- a/src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAggregationTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAggregationTests.cs
@@ -195,14 +195,47 @@ public sealed class OracleAggregationTests : AggregationHavingOrdinalTestsBase<O
 
 
     /// <summary>
-    /// EN: Ensures ordered-set syntax WITHIN GROUP produces actionable not-supported error.
-    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP gere erro claro de não suportado.
+    /// EN: Ensures ordered-set syntax WITHIN GROUP applies ORDER BY to string aggregation output.
+    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP aplique ORDER BY na saída da agregação textual.
     /// </summary>
     [Fact]
     [Trait("Category", "Aggregation")]
-    public void StringAggregation_WithinGroup_ShouldThrowNotSupported()
+    public void StringAggregation_WithinGroup_ShouldApplyOrderBy()
     {
-        AssertWithinGroupNotSupported("SELECT LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders");
+        AssertWithinGroupOrdersAggregation("SELECT LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders", "30|10|5");
+    }
+
+    /// <summary>
+    /// EN: Ensures WITHIN GROUP ascending order is applied by string aggregation.
+    /// PT: Garante que a ordenação ascendente do WITHIN GROUP seja aplicada na agregação textual.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_WithinGroupAscending_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupOrdersAggregation("SELECT LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount ASC) AS joined FROM orders", "5|10|30");
+    }
+
+    /// <summary>
+    /// EN: Ensures WITHIN GROUP supports composite ORDER BY expressions.
+    /// PT: Garante que WITHIN GROUP suporte expressões compostas no ORDER BY.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_WithinGroupCompositeOrder_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupCompositeOrdering("SELECT LISTAGG(val, '|') WITHIN GROUP (ORDER BY ord1 ASC, ord2 ASC) AS joined FROM textagg_order WHERE grp = 1", "b|a|c");
+    }
+
+    /// <summary>
+    /// EN: Ensures DISTINCT respects WITHIN GROUP ordering semantics.
+    /// PT: Garante que DISTINCT respeite a semântica de ordenação do WITHIN GROUP.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_DistinctWithinGroupCompositeOrder_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupDistinctOrdering("SELECT LISTAGG(DISTINCT val, '|') WITHIN GROUP (ORDER BY ord1 ASC, ord2 ASC) AS joined FROM textagg_distinct_order WHERE grp = 1", "b|a");
     }
 
 

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
@@ -697,4 +697,38 @@ public sealed class OracleDialectFeatureParserTests
         Assert.Contains("start bound cannot be greater", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Ensures Oracle parser blocks non-native ordered-set aggregate names with WITHIN GROUP.
+    /// PT: Garante que o parser Oracle bloqueie nomes não nativos de agregação ordered-set com WITHIN GROUP.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_StringAggWithinGroup_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures malformed WITHIN GROUP clause fails with actionable ORDER BY message.
+    /// PT: Garante que cláusula WITHIN GROUP malformada falhe com mensagem acionável de ORDER BY.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_ListAggWithinGroupWithoutOrderBy_ShouldThrowActionableError(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.Oracle/OracleDialect.cs
+++ b/src/DbSqlLikeMem.Oracle/OracleDialect.cs
@@ -79,6 +79,11 @@ internal sealed class OracleDialect : SqlDialectBase
     /// PT: Indica se cláusulas de frame de janela SQL são suportadas pela versão configurada.
     /// </summary>
     public override bool SupportsWindowFrameClause => Version >= WindowFunctionsMinVersion;
+
+    public override bool SupportsWithinGroupForStringAggregates => true;
+
+    public override bool SupportsWithinGroupStringAggregateFunction(string functionName)
+        => functionName.Equals("LISTAGG", StringComparison.OrdinalIgnoreCase);
     /// <summary>
     /// EN: Gets whether order by nulls modifier is supported.
     /// PT: Obtém se há suporte a order by nulls modifier.

--- a/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAggregationTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Dapper.Test/SqlServerAggregationTests.cs
@@ -171,14 +171,47 @@ public sealed class SqlServerAggregationTests : AggregationHavingOrdinalTestsBas
 
 
     /// <summary>
-    /// EN: Ensures ordered-set syntax WITHIN GROUP produces actionable not-supported error.
-    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP gere erro claro de não suportado.
+    /// EN: Ensures ordered-set syntax WITHIN GROUP applies ORDER BY to string aggregation output.
+    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP aplique ORDER BY na saída da agregação textual.
     /// </summary>
     [Fact]
     [Trait("Category", "Aggregation")]
-    public void StringAggregation_WithinGroup_ShouldThrowNotSupported()
+    public void StringAggregation_WithinGroup_ShouldApplyOrderBy()
     {
-        AssertWithinGroupNotSupported("SELECT STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders");
+        AssertWithinGroupOrdersAggregation("SELECT STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders", "30|10|5");
+    }
+
+    /// <summary>
+    /// EN: Ensures WITHIN GROUP ascending order is applied by string aggregation.
+    /// PT: Garante que a ordenação ascendente do WITHIN GROUP seja aplicada na agregação textual.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_WithinGroupAscending_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupOrdersAggregation("SELECT STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount ASC) AS joined FROM orders", "5|10|30");
+    }
+
+    /// <summary>
+    /// EN: Ensures WITHIN GROUP supports composite ORDER BY expressions.
+    /// PT: Garante que WITHIN GROUP suporte expressões compostas no ORDER BY.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_WithinGroupCompositeOrder_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupCompositeOrdering("SELECT STRING_AGG(val, '|') WITHIN GROUP (ORDER BY ord1 ASC, ord2 ASC) AS joined FROM textagg_order WHERE grp = 1", "b|a|c");
+    }
+
+    /// <summary>
+    /// EN: Ensures DISTINCT respects WITHIN GROUP ordering semantics.
+    /// PT: Garante que DISTINCT respeite a semântica de ordenação do WITHIN GROUP.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void StringAggregation_DistinctWithinGroupCompositeOrder_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupDistinctOrdering("SELECT STRING_AGG(DISTINCT val, '|') WITHIN GROUP (ORDER BY ord1 ASC, ord2 ASC) AS joined FROM textagg_distinct_order WHERE grp = 1", "b|a");
     }
 
 

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
@@ -732,6 +732,67 @@ public sealed class SqlServerDialectFeatureParserTests
         Assert.IsType<WindowFunctionExpr>(groupsExpr);
     }
 
+    /// <summary>
+    /// EN: Ensures SQL Server parser accepts ordered-set WITHIN GROUP for STRING_AGG.
+    /// PT: Garante que o parser SQL Server aceite ordered-set WITHIN GROUP para STRING_AGG.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_StringAggWithinGroup_ShouldParse(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        var expr = SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC)", dialect);
+        var call = Assert.IsType<CallExpr>(expr);
+
+        Assert.Equal("STRING_AGG", call.Name, StringComparer.OrdinalIgnoreCase);
+        Assert.NotNull(call.WithinGroupOrderBy);
+        Assert.Single(call.WithinGroupOrderBy!);
+        Assert.True(call.WithinGroupOrderBy![0].Desc);
+
+        var multiExpr = SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC, id ASC)", dialect);
+        var multiCall = Assert.IsType<CallExpr>(multiExpr);
+        Assert.NotNull(multiCall.WithinGroupOrderBy);
+        Assert.Equal(2, multiCall.WithinGroupOrderBy!.Count);
+        Assert.True(multiCall.WithinGroupOrderBy[0].Desc);
+        Assert.False(multiCall.WithinGroupOrderBy[1].Desc);
+    }
+
+    /// <summary>
+    /// EN: Ensures SQL Server parser blocks non-native ordered-set aggregate names with WITHIN GROUP.
+    /// PT: Garante que o parser SQL Server bloqueie nomes não nativos de agregação ordered-set com WITHIN GROUP.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_ListAggWithinGroup_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures malformed WITHIN GROUP clause fails with actionable ORDER BY message.
+    /// PT: Garante que cláusula WITHIN GROUP malformada falhe com mensagem acionável de ORDER BY.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_StringAggWithinGroupWithoutOrderBy_ShouldThrowActionableError(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 
 
     /// <summary>

--- a/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
+++ b/src/DbSqlLikeMem.SqlServer/SqlServerDialect.cs
@@ -80,6 +80,11 @@ internal sealed class SqlServerDialect : SqlDialectBase
     /// </summary>
     public override bool SupportsWindowFrameClause => Version >= WindowFunctionsMinVersion;
 
+    public override bool SupportsWithinGroupForStringAggregates => true;
+
+    public override bool SupportsWithinGroupStringAggregateFunction(string functionName)
+        => functionName.Equals("STRING_AGG", StringComparison.OrdinalIgnoreCase);
+
     // OFFSET ... FETCH entrou no SQL Server 2012.
     /// <summary>
     /// EN: Gets whether offset fetch is supported.

--- a/src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAggregationTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Dapper.Test/SqliteAggregationTests.cs
@@ -171,8 +171,8 @@ public sealed class SqliteAggregationTests : AggregationHavingOrdinalTestsBase<S
     }
 
     /// <summary>
-    /// EN: Ensures ordered-set syntax WITHIN GROUP produces actionable not-supported error.
-    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP gere erro claro de não suportado.
+    /// EN: Ensures ordered-set syntax WITHIN GROUP remains blocked for SQLite string aggregation.
+    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP continue bloqueada para agregação textual no SQLite.
     /// </summary>
     [Fact]
     [Trait("Category", "SqliteAggregation")]

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
@@ -477,4 +477,38 @@ public sealed class SqliteDialectFeatureParserTests
         Assert.Contains("window frame", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Ensures WITHIN GROUP ordered-set syntax remains unsupported for SQLite aggregates.
+    /// PT: Garante que a sintaxe ordered-set WITHIN GROUP continue não suportada para agregações SQLite.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_StringAggregateWithinGroup_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures malformed WITHIN GROUP syntax in SQLite still fails as not-supported (dialect gate precedence).
+    /// PT: Garante que sintaxe malformada de WITHIN GROUP no SQLite continue falhando como não suportada (precedência do gate de dialeto).
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_StringAggregateWithinGroupMalformed_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.Test/AggregationHavingOrdinalTestsBase.cs
+++ b/src/DbSqlLikeMem.Test/AggregationHavingOrdinalTestsBase.cs
@@ -247,6 +247,26 @@ public abstract class AggregationHavingOrdinalTestsBase<TDbMock, TConnection> : 
     }
 
     /// <summary>
+    /// EN: Validates ordered-set aggregate syntax WITHIN GROUP applies ORDER BY semantics to string aggregation.
+    /// PT: Valida que a sintaxe ordered-set WITHIN GROUP aplique semântica de ORDER BY na agregação textual.
+    /// </summary>
+    /// <param name="sql">EN: Provider-specific SQL using WITHIN GROUP. PT: SQL específico do provedor usando WITHIN GROUP.</param>
+    /// <param name="expected">EN: Expected aggregated text. PT: Texto agregado esperado.</param>
+    protected void AssertWithinGroupOrdersAggregation(string sql, string expected)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new ArgumentException("SQL cannot be null, empty, or whitespace.", nameof(sql));
+        }
+
+        var rows = Query(sql);
+        Assert.Single(rows);
+
+        var joined = Convert.ToString(rows[0].joined) ?? string.Empty;
+        Assert.Equal(expected, joined);
+    }
+
+    /// <summary>
     /// EN: Validates ordered-set aggregate syntax WITHIN GROUP is rejected with an actionable message.
     /// PT: Valida que a sintaxe de agregação ordered-set WITHIN GROUP seja rejeitada com mensagem acionável.
     /// </summary>
@@ -286,6 +306,53 @@ public abstract class AggregationHavingOrdinalTestsBase<TDbMock, TConnection> : 
         Assert.Contains("a", joined, StringComparison.Ordinal);
         Assert.Contains("b", joined, StringComparison.Ordinal);
         Assert.Contains("|", joined, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// EN: Validates WITHIN GROUP ordering with composite keys (multiple ORDER BY expressions).
+    /// PT: Valida ordenação WITHIN GROUP com chaves compostas (múltiplas expressões em ORDER BY).
+    /// </summary>
+    /// <param name="querySql">EN: Provider-specific aggregate query over textagg_order. PT: Query agregada específica do provedor sobre textagg_order.</param>
+    /// <param name="expected">EN: Expected aggregated text. PT: Texto agregado esperado.</param>
+    protected void AssertWithinGroupCompositeOrdering(string querySql, string expected)
+    {
+        if (string.IsNullOrWhiteSpace(querySql))
+            throw new ArgumentException("Query SQL cannot be null, empty, or whitespace.", nameof(querySql));
+
+        ExecuteNonQuery("CREATE TABLE textagg_order (grp INT, val VARCHAR(20) NULL, ord1 INT, ord2 INT)");
+        ExecuteNonQuery("INSERT INTO textagg_order (grp, val, ord1, ord2) VALUES (1, 'a', 1, 2)");
+        ExecuteNonQuery("INSERT INTO textagg_order (grp, val, ord1, ord2) VALUES (1, 'b', 1, 1)");
+        ExecuteNonQuery("INSERT INTO textagg_order (grp, val, ord1, ord2) VALUES (1, 'c', 2, 1)");
+
+        var rows = Query(querySql);
+        Assert.Single(rows);
+
+        var joined = Convert.ToString(rows[0].joined) ?? string.Empty;
+        Assert.Equal(expected, joined);
+    }
+
+    /// <summary>
+    /// EN: Validates DISTINCT + WITHIN GROUP ordering to ensure deduplication follows ORDER BY sequence.
+    /// PT: Valida DISTINCT + WITHIN GROUP para garantir que a deduplicação siga a sequência do ORDER BY.
+    /// </summary>
+    /// <param name="querySql">EN: Provider-specific aggregate query over textagg_distinct_order. PT: Query agregada específica do provedor sobre textagg_distinct_order.</param>
+    /// <param name="expected">EN: Expected aggregated text after ordering and distinct. PT: Texto agregado esperado após ordenação e distinct.</param>
+    protected void AssertWithinGroupDistinctOrdering(string querySql, string expected)
+    {
+        if (string.IsNullOrWhiteSpace(querySql))
+            throw new ArgumentException("Query SQL cannot be null, empty, or whitespace.", nameof(querySql));
+
+        ExecuteNonQuery("CREATE TABLE textagg_distinct_order (grp INT, val VARCHAR(20) NULL, ord1 INT, ord2 INT)");
+        ExecuteNonQuery("INSERT INTO textagg_distinct_order (grp, val, ord1, ord2) VALUES (1, 'b', 1, 1)");
+        ExecuteNonQuery("INSERT INTO textagg_distinct_order (grp, val, ord1, ord2) VALUES (1, 'a', 1, 2)");
+        ExecuteNonQuery("INSERT INTO textagg_distinct_order (grp, val, ord1, ord2) VALUES (1, 'a', 2, 1)");
+        ExecuteNonQuery("INSERT INTO textagg_distinct_order (grp, val, ord1, ord2) VALUES (1, NULL, 0, 0)");
+
+        var rows = Query(querySql);
+        Assert.Single(rows);
+
+        var joined = Convert.ToString(rows[0].joined) ?? string.Empty;
+        Assert.Equal(expected, joined);
     }
 
 

--- a/src/DbSqlLikeMem/Parser/Dialects.cs
+++ b/src/DbSqlLikeMem/Parser/Dialects.cs
@@ -136,6 +136,8 @@ internal interface ISqlDialect
     bool SupportsWindowFunction(string functionName);
     bool RequiresOrderByInWindowFunction(string functionName);
     bool TryGetWindowFunctionArgumentArity(string functionName, out int minArgs, out int maxArgs);
+    bool SupportsWithinGroupForStringAggregates { get; }
+    bool SupportsWithinGroupStringAggregateFunction(string functionName);
     bool SupportsPivotClause { get; }
     DbType InferWindowFunctionDbType(WindowFunctionExpr windowFunctionExpr, Func<SqlExpr, DbType> inferArgDbType);
 }
@@ -367,6 +369,18 @@ internal abstract class SqlDialectBase : ISqlDialect
     }
 
     public virtual bool SupportsLikeEscapeClause => true;
+
+    public virtual bool SupportsWithinGroupForStringAggregates => false;
+
+    public virtual bool SupportsWithinGroupStringAggregateFunction(string functionName)
+    {
+        if (!SupportsWithinGroupForStringAggregates || string.IsNullOrWhiteSpace(functionName))
+            return false;
+
+        return functionName.Equals("GROUP_CONCAT", StringComparison.OrdinalIgnoreCase)
+            || functionName.Equals("STRING_AGG", StringComparison.OrdinalIgnoreCase)
+            || functionName.Equals("LISTAGG", StringComparison.OrdinalIgnoreCase);
+    }
 
     public virtual bool IsRowNumberWindowFunction(string functionName)
         => functionName.Equals("ROW_NUMBER", StringComparison.OrdinalIgnoreCase);

--- a/src/DbSqlLikeMem/Parser/ExprAst.cs
+++ b/src/DbSqlLikeMem/Parser/ExprAst.cs
@@ -22,7 +22,11 @@ internal sealed record QuantifiedComparisonExpr(
     SubqueryExpr Subquery) : SqlExpr;
 internal sealed record FunctionCallExpr(string Name, IReadOnlyList<SqlExpr> Args) : SqlExpr;
 internal sealed record JsonAccessExpr(SqlExpr Target, SqlExpr Path, bool Unquote) : SqlExpr;
-internal sealed record CallExpr(string Name, IReadOnlyList<SqlExpr> Args, bool Distinct = false) : SqlExpr;
+internal sealed record CallExpr(
+    string Name,
+    IReadOnlyList<SqlExpr> Args,
+    bool Distinct = false,
+    IReadOnlyList<WindowOrderItem>? WithinGroupOrderBy = null) : SqlExpr;
 internal sealed record WindowFunctionExpr(string Name, IReadOnlyList<SqlExpr> Args, WindowSpec Spec, bool Distinct = false) : SqlExpr;
 internal sealed record WindowSpec(
     IReadOnlyList<SqlExpr> PartitionBy,

--- a/src/DbSqlLikeMem/Parser/SqlExpressionParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlExpressionParser.cs
@@ -913,13 +913,7 @@ internal sealed class SqlExpressionParser(
         if (IsSymbol(Peek(), "("))
         {
             var call = ParseCallAfterName(name);
-
-            if (IsKeywordOrIdentifierWord(Peek(), "WITHIN"))
-            {
-                throw SqlUnsupported.ForDialect(
-                    _dialect,
-                    $"ordered-set aggregate syntax WITHIN GROUP for function '{call.Name}'");
-            }
+            call = ParseWithinGroupOrderByIfPresent(call);
 
             // ✅ Window function: ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)
             if (IsKeywordOrIdentifierWord(Peek(), "OVER"))
@@ -1254,6 +1248,65 @@ internal sealed class SqlExpressionParser(
 
         ExpectSymbol(")");
         return new CallExpr(name, args, distinct);
+    }
+
+    private CallExpr ParseWithinGroupOrderByIfPresent(CallExpr call)
+    {
+        if (!IsKeywordOrIdentifierWord(Peek(), "WITHIN"))
+            return call;
+
+        var normalizedName = call.Name.ToUpperInvariant();
+        if (normalizedName is not "GROUP_CONCAT" and not "STRING_AGG" and not "LISTAGG")
+        {
+            throw SqlUnsupported.ForDialect(
+                _dialect,
+                $"ordered-set aggregate syntax WITHIN GROUP for function '{call.Name}'");
+        }
+
+        if (!_dialect.SupportsWithinGroupForStringAggregates)
+            throw SqlUnsupported.ForDialect(_dialect, "ordered-set aggregate syntax WITHIN GROUP");
+
+        if (!_dialect.SupportsWithinGroupStringAggregateFunction(call.Name))
+            throw SqlUnsupported.ForDialect(_dialect, $"ordered-set aggregate syntax WITHIN GROUP for function '{call.Name}'");
+
+        Consume(); // WITHIN
+        ExpectWord("GROUP");
+        ExpectSymbol("(");
+
+        if (!IsKeywordOrIdentifierWord(Peek(), "ORDER"))
+            throw Error("WITHIN GROUP requires ORDER BY", Peek());
+        Consume();
+
+        if (!IsKeywordOrIdentifierWord(Peek(), "BY"))
+            throw Error("WITHIN GROUP requires ORDER BY", Peek());
+        Consume();
+
+        var orderBy = new List<WindowOrderItem>();
+        while (true)
+        {
+            var expr = ParseExpression(0);
+
+            var desc = false;
+            if (IsKeywordOrIdentifierWord(Peek(), "DESC"))
+            {
+                Consume();
+                desc = true;
+            }
+            else if (IsKeywordOrIdentifierWord(Peek(), "ASC"))
+            {
+                Consume();
+            }
+
+            orderBy.Add(new WindowOrderItem(expr, desc));
+
+            if (!IsSymbol(Peek(), ","))
+                break;
+
+            Consume();
+        }
+
+        ExpectSymbol(")");
+        return call with { WithinGroupOrderBy = orderBy };
     }
 
     private WindowSpec ParseWindowSpec()

--- a/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
+++ b/src/DbSqlLikeMem/Query/AstQueryExecutorBase.cs
@@ -6323,9 +6323,34 @@ private void FillPercentRankOrCumeDist(
         if (fn.Args.Count > 1 && group.Rows.Count > 0)
             separatorObj = Eval(fn.Args[1], group.Rows[0], null, ctes);
 
+        IEnumerable<EvalRow> rows = group.Rows;
+        if (fn.WithinGroupOrderBy is { Count: > 0 })
+        {
+            rows = rows.OrderBy(
+                row => fn.WithinGroupOrderBy
+                    .Select(order => Eval(order.Expr, row, null, ctes))
+                    .ToArray(),
+                Comparer<object?[]>.Create((left, right) =>
+                {
+                    for (var i = 0; i < fn.WithinGroupOrderBy.Count; i++)
+                    {
+                        var cmp = CompareSql(left[i], right[i]);
+                        if (cmp == 0)
+                            continue;
+
+                        if (fn.WithinGroupOrderBy[i].Desc)
+                            cmp = -cmp;
+
+                        return cmp;
+                    }
+
+                    return 0;
+                }));
+        }
+
         var values = new List<object?>();
         var distinct = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var r in group.Rows)
+        foreach (var r in rows)
         {
             var v = Eval(fn.Args[0], r, null, ctes);
             if (IsNullish(v))


### PR DESCRIPTION
### Motivation
- Introduce ordered-set `WITHIN GROUP (ORDER BY ...)` semantics for string aggregation functions and gate them per-dialect to match real DB behavior.
- Provide actionable errors for malformed `WITHIN GROUP` clauses and preserve existing not-supported behavior for dialects that do not implement the feature.
- Ensure executor applies the specified ordering (including composite keys and `DESC/ASC`) before aggregation and that `DISTINCT` honors the ordering when deduplicating.

### Description
- Parser: extended `SqlExpressionParser` to parse `WITHIN GROUP (ORDER BY ...)` and attach an ordered `WithinGroupOrderBy` list to `CallExpr`, and emit actionable `WITHIN GROUP requires ORDER BY` validation for malformed clauses.
- AST: extended `CallExpr` to carry `WithinGroupOrderBy` as `IReadOnlyList<WindowOrderItem>?` so ordered-set info travels through the AST.
- Dialects: added `SupportsWithinGroupForStringAggregates` and `SupportsWithinGroupStringAggregateFunction` to `ISqlDialect/SqlDialectBase` with overrides in `Db2`, `Npgsql`, `Oracle`, and `SqlServer` and defaults to block for others (e.g. MySQL/SQLite remain not supported).
- Executor: updated aggregation evaluation (`EvalStringAggregateForCallExpr`) to apply ordering from `WithinGroupOrderBy` prior to building the aggregated string, honoring `DESC/ASC` and composite ordering, and preserving `DISTINCT` semantics.
- Tests & Helpers: added and updated parser and integration tests across dialect test projects to assert parsing and execution behavior (`*WithinGroup_ShouldParse`, `*ShouldThrowNotSupported`, and ordering assertions); extended test base `AggregationHavingOrdinalTestsBase` with helpers `AssertWithinGroupOrdersAggregation`, `AssertWithinGroupCompositeOrdering`, and `AssertWithinGroupDistinctOrdering` and kept `AssertWithinGroupNotSupported` for negative cases.

### Testing
- Ran parser and aggregation unit tests across affected projects including `*.Test` and `*.Dapper.Test` for `Db2`, `Npgsql`, `Oracle`, `SqlServer`, `MySql`, and `Sqlite`, covering both parsing and execution scenarios; all executed tests passed.
- Exercised negative flows verifying `WITHIN GROUP` is rejected with clear messages when unsupported or malformed, and these assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78263ecec832c92a102f918044675)