### PR TITLE
docs: bilingual and expanded README for DbSqlLikeMem core package

### DIFF
--- a/src/DbSqlLikeMem/README.md
+++ b/src/DbSqlLikeMem/README.md
@@ -1,38 +1,59 @@
 # DbSqlLikeMem
 
-A base do ecossistema **DbSqlLikeMem**: um motor SQL-like em memória para você testar acesso a dados em C# com mais velocidade, previsibilidade e confiança.
+**EN:** Core package of the **DbSqlLikeMem** ecosystem: an in-memory SQL-like engine that helps you test data access code in C# with speed, repeatability, and confidence.
+**PT-BR:** Pacote base do ecossistema **DbSqlLikeMem**: um motor SQL-like em memória para testar acesso a dados em C# com velocidade, previsibilidade e confiança.
 
-## O que este pacote entrega
+## What this package provides | O que este pacote entrega
 
-- Estruturas de banco em memória (schema, tabelas, colunas, índices)
-- Parser e executor SQL para cenários comuns de testes
-- Helpers de seed e construção de dados
-- Integração amigável com ADO.NET/Dapper
-- Plano de execução mock com métricas de runtime e histórico por conexão
+- **EN:** In-memory database structures (schema, tables, columns, indexes).
+  **PT-BR:** Estruturas de banco em memória (schema, tabelas, colunas, índices).
+- **EN:** SQL parser and executor for common test scenarios (DDL and DML subsets).
+  **PT-BR:** Parser e executor SQL para cenários comuns de teste (subconjuntos de DDL e DML).
+- **EN:** Data seeding helpers and fluent builders for setup.
+  **PT-BR:** Helpers de seed e builders fluentes para setup.
+- **EN:** ADO.NET-friendly behavior used by provider packages.
+  **PT-BR:** Comportamento compatível com ADO.NET usado pelos pacotes de provedor.
+- **EN:** Mock execution plans with lightweight runtime metrics and per-connection history.
+  **PT-BR:** Planos de execução mock com métricas de runtime simplificadas e histórico por conexão.
 
-## Quando usar
+## Typical use cases | Quando usar
 
-Use `DbSqlLikeMem` quando quiser:
+Use `DbSqlLikeMem` when you want to / Use `DbSqlLikeMem` quando quiser:
 
-- reduzir custo de testes que hoje dependem de banco real
-- criar cenários de QA de forma reproduzível
-- validar regras de query e transformação de dados com ciclo rápido
-- investigar custo/impacto de queries em testes através de métricas simplificadas do plano
+- **EN:** Reduce test costs that currently rely on a real database server.
+  **PT-BR:** Reduzir custo de testes que hoje dependem de banco real.
+- **EN:** Build reproducible QA scenarios with deterministic data setup.
+  **PT-BR:** Criar cenários de QA reproduzíveis com setup determinístico.
+- **EN:** Validate query and transformation logic with fast feedback loops.
+  **PT-BR:** Validar regras de query e transformação de dados com ciclo rápido.
+- **EN:** Inspect query behavior in tests with simplified execution-plan metrics.
+  **PT-BR:** Investigar comportamento de queries em testes com métricas simplificadas de plano.
 
-## Instalação
+## Installation | Instalação
 
 ```bash
 dotnet add package DbSqlLikeMem
 ```
 
-## Próximo passo
+## Quick example | Exemplo rápido
 
-Escolha também um pacote de provedor (MySql, SqlServer, Oracle, Npgsql, Sqlite ou Db2) para simular o dialeto do seu sistema.
+```csharp
+var db = new DbMock();
+var users = db.AddTable("Users");
+users.AddColumn("Id", DbType.Int32, false);
+users.AddColumn("Name", DbType.String, false);
+users.AddPrimaryKeyIndexes("Id");
+```
 
+## Next step: choose a provider package | Próximo passo: escolha um pacote de provedor
 
-## Factory rápida para testes
+**EN:** Add at least one provider package to emulate your database dialect in tests (`DbSqlLikeMem.MySql`, `DbSqlLikeMem.SqlServer`, `DbSqlLikeMem.Oracle`, `DbSqlLikeMem.Npgsql`, `DbSqlLikeMem.Sqlite`, or `DbSqlLikeMem.Db2`).
+**PT-BR:** Adicione ao menos um pacote de provedor para simular o dialeto do seu banco nos testes (`DbSqlLikeMem.MySql`, `DbSqlLikeMem.SqlServer`, `DbSqlLikeMem.Oracle`, `DbSqlLikeMem.Npgsql`, `DbSqlLikeMem.Sqlite` ou `DbSqlLikeMem.Db2`).
 
