### PR TITLE
Set UseAppHost for xUnit v3 on net8/net10 test targets

### DIFF
--- a/src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj
+++ b/src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj
@@ -7,6 +7,10 @@
 		<TargetFrameworks>net48;net6.0;net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
+		<UseAppHost>true</UseAppHost>
+	</PropertyGroup>
+
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
### Motivation
- xUnit v3 requires test projects to build an app host for .NET 8/10; the CI build failed with an error asking to set `<UseAppHost>true</UseAppHost>`.

### Description
- Added a conditional `PropertyGroup` to `src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj` that sets `<UseAppHost>true</UseAppHost>` when `TargetFramework` is `net8.0` or `net10.0`, leaving the default setting unchanged for other targets.

### Testing
- Attempted `dotnet build src/DbSqlLikeMem.Test/DbSqlLikeMem.Test.csproj -f net8.0` but the command could not be executed in this environment because `dotnet` is not installed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8bbb17220832cb98f7646b0709db3)