### PR TITLE
Parser hardening: validate WITHIN GROUP ORDER BY and RETURNING; add tests and docs updates

### DIFF
--- a/docs/features-backlog/index.md
+++ b/docs/features-backlog/index.md
@@ -42,9 +42,10 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - Aplicação de regras específicas por dialeto e versão simulada.
 
 #### 1.2.2 Interpretação de comandos DML
-- Implementação estimada: **72%**.
+- Implementação estimada: **74%**.
 - Processamento de comandos de escrita e leitura.
 - Tradução da consulta para operações no estado em memória.
+- Hardening recente reforça parsing de DML com `RETURNING` (itens vazios, vírgula inicial e vírgula final) com mensagens acionáveis no dialeto suportado e gate explícito nos não suportados.
 - Preservação da experiência de uso próxima ao fluxo SQL tradicional.
 
 #### 1.2.3 Regras por dialeto e versão
@@ -63,10 +64,12 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - Backlog operacional segue cadência priorizada P0→P14 para reduzir dispersão de implementação entre parser/executor/docs.
 
 #### 1.2.5 Funções SQL agregadoras e de composição de texto
-- Implementação estimada: **91%**.
+- Implementação estimada: **100%**.
 - Parser e AST agora suportam `WITHIN GROUP (ORDER BY ...)` para agregações textuais com gate explícito por dialeto/função.
 - Cobertura atual inclui parsing de ordenação simples e composta, validação de cláusula malformada (`WITHIN GROUP requires ORDER BY`) e cenários negativos por função não nativa no dialeto.
+- Hardening recente ampliou a validação de `ORDER BY` malformado dentro de `WITHIN GROUP` (lista vazia, vírgula inicial, vírgula final e ausência de vírgula entre expressões), com mensagens acionáveis por cenário.
 - Runtime aplica a ordenação de `WITHIN GROUP` antes da agregação, incluindo combinações com `DISTINCT` e separador customizado.
+- Trilha ordered-set para agregações textuais concluída para dialetos suportados (SQL Server, Npgsql, Oracle e DB2), com bloqueio explícito e testado para MySQL/SQLite.
 
 #### 1.2.6 Funções de data/hora cross-dialect
 - Implementação estimada: **93%**.
@@ -150,13 +153,13 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
     - manter suíte de rowcount por dialeto atualizada conforme expansão de parser/executor.
 
 #### 1.3.3 Resultados e consistência
-- Implementação estimada: **88%**.
+- Implementação estimada: **90%**.
 - Entrega de resultados em formatos esperados por consumidores ADO.NET.
 - Coerência entre operação executada e estado final da base simulada.
 - Comportamento determinístico para repetição do mesmo script.
 - Hardening recente reforçou previsibilidade de regressão com foco em mensagens de erro não suportado e consistência de diagnóstico.
 - Checklist operacional confirma padronização de `SqlUnsupported.ForDialect(...)` no runtime para fluxos não suportados.
-- Hardening recente também consolidou semântica ordered-set para agregações textuais com cobertura de ordenação `ASC/DESC`, ordenação composta e `DISTINCT + WITHIN GROUP` nos dialetos suportados.
+- Hardening recente também consolidou semântica ordered-set para agregações textuais com cobertura de ordenação `ASC/DESC`, ordenação composta, `DISTINCT + WITHIN GROUP` e `LISTAGG` sem separador explícito nos dialetos suportados.
 
 #### 1.3.4 Particionamento de tabelas (avaliação)
 - Implementação estimada: **8%**.
@@ -343,10 +346,10 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - 7, 2000, 2005, 2008, 2012, 2014, 2016, 2017, 2019, 2022.
 
 #### 3.2.2 Recursos relevantes
-- Implementação estimada: **85%**.
+- Implementação estimada: **88%**.
 - Parser/executor para DDL/DML comuns.
 - Diferenças de dialeto por versão simulada.
-- Cobertura de `STRING_AGG` ampliada para `DISTINCT` e tratamento de `NULL`; ordenação interna segue no backlog, com fallback atual de não suportado explícito para `WITHIN GROUP`.
+- Cobertura de `STRING_AGG` ampliada para `DISTINCT`, tratamento de `NULL` e ordenação interna via `WITHIN GROUP`, incluindo cenários de erro malformado com diagnóstico acionável.
 - P8 consolidado: paginação por versão (`OFFSET/FETCH`, `TOP`) com gates explícitos de dialeto.
 - Funções-chave do banco: `STRING_AGG`, `ISNULL`, `DATEADD`, `JSON_VALUE`/`OPENJSON` (subset no mock).
 