-Para facilitar o uso no dia a dia, você pode criar `DbMock` + `IDbConnection` com uma chamada única:
+## One-call test factory | Factory de uma chamada para testes
+
+**EN:** You can create `DbMock` + `IDbConnection` in a single call:
+**PT-BR:** Você pode criar `DbMock` + `IDbConnection` com uma chamada única:
 
 ```csharp
 var (db, conn) = DbMockConnectionFactory.CreateSqliteWithTables(
@@ -41,20 +62,40 @@ var (db, conn) = DbMockConnectionFactory.CreateSqliteWithTables(
         [new Dictionary<int, object?> { [0] = 1, [1] = "Ana" }]));
 ```
 
-Também existem atalhos por banco: `CreateOracleWithTables`, `CreateSqlServerWithTables`, `CreateMySqlWithTables`, `CreateSqliteWithTables`, `CreateDb2WithTables` e `CreateNpgsqlWithTables`.
+**EN:** There are provider shortcuts as well: `CreateOracleWithTables`, `CreateSqlServerWithTables`, `CreateMySqlWithTables`, `CreateSqliteWithTables`, `CreateDb2WithTables`, and `CreateNpgsqlWithTables`.
+**PT-BR:** Também existem atalhos por banco: `CreateOracleWithTables`, `CreateSqlServerWithTables`, `CreateMySqlWithTables`, `CreateSqliteWithTables`, `CreateDb2WithTables` e `CreateNpgsqlWithTables`.
 
-Se preferir, use a versão genérica por string:
+**EN:** If preferred, use the generic string-based entry point:
+**PT-BR:** Se preferir, use a entrada genérica por string:
 
 ```csharp
 var (db, conn) = DbMockConnectionFactory.CreateWithTables("SqlServer", d => { /* mapeamentos */ });
 ```
 
-> Dica: a factory resolve a conexão automaticamente via reflexão, então ela funciona melhor quando o pacote do provedor já está referenciado e carregado no seu projeto de teste.
+> **EN:** Tip: the factory resolves connection types via reflection, so it works best when the provider package is already referenced and loaded by your test project.
+> **PT-BR:** Dica: a factory resolve os tipos de conexão via reflexão, então funciona melhor quando o pacote de provedor já está referenciado e carregado no projeto de teste.
 
-## Contribuindo
+## Scope and expectations | Escopo e expectativas
 
-Contribuições são super bem-vindas 💙
+- **EN:** This package is intended for tests and local validation, not as a production database replacement.
+  **PT-BR:** Este pacote é voltado para testes e validação local, não para substituir banco em produção.
+- **EN:** SQL support is incremental and dialect-aware through provider-specific packages.
+  **PT-BR:** O suporte SQL é incremental e sensível a dialeto por meio de pacotes específicos por provedor.
+- **EN:** Unsupported SQL constructs should fail fast with clear exceptions.
+  **PT-BR:** Construções SQL não suportadas devem falhar rapidamente com exceções claras.
 
-- Abra issues com exemplos reais de SQL
-- Envie PR com testes cobrindo o comportamento esperado
-- Ajude a melhorar documentação e exemplos para novos usuários
+## Learn more | Saiba mais
+
+- **EN:** Full docs and guides: [Repository README](../../README.md) and [Getting Started](../../docs/getting-started.md).
+  **PT-BR:** Documentação completa e guias: [README do repositório](../../README.md) e [Guia de início](../../docs/getting-started.md).
+
+## Contributing | Contribuindo
+
+Contributions are very welcome / Contribuições são muito bem-vindas 💙
+
+- **EN:** Open issues with real SQL samples and expected behavior.
+  **PT-BR:** Abra issues com exemplos reais de SQL e comportamento esperado.
+- **EN:** Submit PRs with focused tests and clear intent.
+  **PT-BR:** Envie PRs com testes objetivos e intenção clara.
+- **EN:** Help improve docs and examples for new users.
+  **PT-BR:** Ajude a melhorar documentação e exemplos para novos usuários.


### PR DESCRIPTION
### Motivation
- Provide English documentation for the README that is shipped with the NuGet/core package and keep the existing Portuguese content. 
- Improve onboarding and clarity for package consumers by adding a concise quick example, installation instructions, provider guidance, and expectations for test usage. 

### Description
- Rewrote and expanded `src/DbSqlLikeMem/README.md` to be fully bilingual (English + PT-BR) and restructured it into clear sections (capabilities, typical use cases, installation, quick example, next steps for provider packages, one-call factory, scope/expectations, learn more, and contributing). 
- Preserved existing examples and added a short `csharp` quick-start snippet and explicit guidance for choosing provider packages like `DbSqlLikeMem.MySql`, `DbSqlLikeMem.SqlServer`, `DbSqlLikeMem.Oracle`, `DbSqlLikeMem.Npgsql`, `DbSqlLikeMem.Sqlite`, and `DbSqlLikeMem.Db2`. 
- The change is documentation-only and does not modify runtime behavior, public APIs, or project files. 

### Testing
- Ran `git diff --check` to detect trailing whitespace and style issues and fixed any occurrences, and the check completed successfully. 
- Verified the updated file path `src/DbSqlLikeMem/README.md` renders the intended bilingual sections via local inspection of the file contents.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c57842d0832c9a040853e4148038)