### PR TITLE
Disable apphost generation for shared test project

### DIFF
--- a/src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj
+++ b/src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>false</IsTestProject>
+		<UseAppHost>false</UseAppHost>
 		<TargetFrameworks>net48;net6.0;net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 


### PR DESCRIPTION
### Motivation
- Prevent the SDK from attempting to generate and copy an `apphost` for the shared test helper project because that triggers MSB3030 `apphost` not found errors when provider-specific test projects reference it.

### Description
- Add `<UseAppHost>false</UseAppHost>` to `src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj` to disable apphost generation for the shared test project.

### Testing
- Attempted to run `dotnet test src/DbSqlLikeMem.Db2.Test/DbSqlLikeMem.Db2.Test.csproj --framework net8.0 --configuration Release --no-restore --verbosity minimal`, but the `dotnet` CLI is not available in this environment so the automated test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8b7bbf330832c8896c6f70ceca51f)