@@ -362,10 +365,10 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - 7, 8, 9, 10, 11, 12, 18, 19, 21, 23.
 
 #### 3.3.2 Recursos relevantes
-- Implementação estimada: **85%**.
+- Implementação estimada: **88%**.
 - Parser/executor para DDL/DML comuns.
 - Diferenças de dialeto por versão simulada.
-- Cobertura de `LISTAGG` ampliada com separador customizado e comportamento padrão sem delimitador quando omitido; `WITHIN GROUP` permanece na trilha de evolução (com erro padronizado de não suportado no estado atual).
+- Cobertura de `LISTAGG` ampliada com separador customizado, comportamento padrão sem delimitador quando omitido e ordenação interna via `WITHIN GROUP` (incluindo combinações com `DISTINCT`).
 - P8 consolidado: suporte a `FETCH FIRST/NEXT` por versão e contratos de ordenação por dialeto.
 - Funções-chave do banco: `LISTAGG`, `NVL`, `JSON_VALUE` (subset escalar) e operações de data por versão.
 
@@ -381,10 +384,10 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17.
 
 #### 3.4.2 Recursos relevantes
-- Implementação estimada: **85%**.
+- Implementação estimada: **88%**.
 - Parser/executor para DDL/DML comuns.
 - Diferenças de dialeto por versão simulada.
-- Cobertura de `STRING_AGG` ampliada para agregação textual com `DISTINCT` e `NULL`; ordenação por grupo permanece no backlog, com fallback atual de não suportado explícito para `WITHIN GROUP`.
+- Cobertura de `STRING_AGG` ampliada para agregação textual com `DISTINCT`, `NULL` e ordenação por grupo via `WITHIN GROUP`, com gate por função/dialeto e mensagens acionáveis em sintaxe malformada.
 - P7/P10 consolidado: `RETURNING` sintático mínimo em caminhos suportados e fluxo de procedures no contrato Dapper.
 - Funções-chave do banco: `STRING_AGG`, operadores JSON (`->`, `->>`, `#>`, `#>>`) e expressões de data por intervalo.
 
@@ -424,11 +427,11 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - 8, 9, 10, 11.
 
 #### 3.6.2 Recursos relevantes
-- Implementação estimada: **84%**.
+- Implementação estimada: **87%**.
 - `WITH`/CTE disponível.
 - `MERGE` disponível (>= 9).
 - `FETCH FIRST` suportado.
-- Cobertura de `LISTAGG` ampliada com separador customizado, `DISTINCT` e tratamento de `NULL`; alinhamento fino por versão simulada segue em backlog.
+- Cobertura de `LISTAGG` ampliada com separador customizado, `DISTINCT`, tratamento de `NULL` e ordenação ordered-set via `WITHIN GROUP`, incluindo validações sintáticas malformadas.
 - P9 consolidado: fallback explícito de não suportado para JSON avançado e cobertura de `FETCH FIRST` no dialeto DB2.
 - Funções-chave do banco: `LISTAGG` (por versão), `COALESCE`, `TIMESTAMPADD` e `FETCH FIRST` no fluxo de paginação.
 

--- a/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AggregationTests.cs
+++ b/src/DbSqlLikeMem.Db2.Dapper.Test/Db2AggregationTests.cs
@@ -194,6 +194,17 @@ public sealed class Db2AggregationTests : AggregationHavingOrdinalTestsBase<Db2D
     }
 
     /// <summary>
+    /// EN: Ensures LISTAGG without explicit separator still honors WITHIN GROUP ordering.
+    /// PT: Garante que LISTAGG sem separador explícito ainda respeite a ordenação do WITHIN GROUP.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void ListAgg_WithinGroupWithoutSeparator_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupOrdersAggregation("SELECT LISTAGG(amount) WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders", "30105");
+    }
+
+    /// <summary>
     /// EN: Ensures WITHIN GROUP supports composite ORDER BY expressions.
     /// PT: Garante que WITHIN GROUP suporte expressões compostas no ORDER BY.
     /// </summary>

--- a/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Db2.Test/Parser/Db2DialectFeatureParserTests.cs
@@ -713,4 +713,73 @@ public sealed class Db2DialectFeatureParserTests
         Assert.Contains("WITHIN GROUP requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Ensures trailing commas in WITHIN GROUP ORDER BY are rejected with actionable message.
+    /// PT: Garante que vírgulas finais no ORDER BY do WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_WithinGroupOrderByTrailingComma_ShouldThrowActionableError(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC,)", dialect));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures empty ORDER BY lists in WITHIN GROUP are rejected with actionable message.
+    /// PT: Garante que listas ORDER BY vazias em WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_WithinGroupOrderByEmptyList_ShouldThrowActionableError(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY)", dialect));
+
+        Assert.Contains("requires at least one expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures leading commas in WITHIN GROUP ORDER BY are rejected with actionable message.
+    /// PT: Garante que vírgulas iniciais no ORDER BY do WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_WithinGroupOrderByLeadingComma_ShouldThrowActionableError(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY, amount DESC)", dialect));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures missing commas between WITHIN GROUP ORDER BY expressions are rejected with actionable message.
+    /// PT: Garante que ausência de vírgula entre expressões de ORDER BY no WITHIN GROUP seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataDb2Version]
+    public void ParseScalar_WithinGroupOrderByMissingCommaBetweenExpressions_ShouldThrowActionableError(int version)
+    {
+        var dialect = new Db2Dialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC id ASC)", dialect));
+
+        Assert.Contains("requires commas", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.MySql.Test/Parser/MySqlDialectFeatureParserTests.cs
@@ -693,4 +693,74 @@ public sealed class MySqlDialectFeatureParserTests
         Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+
+    /// <summary>
+    /// EN: Ensures malformed trailing comma in WITHIN GROUP remains blocked by dialect gate.
+    /// PT: Garante que vírgula final malformada no WITHIN GROUP continue bloqueada pelo gate de dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_StringAggregateWithinGroupTrailingComma_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY amount DESC,)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures empty ORDER BY list in WITHIN GROUP remains blocked by dialect gate.
+    /// PT: Garante que lista ORDER BY vazia em WITHIN GROUP continue bloqueada pelo gate de dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_StringAggregateWithinGroupOrderByEmptyList_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures leading commas in WITHIN GROUP ORDER BY remain blocked by dialect gate.
+    /// PT: Garante que vírgulas iniciais no ORDER BY do WITHIN GROUP continuem bloqueadas pelo gate de dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_StringAggregateWithinGroupOrderByLeadingComma_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY, amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures missing commas in malformed WITHIN GROUP ORDER BY remain blocked by dialect gate.
+    /// PT: Garante que ausência de vírgula em ORDER BY malformado no WITHIN GROUP continue bloqueada pelo gate de dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataMySqlVersion]
+    public void ParseScalar_StringAggregateWithinGroupOrderByMissingCommaBetweenExpressions_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new MySqlDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY amount DESC id ASC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
@@ -167,6 +167,58 @@ RETURNING id";
         Assert.Equal("id", parsed.Returning[0].Raw);
     }
 
+
+    /// <summary>
+    /// EN: Ensures empty RETURNING clause is rejected with actionable message.
+    /// PT: Garante que cláusula RETURNING vazia seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_EmptyReturning_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') RETURNING";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("requires at least one expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures RETURNING leading comma is rejected with actionable message.
+    /// PT: Garante que vírgula inicial no RETURNING seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseUpdate_ReturningLeadingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' WHERE id = 1 RETURNING, id";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures RETURNING trailing comma is rejected with actionable message.
+    /// PT: Garante que vírgula final no RETURNING seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseDelete_ReturningTrailingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "DELETE FROM users WHERE id = 1 RETURNING id,";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     /// EN: Ensures SQL Server table hints are rejected for Npgsql.
     /// PT: Garante que hints de tabela do SQL Server sejam rejeitados para Npgsql.
@@ -703,6 +755,75 @@ RETURNING id";
             SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (amount DESC)", dialect));
 
         Assert.Contains("WITHIN GROUP requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures trailing commas in WITHIN GROUP ORDER BY are rejected with actionable message.
+    /// PT: Garante que vírgulas finais no ORDER BY do WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseScalar_WithinGroupOrderByTrailingComma_ShouldThrowActionableError(int version)
+    {
+        var dialect = new NpgsqlDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC,)", dialect));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures empty ORDER BY lists in WITHIN GROUP are rejected with actionable message.
+    /// PT: Garante que listas ORDER BY vazias em WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseScalar_WithinGroupOrderByEmptyList_ShouldThrowActionableError(int version)
+    {
+        var dialect = new NpgsqlDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY)", dialect));
+
+        Assert.Contains("requires at least one expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures leading commas in WITHIN GROUP ORDER BY are rejected with actionable message.
+    /// PT: Garante que vírgulas iniciais no ORDER BY do WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseScalar_WithinGroupOrderByLeadingComma_ShouldThrowActionableError(int version)
+    {
+        var dialect = new NpgsqlDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY, amount DESC)", dialect));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures missing commas between WITHIN GROUP ORDER BY expressions are rejected with actionable message.
+    /// PT: Garante que ausência de vírgula entre expressões de ORDER BY no WITHIN GROUP seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseScalar_WithinGroupOrderByMissingCommaBetweenExpressions_ShouldThrowActionableError(int version)
+    {
+        var dialect = new NpgsqlDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC id ASC)", dialect));
+
+        Assert.Contains("requires commas", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 }

--- a/src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAggregationTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Dapper.Test/OracleAggregationTests.cs
@@ -217,6 +217,17 @@ public sealed class OracleAggregationTests : AggregationHavingOrdinalTestsBase<O
     }
 
     /// <summary>
+    /// EN: Ensures LISTAGG without explicit separator still honors WITHIN GROUP ordering.
+    /// PT: Garante que LISTAGG sem separador explícito ainda respeite a ordenação do WITHIN GROUP.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Aggregation")]
+    public void ListAgg_WithinGroupWithoutSeparator_ShouldApplyOrderBy()
+    {
+        AssertWithinGroupOrdersAggregation("SELECT LISTAGG(amount) WITHIN GROUP (ORDER BY amount DESC) AS joined FROM orders", "30105");
+    }
+
+    /// <summary>
     /// EN: Ensures WITHIN GROUP supports composite ORDER BY expressions.
     /// PT: Garante que WITHIN GROUP suporte expressões compostas no ORDER BY.
     /// </summary>

--- a/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Oracle.Test/Parser/OracleDialectFeatureParserTests.cs
@@ -731,4 +731,73 @@ public sealed class OracleDialectFeatureParserTests
         Assert.Contains("WITHIN GROUP requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Ensures trailing commas in WITHIN GROUP ORDER BY are rejected with actionable message.
+    /// PT: Garante que vírgulas finais no ORDER BY do WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_WithinGroupOrderByTrailingComma_ShouldThrowActionableError(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC,)", dialect));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures empty ORDER BY lists in WITHIN GROUP are rejected with actionable message.
+    /// PT: Garante que listas ORDER BY vazias em WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_WithinGroupOrderByEmptyList_ShouldThrowActionableError(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY)", dialect));
+
+        Assert.Contains("requires at least one expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures leading commas in WITHIN GROUP ORDER BY are rejected with actionable message.
+    /// PT: Garante que vírgulas iniciais no ORDER BY do WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_WithinGroupOrderByLeadingComma_ShouldThrowActionableError(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY, amount DESC)", dialect));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures missing commas between WITHIN GROUP ORDER BY expressions are rejected with actionable message.
+    /// PT: Garante que ausência de vírgula entre expressões de ORDER BY no WITHIN GROUP seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataOracleVersion]
+    public void ParseScalar_WithinGroupOrderByMissingCommaBetweenExpressions_ShouldThrowActionableError(int version)
+    {
+        var dialect = new OracleDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("LISTAGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC id ASC)", dialect));
+
+        Assert.Contains("requires commas", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
@@ -793,6 +793,75 @@ public sealed class SqlServerDialectFeatureParserTests
         Assert.Contains("WITHIN GROUP requires ORDER BY", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// EN: Ensures trailing commas in WITHIN GROUP ORDER BY are rejected with actionable message.
+    /// PT: Garante que vírgulas finais no ORDER BY do WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_WithinGroupOrderByTrailingComma_ShouldThrowActionableError(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC,)", dialect));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures empty ORDER BY lists in WITHIN GROUP are rejected with actionable message.
+    /// PT: Garante que listas ORDER BY vazias em WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_WithinGroupOrderByEmptyList_ShouldThrowActionableError(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY)", dialect));
+
+        Assert.Contains("requires at least one expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures leading commas in WITHIN GROUP ORDER BY are rejected with actionable message.
+    /// PT: Garante que vírgulas iniciais no ORDER BY do WITHIN GROUP sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_WithinGroupOrderByLeadingComma_ShouldThrowActionableError(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY, amount DESC)", dialect));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures missing commas between WITHIN GROUP ORDER BY expressions are rejected with actionable message.
+    /// PT: Garante que ausência de vírgula entre expressões de ORDER BY no WITHIN GROUP seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseScalar_WithinGroupOrderByMissingCommaBetweenExpressions_ShouldThrowActionableError(int version)
+    {
+        var dialect = new SqlServerDialect(version);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlExpressionParser.ParseScalar("STRING_AGG(amount, '|') WITHIN GROUP (ORDER BY amount DESC id ASC)", dialect));
+
+        Assert.Contains("requires commas", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 
 
     /// <summary>
@@ -847,6 +916,24 @@ public sealed class SqlServerDialectFeatureParserTests
     public void ParseDelete_WithReturning_ShouldBeRejected(int version)
     {
         const string sql = "DELETE FROM users WHERE id = 1 RETURNING id";
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("RETURNING", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures malformed RETURNING in INSERT remains blocked by SQL Server dialect gate.
+    /// PT: Garante que RETURNING malformado em INSERT continue bloqueado pelo gate de dialeto SQL Server.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_WithMalformedReturning_ShouldBeRejectedByDialectGate(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') RETURNING, id";
 
         var ex = Assert.Throws<NotSupportedException>(() =>
             SqlQueryParser.Parse(sql, new SqlServerDialect(version)));

--- a/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Sqlite.Test/Parser/SqliteDialectFeatureParserTests.cs
@@ -511,4 +511,74 @@ public sealed class SqliteDialectFeatureParserTests
         Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+
+    /// <summary>
+    /// EN: Ensures malformed trailing comma in WITHIN GROUP remains blocked by dialect gate.
+    /// PT: Garante que vírgula final malformada no WITHIN GROUP continue bloqueada pelo gate de dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_StringAggregateWithinGroupTrailingComma_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY amount DESC,)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures empty ORDER BY list in WITHIN GROUP remains blocked by dialect gate.
+    /// PT: Garante que lista ORDER BY vazia em WITHIN GROUP continue bloqueada pelo gate de dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_StringAggregateWithinGroupOrderByEmptyList_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures leading commas in WITHIN GROUP ORDER BY remain blocked by dialect gate.
+    /// PT: Garante que vírgulas iniciais no ORDER BY do WITHIN GROUP continuem bloqueadas pelo gate de dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_StringAggregateWithinGroupOrderByLeadingComma_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY, amount DESC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures missing commas in malformed WITHIN GROUP ORDER BY remain blocked by dialect gate.
+    /// PT: Garante que ausência de vírgula em ORDER BY malformado no WITHIN GROUP continue bloqueada pelo gate de dialeto.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqliteVersion]
+    public void ParseScalar_StringAggregateWithinGroupOrderByMissingCommaBetweenExpressions_ShouldThrowNotSupported(int version)
+    {
+        var dialect = new SqliteDialect(version);
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlExpressionParser.ParseScalar("GROUP_CONCAT(amount, '|') WITHIN GROUP (ORDER BY amount DESC id ASC)", dialect));
+
+        Assert.Contains("WITHIN GROUP", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
 }

--- a/src/DbSqlLikeMem/Parser/SqlExpressionParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlExpressionParser.cs
@@ -1284,6 +1284,12 @@ internal sealed class SqlExpressionParser(
         var orderBy = new List<WindowOrderItem>();
         while (true)
         {
+            if (IsSymbol(Peek(), ")"))
+                throw Error("WITHIN GROUP ORDER BY requires at least one expression", Peek());
+
+            if (IsSymbol(Peek(), ","))
+                throw Error("WITHIN GROUP ORDER BY has an unexpected comma before expression", Peek());
+
             var expr = ParseExpression(0);
 
             var desc = false;
@@ -1299,10 +1305,20 @@ internal sealed class SqlExpressionParser(
 
             orderBy.Add(new WindowOrderItem(expr, desc));
 
-            if (!IsSymbol(Peek(), ","))
-                break;
+            if (IsSymbol(Peek(), ","))
+            {
+                Consume();
 
-            Consume();
+                if (IsSymbol(Peek(), ")"))
+                    throw Error("WITHIN GROUP ORDER BY has a trailing comma without expression", Peek());
+
+                continue;
+            }
+
+            if (!IsSymbol(Peek(), ")"))
+                throw Error("WITHIN GROUP ORDER BY requires commas between expressions", Peek());
+
+            break;
         }
 
         ExpectSymbol(")");

--- a/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
@@ -1216,16 +1216,78 @@ internal sealed class SqlQueryParser
             throw SqlUnsupported.ForDialect(_dialect, "RETURNING");
 
         Consume(); // RETURNING
-        var raws = ParseCommaSeparatedRawItemsUntilAny();
+
+        var raws = ParseReturningItemsRaw();
         return raws.ConvertAll(raw =>
         {
             var (expr, alias) = SplitTrailingAsAliasTopLevel(raw, _dialect);
             if (string.IsNullOrWhiteSpace(expr))
-                throw new InvalidOperationException("Empty RETURNING item.");
+                throw new InvalidOperationException("RETURNING requires at least one expression.");
 
             _ = SqlExpressionParser.ParseScalar(expr, _dialect);
             return new SqlSelectItem(expr, alias);
         });
+    }
+
+    private List<string> ParseReturningItemsRaw()
+    {
+        var items = new List<string>();
+
+        while (true)
+        {
+            if (IsEnd(Peek()) || IsSymbol(Peek(), ";"))
+            {
+                if (items.Count == 0)
+                    throw new InvalidOperationException("RETURNING requires at least one expression.");
+                break;
+            }
+
+            if (IsSymbol(Peek(), ","))
+                throw new InvalidOperationException("RETURNING has an unexpected comma before expression.");
+
+            var raw = ReadRawExpressionUntilCommaOrTerminator().Trim();
+            if (string.IsNullOrWhiteSpace(raw))
+                throw new InvalidOperationException("RETURNING requires at least one expression.");
+
+            items.Add(raw);
+
+            if (IsSymbol(Peek(), ","))
+            {
+                Consume();
+
+                if (IsEnd(Peek()) || IsSymbol(Peek(), ";"))
+                    throw new InvalidOperationException("RETURNING has a trailing comma without expression.");
+
+                continue;
+            }
+
+            break;
+        }
+
+        return items;
+    }
+
+    private string ReadRawExpressionUntilCommaOrTerminator()
+    {
+        var buf = new List<SqlToken>();
+        int depth = 0;
+
+        while (!IsEnd(Peek()))
+        {
+            var t = Peek();
+
+            if (depth == 0 && (IsSymbol(t, ",") || IsSymbol(t, ";")))
+                break;
+
+            if (IsSymbol(t, "("))
+                depth++;
+            else if (IsSymbol(t, ")"))
+                depth--;
+
+            buf.Add(Consume());
+        }
+
+        return TokensToSql(buf);
     }
 
     private List<SqlSelectItem> ParseSelectItemsWithValidation()


### PR DESCRIPTION
### Motivation
- Reduce parser fragility and provide actionable diagnostics for malformed ordered-set `WITHIN GROUP (ORDER BY ...)` clauses (empty lists, leading/trailing commas, missing commas between expressions). 
- Make `RETURNING` parsing robust with explicit validation for empty lists and misplaced commas and keep dialect gating behavior consistent. 
- Improve cross-dialect coverage and document recent hardening and feature progress in the backlog index.

### Description
- Added strict validation in `SqlExpressionParser` for `WITHIN GROUP ORDER BY` to reject empty lists, leading/trailing commas, and missing commas with clear `InvalidOperationException` messages. 
- Enhanced `SqlQueryParser.ParseOptionalReturningItems` with `ParseReturningItemsRaw` and `ReadRawExpressionUntilCommaOrTerminator` to validate `RETURNING` items (empty item, unexpected leading comma, trailing comma) and preserve dialect gating via `SupportsReturning`. 
- Added parser unit tests across dialect projects (`Db2`, `MySql`, `Npgsql`, `Oracle`, `SqlServer`, `Sqlite`) exercising malformed `WITHIN GROUP` and `RETURNING` cases and added Dapper aggregation tests (`LISTAGG` without explicit separator) to `Oracle` and `Db2` test projects. 
- Updated `docs/features-backlog/index.md` to reflect the hardening: increased implementation estimates and notes about `WITHIN GROUP`, ordered-set semantics, `RETURNING` parsing, and cross-dialect testing coverage.

### Testing
- Ran parser unit test suites in `src/*/*.Test` (parser-focused projects for `Db2`, `MySql`, `Npgsql`, `Oracle`, `SqlServer`, `Sqlite`) which exercise the new error paths; all tests passed. 
- Ran aggregation/Dapper tests (`*.Dapper.Test`) including the new `LISTAGG` cases in `Db2` and `Oracle`; all tests passed. 
- Executed the overall test matrix invoked by CI (parser + dapper suites) and observed no regressions in existing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78c422f60832c861ef413eb73c655)