### PR TITLE
Harden SQL parser for DML (INSERT/UPDATE/DELETE/ON CONFLICT/RETURNING) and add comprehensive parser tests

### DIFF
--- a/docs/features-backlog/index.md
+++ b/docs/features-backlog/index.md
@@ -42,10 +42,32 @@ Este documento organiza as funcionalidades do DbSqlLikeMem em camadas de profund
 - Aplicação de regras específicas por dialeto e versão simulada.
 
 #### 1.2.2 Interpretação de comandos DML
-- Implementação estimada: **74%**.
+- Implementação estimada: **96%**.
 - Processamento de comandos de escrita e leitura.
 - Tradução da consulta para operações no estado em memória.
 - Hardening recente reforça parsing de DML com `RETURNING` (itens vazios, vírgula inicial e vírgula final) com mensagens acionáveis no dialeto suportado e gate explícito nos não suportados.
+- Incremento desta sessão: `RETURNING` agora valida parênteses desbalanceados com mensagem acionável e mantém fronteira por `;` em projeções complexas, com cobertura adicional para gate de dialeto não suportado.
+- Incremento desta sessão: `ON CONFLICT (...)` recebeu hardening de lista de alvo (vazio, vírgula inicial e vírgula final) com mensagens acionáveis no dialeto suportado e regressão explícita de gate para dialeto não suportado.
+- Incremento desta sessão: `ON CONFLICT DO UPDATE SET` recebeu validações acionáveis para lista de atribuições malformada (vazia, vírgula inicial/final e atribuição sem expressão).
+- Incremento desta sessão: `ON CONFLICT DO UPDATE SET` passou a validar ausência de vírgula entre atribuições e a respeitar `;` como fronteira de statement após a lista.
+- Incremento desta sessão: `ON CONFLICT` ganhou validações acionáveis para ramo `DO` ausente/inválido e para `DO UPDATE` sem `SET`, com regressão de gate em dialeto não suportado.
+- Incremento desta sessão: `ON CONFLICT` passou a validar `WHERE` vazio no alvo e em `DO UPDATE`, com mensagens acionáveis em dialeto suportado e regressão de gate em não suportados.
+- Incremento desta sessão: `ON CONFLICT ON CONSTRAINT` passou a validar ausência do nome da constraint com mensagem acionável e cobertura de gate para dialeto não suportado.
+- Incremento desta sessão: `INSERT` passou a validar tokens inesperados após o statement (com tolerância a `;` final), evitando parse parcial silencioso em SQL malformado.
+- Incremento desta sessão: `UPDATE` e `DELETE` também passaram a validar tokens inesperados após o statement (com tolerância a `;` final), alinhando boundary check de DML.
+- Incremento desta sessão: `UPDATE` e `DELETE` agora rejeitam `WHERE` vazio com mensagens acionáveis (`... WHERE requires a predicate.`).
+- Incremento desta sessão: cláusulas `WHERE` de `UPDATE`/`DELETE` e de `ON CONFLICT` agora normalizam `;` terminal antes da validação, rejeitando explicitamente casos como `WHERE;` com mensagem acionável de predicado ausente.
+- Incremento desta sessão: cobertura de parser foi estendida para casos `ON CONFLICT ... WHERE;` e `ON CONFLICT DO UPDATE ... WHERE;`, garantindo erro acionável no dialeto suportado e preservando gate `NotSupported` no SQL Server.
+- Incremento desta sessão: `UPDATE SET` ganhou boundary check para `RETURNING` sem `WHERE` e validações acionáveis de lista de atribuições (vírgula final/falta de separador), evitando captura indevida de `RETURNING` como expressão.
+- Incremento desta sessão: `INSERT VALUES` ganhou validações acionáveis de lista de tuplas (linha vazia, vírgula inicial/final e separação obrigatória por vírgula), reduzindo parse parcial em sintaxe malformada.
+- Incremento desta sessão: `INSERT (colunas) VALUES (...)` passou a validar cardinalidade entre colunas alvo e expressões por linha, com mensagem acionável por linha divergente.
+- Incremento desta sessão: `INSERT VALUES` também passou a validar cardinalidade consistente entre múltiplas linhas (row arity), mesmo sem lista explícita de colunas.
+- Incremento desta sessão: `INSERT VALUES` passou a rejeitar expressão vazia dentro da tupla (ex.: `(1,,2)` e `(1,)`) com mensagem acionável.
+- Incremento desta sessão: `INSERT (col1, ...)` passou a validar lista de colunas malformada (vazia, vírgula inicial/final e separação obrigatória por vírgula) com mensagens acionáveis.
+- Incremento desta sessão: `INSERT VALUES` passou a validar fechamento de parênteses na tupla da linha, com erro acionável para tupla não encerrada.
+- Incremento desta sessão: lista de colunas em `INSERT` ganhou cobertura de vírgula inicial e fechamento ausente antes de `;`, com mensagens acionáveis consistentes.
+- Incremento desta sessão: `INSERT VALUES` passou a detectar tuplas consecutivas sem vírgula separadora (`VALUES (1) (2)`) com mensagem acionável específica.
+- Incremento desta sessão: alvo `ON CONFLICT (...)` interrompido por `;` passou a falhar com mensagem acionável de fechamento incorreto da lista.
 - Preservação da experiência de uso próxima ao fluxo SQL tradicional.
 
 #### 1.2.3 Regras por dialeto e versão

--- a/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.Npgsql.Test/Parser/NpgsqlDialectFeatureParserTests.cs
@@ -93,6 +93,319 @@ RETURNING id";
     }
 
     /// <summary>
+    /// EN: Ensures empty ON CONFLICT target list is rejected with actionable message.
+    /// PT: Garante que lista vazia no alvo de ON CONFLICT seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_EmptyTarget_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT () DO NOTHING";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("requires at least one expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT target leading comma is rejected with actionable message.
+    /// PT: Garante que vírgula inicial no alvo de ON CONFLICT seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_TargetLeadingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (, id) DO NOTHING";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT target trailing comma is rejected with actionable message.
+    /// PT: Garante que vírgula final no alvo de ON CONFLICT seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_TargetTrailingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id,) DO NOTHING";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT target interrupted by semicolon is rejected with actionable message.
+    /// PT: Garante que alvo de ON CONFLICT interrompido por ponto e vírgula seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_TargetUnclosedBeforeSemicolon_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id;";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("not closed correctly", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT DO UPDATE SET with empty assignment list is rejected with actionable message.
+    /// PT: Garante que ON CONFLICT DO UPDATE SET com lista vazia de atribuições seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_DoUpdateSetEmptyAssignments_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE SET";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("requires at least one assignment", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT DO UPDATE SET leading comma is rejected with actionable message.
+    /// PT: Garante que vírgula inicial em ON CONFLICT DO UPDATE SET seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_DoUpdateSetLeadingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE SET , name = EXCLUDED.name";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT DO UPDATE SET trailing comma is rejected with actionable message.
+    /// PT: Garante que vírgula final em ON CONFLICT DO UPDATE SET seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_DoUpdateSetTrailingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name,";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT DO UPDATE SET assignment without expression is rejected with actionable message.
+    /// PT: Garante que atribuição sem expressão em ON CONFLICT DO UPDATE SET seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_DoUpdateSetAssignmentWithoutExpression_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE SET name = WHERE id = 1";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("requires an expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT DO UPDATE SET assignments without comma separator are rejected with actionable message.
+    /// PT: Garante que atribuições em ON CONFLICT DO UPDATE SET sem separação por vírgula sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_DoUpdateSetMissingCommaBetweenAssignments_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name updated_at = NOW()";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("separate assignments with commas", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT DO UPDATE SET accepts semicolon statement boundary after assignment list.
+    /// PT: Garante que ON CONFLICT DO UPDATE SET aceite fronteira de statement por ponto e vírgula após lista de atribuições.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_DoUpdateSetWithSemicolonBoundary_ShouldParse(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;";
+
+        var parsed = Assert.IsType<SqlInsertQuery>(SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.True(parsed.HasOnDuplicateKeyUpdate);
+        Assert.Single(parsed.OnDupAssigns);
+        Assert.Equal("name", parsed.OnDupAssigns[0].Col);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT without DO branch is rejected with actionable message.
+    /// PT: Garante que ON CONFLICT sem ramo DO seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_WithoutDoBranch_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("requires DO NOTHING or DO UPDATE SET", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT DO with invalid continuation is rejected with actionable message.
+    /// PT: Garante que ON CONFLICT DO com continuação inválida seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_DoInvalidContinuation_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO SKIP";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("must be followed by NOTHING or UPDATE SET", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT DO UPDATE without SET is rejected with actionable message.
+    /// PT: Garante que ON CONFLICT DO UPDATE sem SET seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflict_DoUpdateWithoutSet_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("requires SET assignments", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT target WHERE without predicate is rejected with actionable message.
+    /// PT: Garante que WHERE no alvo de ON CONFLICT sem predicado seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflictTargetWhereWithoutPredicate_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) WHERE DO NOTHING";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("target WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT target WHERE terminated only by semicolon is rejected with actionable message.
+    /// PT: Garante que WHERE no alvo de ON CONFLICT finalizado apenas por ponto e vírgula seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflictTargetWhereOnlySemicolon_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) WHERE; DO NOTHING";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("target WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT ON CONSTRAINT without constraint name is rejected with actionable message.
+    /// PT: Garante que ON CONFLICT ON CONSTRAINT sem nome da constraint seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflictOnConstraintWithoutName_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT ON CONSTRAINT DO NOTHING";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("requires a constraint name", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT DO UPDATE WHERE without predicate is rejected with actionable message.
+    /// PT: Garante que WHERE em ON CONFLICT DO UPDATE sem predicado seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflictDoUpdateWhereWithoutPredicate_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name WHERE RETURNING id";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("DO UPDATE WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT DO UPDATE WHERE terminated only by semicolon is rejected with actionable message.
+    /// PT: Garante que WHERE em ON CONFLICT DO UPDATE finalizado apenas por ponto e vírgula seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_OnConflictDoUpdateWhereOnlySemicolon_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name WHERE; RETURNING id";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("DO UPDATE WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// EN: Ensures INSERT ... RETURNING captures projection payload in AST for PostgreSQL dialect.
     /// PT: Garante que INSERT ... RETURNING capture o payload de projeção na AST para o dialeto PostgreSQL.
     /// </summary>
@@ -110,6 +423,255 @@ RETURNING id";
         Assert.Equal("id", parsed.Returning[0].Raw);
         Assert.Equal("name", parsed.Returning[1].Raw);
         Assert.Equal("user_name", parsed.Returning[1].Alias);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT with unexpected trailing token is rejected with actionable message.
+    /// PT: Garante que INSERT com token inesperado ao final seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_WithUnexpectedTrailingToken_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') EXTRA";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("Unexpected token after INSERT", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES trailing comma is rejected with actionable message.
+    /// PT: Garante que vírgula final em INSERT VALUES seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ValuesTrailingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id) VALUES (1),";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES tuples without comma separator are rejected with actionable message.
+    /// PT: Garante que tuplas em INSERT VALUES sem vírgula separadora sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ValuesTuplesWithoutCommaSeparator_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id) VALUES (1) (2)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("separate row tuples with commas", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES leading comma is rejected with actionable message.
+    /// PT: Garante que vírgula inicial em INSERT VALUES seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ValuesLeadingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id) VALUES , (1)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT column list trailing comma is rejected with actionable message.
+    /// PT: Garante que vírgula final na lista de colunas do INSERT seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ColumnListTrailingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id,) VALUES (1)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures INSERT empty column list is rejected with actionable message.
+    /// PT: Garante que lista de colunas vazia no INSERT seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_EmptyColumnList_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users () VALUES (1)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("at least one column", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT column list leading comma is rejected with actionable message.
+    /// PT: Garante que vírgula inicial na lista de colunas do INSERT seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ColumnListLeadingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (,id) VALUES (1)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures INSERT column list unclosed before semicolon is rejected with actionable message.
+    /// PT: Garante que lista de colunas do INSERT não fechada antes de ponto e vírgula seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ColumnListUnclosedBeforeSemicolon_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id;";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("not closed correctly", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES empty row tuple is rejected with actionable message.
+    /// PT: Garante que linha vazia em INSERT VALUES seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ValuesEmptyRowTuple_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id) VALUES ()";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("at least one expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES rejects empty expression between commas inside tuple.
+    /// PT: Garante que INSERT VALUES rejeite expressão vazia entre vírgulas dentro da tupla.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ValuesTupleMissingExpressionBetweenCommas_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users VALUES (1,,2)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("empty expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES rejects trailing comma inside tuple.
+    /// PT: Garante que INSERT VALUES rejeite vírgula final dentro da tupla.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ValuesTupleTrailingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users VALUES (1,)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("empty expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES tuple with unclosed parenthesis is rejected with actionable message.
+    /// PT: Garante que tupla em INSERT VALUES com parêntese não fechado seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ValuesTupleUnclosedParenthesis_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users VALUES (1, 2";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("not closed correctly", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES row expression count matches target column count.
+    /// PT: Garante que a quantidade de expressões em INSERT VALUES corresponda à quantidade de colunas alvo.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ValuesColumnCountMismatch_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("column count", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("row 1", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES rows with inconsistent expression counts are rejected with actionable message.
+    /// PT: Garante que linhas de INSERT VALUES com cardinalidade inconsistente de expressões sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ValuesRowArityMismatch_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users VALUES (1, 'a'), (2)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("row 2", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("row 1", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -171,6 +733,97 @@ RETURNING id";
         Assert.Equal("name", parsed.Returning[1].Raw);
     }
 
+
+    /// <summary>
+    /// EN: Ensures UPDATE ... RETURNING without WHERE keeps SET boundary and captures RETURNING projection.
+    /// PT: Garante que UPDATE ... RETURNING sem WHERE preserve o limite do SET e capture a projeção de RETURNING.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseUpdate_ReturningWithoutWhere_ShouldCaptureReturningItems(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' RETURNING id";
+
+        var parsed = Assert.IsType<SqlUpdateQuery>(SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Null(parsed.WhereRaw);
+        Assert.Single(parsed.Set);
+        Assert.Equal("'b'", parsed.Set[0].ValueRaw);
+        Assert.Single(parsed.Returning);
+        Assert.Equal("id", parsed.Returning[0].Raw);
+    }
+
+    /// <summary>
+    /// EN: Ensures UPDATE SET trailing comma is rejected with actionable message.
+    /// PT: Garante que vírgula final em UPDATE SET seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseUpdate_SetTrailingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b', RETURNING id";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures UPDATE with unexpected trailing token is rejected with actionable message.
+    /// PT: Garante que UPDATE com token inesperado ao final seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseUpdate_WithUnexpectedTrailingToken_ShouldThrowActionableError(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' WHERE id = 1 EXTRA";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("Unexpected token after UPDATE", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures UPDATE WHERE without predicate is rejected with actionable message.
+    /// PT: Garante que UPDATE com WHERE sem predicado seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseUpdate_WhereWithoutPredicate_ShouldThrowActionableError(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' WHERE";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures UPDATE WHERE terminated only by semicolon is rejected with actionable message.
+    /// PT: Garante que UPDATE com WHERE finalizado apenas por ponto e vírgula seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseUpdate_WhereOnlySemicolon_ShouldThrowActionableError(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' WHERE;";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     /// EN: Ensures UPDATE ... RETURNING with qualified wildcard preserves projection item in AST.
     /// PT: Garante que UPDATE ... RETURNING com wildcard qualificado preserve o item de projeção na AST.
@@ -206,6 +859,59 @@ RETURNING id";
         Assert.Contains("id = 1", parsed.WhereRaw, StringComparison.OrdinalIgnoreCase);
         Assert.Single(parsed.Returning);
         Assert.Equal("id", parsed.Returning[0].Raw);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures DELETE with unexpected trailing token is rejected with actionable message.
+    /// PT: Garante que DELETE com token inesperado ao final seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseDelete_WithUnexpectedTrailingToken_ShouldThrowActionableError(int version)
+    {
+        const string sql = "DELETE FROM users WHERE id = 1 EXTRA";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("Unexpected token after DELETE", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures DELETE WHERE without predicate is rejected with actionable message.
+    /// PT: Garante que DELETE com WHERE sem predicado seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseDelete_WhereWithoutPredicate_ShouldThrowActionableError(int version)
+    {
+        const string sql = "DELETE FROM users WHERE";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures DELETE WHERE terminated only by semicolon is rejected with actionable message.
+    /// PT: Garante que DELETE com WHERE finalizado apenas por ponto e vírgula seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseDelete_WhereOnlySemicolon_ShouldThrowActionableError(int version)
+    {
+        const string sql = "DELETE FROM users WHERE;";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 
@@ -258,6 +964,43 @@ RETURNING id";
             SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
 
         Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures RETURNING supports nested expressions with commas and semicolon statement boundary.
+    /// PT: Garante que RETURNING suporte expressões aninhadas com vírgulas e limite de statement por ponto e vírgula.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseInsert_ReturningNestedExpressionsWithSemicolon_ShouldCaptureItems(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') RETURNING COALESCE((SELECT max(id) FROM users), 0) AS next_id, concat(name, ',x') AS decorated;";
+
+        var parsed = Assert.IsType<SqlInsertQuery>(SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Equal(2, parsed.Returning.Count);
+        Assert.Equal("COALESCE((SELECT max(id) FROM users), 0)", parsed.Returning[0].Raw);
+        Assert.Equal("next_id", parsed.Returning[0].Alias);
+        Assert.Equal("concat(name, ',x')", parsed.Returning[1].Raw);
+        Assert.Equal("decorated", parsed.Returning[1].Alias);
+    }
+
+    /// <summary>
+    /// EN: Ensures malformed RETURNING expression with unbalanced parentheses is rejected with actionable message.
+    /// PT: Garante que expressão malformada em RETURNING com parênteses desbalanceados seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataNpgsqlVersion]
+    public void ParseUpdate_ReturningUnbalancedParenthesis_ShouldThrowActionableError(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' WHERE id = 1 RETURNING (id";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new NpgsqlDialect(version)));
+
+        Assert.Contains("unbalanced parentheses", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -868,4 +1611,3 @@ RETURNING id";
     }
 
 }
-

--- a/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
+++ b/src/DbSqlLikeMem.SqlServer.Test/Parser/SqlServerDialectFeatureParserTests.cs
@@ -905,6 +905,77 @@ public sealed class SqlServerDialectFeatureParserTests
         Assert.Contains("RETURNING", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+
+    /// <summary>
+    /// EN: Ensures PostgreSQL RETURNING clause is rejected for SQL Server UPDATE statements even without WHERE.
+    /// PT: Garante que a cláusula RETURNING do PostgreSQL seja rejeitada em UPDATE no SQL Server mesmo sem WHERE.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseUpdate_WithReturningWithoutWhere_ShouldBeRejected(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' RETURNING id";
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("RETURNING", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures UPDATE with unexpected trailing token is rejected with actionable message.
+    /// PT: Garante que UPDATE com token inesperado ao final seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseUpdate_WithUnexpectedTrailingToken_ShouldThrowActionableError(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' WHERE id = 1 EXTRA";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("Unexpected token after UPDATE", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures UPDATE WHERE without predicate is rejected with actionable message.
+    /// PT: Garante que UPDATE com WHERE sem predicado seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseUpdate_WhereWithoutPredicate_ShouldThrowActionableError(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' WHERE";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures UPDATE WHERE terminated only by semicolon is rejected with actionable message.
+    /// PT: Garante que UPDATE com WHERE finalizado apenas por ponto e vírgula seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseUpdate_WhereOnlySemicolon_ShouldThrowActionableError(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' WHERE;";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     /// EN: Ensures PostgreSQL RETURNING clause is rejected for SQL Server DELETE statements.
     /// PT: Garante que a cláusula RETURNING do PostgreSQL seja rejeitada em DELETE no SQL Server.
@@ -925,6 +996,59 @@ public sealed class SqlServerDialectFeatureParserTests
 
 
     /// <summary>
+    /// EN: Ensures DELETE with unexpected trailing token is rejected with actionable message.
+    /// PT: Garante que DELETE com token inesperado ao final seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseDelete_WithUnexpectedTrailingToken_ShouldThrowActionableError(int version)
+    {
+        const string sql = "DELETE FROM users WHERE id = 1 EXTRA";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("Unexpected token after DELETE", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures DELETE WHERE without predicate is rejected with actionable message.
+    /// PT: Garante que DELETE com WHERE sem predicado seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseDelete_WhereWithoutPredicate_ShouldThrowActionableError(int version)
+    {
+        const string sql = "DELETE FROM users WHERE";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures DELETE WHERE terminated only by semicolon is rejected with actionable message.
+    /// PT: Garante que DELETE com WHERE finalizado apenas por ponto e vírgula seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseDelete_WhereOnlySemicolon_ShouldThrowActionableError(int version)
+    {
+        const string sql = "DELETE FROM users WHERE;";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("WHERE requires a predicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
     /// EN: Ensures malformed RETURNING in INSERT remains blocked by SQL Server dialect gate.
     /// PT: Garante que RETURNING malformado em INSERT continue bloqueado pelo gate de dialeto SQL Server.
     /// </summary>
@@ -934,6 +1058,380 @@ public sealed class SqlServerDialectFeatureParserTests
     public void ParseInsert_WithMalformedReturning_ShouldBeRejectedByDialectGate(int version)
     {
         const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') RETURNING, id";
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("RETURNING", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT with unexpected trailing token is rejected with actionable message.
+    /// PT: Garante que INSERT com token inesperado ao final seja rejeitado com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_WithUnexpectedTrailingToken_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') EXTRA";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("Unexpected token after INSERT", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES trailing comma is rejected with actionable message.
+    /// PT: Garante que vírgula final em INSERT VALUES seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ValuesTrailingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id) VALUES (1),";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES tuples without comma separator are rejected with actionable message.
+    /// PT: Garante que tuplas em INSERT VALUES sem vírgula separadora sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ValuesTuplesWithoutCommaSeparator_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id) VALUES (1) (2)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("separate row tuples with commas", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES leading comma is rejected with actionable message.
+    /// PT: Garante que vírgula inicial em INSERT VALUES seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ValuesLeadingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id) VALUES , (1)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT column list trailing comma is rejected with actionable message.
+    /// PT: Garante que vírgula final na lista de colunas do INSERT seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ColumnListTrailingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id,) VALUES (1)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("trailing comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures INSERT empty column list is rejected with actionable message.
+    /// PT: Garante que lista de colunas vazia no INSERT seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_EmptyColumnList_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users () VALUES (1)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("at least one column", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT column list leading comma is rejected with actionable message.
+    /// PT: Garante que vírgula inicial na lista de colunas do INSERT seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ColumnListLeadingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (,id) VALUES (1)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("unexpected comma", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures INSERT column list unclosed before semicolon is rejected with actionable message.
+    /// PT: Garante que lista de colunas do INSERT não fechada antes de ponto e vírgula seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ColumnListUnclosedBeforeSemicolon_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id;";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("not closed correctly", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES rejects empty expression between commas inside tuple.
+    /// PT: Garante que INSERT VALUES rejeite expressão vazia entre vírgulas dentro da tupla.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ValuesTupleMissingExpressionBetweenCommas_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users VALUES (1,,2)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("empty expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES rejects trailing comma inside tuple.
+    /// PT: Garante que INSERT VALUES rejeite vírgula final dentro da tupla.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ValuesTupleTrailingComma_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users VALUES (1,)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("empty expression", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES tuple with unclosed parenthesis is rejected with actionable message.
+    /// PT: Garante que tupla em INSERT VALUES com parêntese não fechado seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ValuesTupleUnclosedParenthesis_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users VALUES (1, 2";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("not closed correctly", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES row expression count mismatch is rejected with actionable message.
+    /// PT: Garante que divergência entre número de colunas e expressões em INSERT VALUES seja rejeitada com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ValuesColumnCountMismatch_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("column count", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("row 1", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures INSERT VALUES rows with inconsistent expression counts are rejected with actionable message.
+    /// PT: Garante que linhas de INSERT VALUES com cardinalidade inconsistente de expressões sejam rejeitadas com mensagem acionável.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_ValuesRowArityMismatch_ShouldThrowActionableError(int version)
+    {
+        const string sql = "INSERT INTO users VALUES (1, 'a'), (2)";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("row 2", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("row 1", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures PostgreSQL ON CONFLICT remains rejected by SQL Server dialect gate even when malformed.
+    /// PT: Garante que ON CONFLICT do PostgreSQL continue rejeitado pelo gate de dialeto SQL Server mesmo malformado.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_WithMalformedOnConflictTarget_ShouldBeRejectedByDialectGate(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (, id) DO NOTHING";
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("ON CONFLICT", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT target interrupted by semicolon remains rejected by SQL Server dialect gate.
+    /// PT: Garante que alvo de ON CONFLICT interrompido por ponto e vírgula continue rejeitado pelo gate de dialeto SQL Server.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_WithOnConflictTargetUnclosedBeforeSemicolon_ShouldBeRejectedByDialectGate(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id;";
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("ON CONFLICT", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures malformed ON CONFLICT DO UPDATE SET remains rejected by SQL Server dialect gate.
+    /// PT: Garante que ON CONFLICT DO UPDATE SET malformado continue rejeitado pelo gate de dialeto SQL Server.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_WithMalformedOnConflictDoUpdateSet_ShouldBeRejectedByDialectGate(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) DO UPDATE SET , name = EXCLUDED.name";
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("ON CONFLICT", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT without DO branch remains rejected by SQL Server dialect gate.
+    /// PT: Garante que ON CONFLICT sem ramo DO continue rejeitado pelo gate de dialeto SQL Server.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_WithOnConflictMissingDoBranch_ShouldBeRejectedByDialectGate(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id)";
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("ON CONFLICT", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT target WHERE without predicate remains rejected by SQL Server dialect gate.
+    /// PT: Garante que ON CONFLICT com WHERE de alvo sem predicado continue rejeitado pelo gate de dialeto SQL Server.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_WithOnConflictTargetWhereWithoutPredicate_ShouldBeRejectedByDialectGate(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) WHERE DO NOTHING";
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("ON CONFLICT", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT target WHERE terminated only by semicolon remains rejected by SQL Server dialect gate.
+    /// PT: Garante que ON CONFLICT com WHERE de alvo finalizado apenas por ponto e vírgula continue rejeitado pelo gate de dialeto SQL Server.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_WithOnConflictTargetWhereOnlySemicolon_ShouldBeRejectedByDialectGate(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT (id) WHERE; DO NOTHING";
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("ON CONFLICT", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    /// <summary>
+    /// EN: Ensures ON CONFLICT ON CONSTRAINT without name remains rejected by SQL Server dialect gate.
+    /// PT: Garante que ON CONFLICT ON CONSTRAINT sem nome continue rejeitado pelo gate de dialeto SQL Server.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseInsert_WithOnConflictOnConstraintWithoutName_ShouldBeRejectedByDialectGate(int version)
+    {
+        const string sql = "INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT ON CONSTRAINT DO NOTHING";
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
+
+        Assert.Contains("ON CONFLICT", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// EN: Ensures malformed RETURNING with unbalanced parentheses in UPDATE remains blocked by SQL Server dialect gate.
+    /// PT: Garante que RETURNING malformado com parênteses desbalanceados em UPDATE continue bloqueado pelo gate de dialeto SQL Server.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Parser")]
+    [MemberDataSqlServerVersion]
+    public void ParseUpdate_WithMalformedReturningUnbalancedParenthesis_ShouldBeRejectedByDialectGate(int version)
+    {
+        const string sql = "UPDATE users SET name = 'b' WHERE id = 1 RETURNING (id";
 
         var ex = Assert.Throws<NotSupportedException>(() =>
             SqlQueryParser.Parse(sql, new SqlServerDialect(version)));
@@ -967,4 +1465,3 @@ WHERE u.id > 0";
     }
 
 }
-

--- a/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
+++ b/src/DbSqlLikeMem/Parser/SqlQueryParser.cs
@@ -279,32 +279,7 @@ internal sealed class SqlQueryParser
         if (IsWord(Peek(), "VALUES"))
         {
             Consume(); // VALUES
-            while (true)
-            {
-                if (IsSymbol(Peek(), "("))
-                {
-                    // Lê raw tokens dentro dos parênteses para ValuesRaw
-                    // AST espera List<string> (tokens raw). 
-                    // Melhor seria parsear expressões, mas mantendo compatibilidade com teu AST:
-                    var rawBlock = ReadBalancedParenRawTokens();
-                    // ReadBalanced retorna string "expr, expr", vamos dividir por virgula simplificado ou salvar tudo?
-                    // O AST diz "IReadOnlyList<List<string>> ValuesRaw". Assumindo lista de tokens.
-                    // Para simplificar, vamos armazenar o conteúdo bruto tokenizado.
-
-                    // Nota: Teu AST pede List<string> que são tokens raw por valor? 
-                    // Vou assumir que cada item da lista interna é um valor (ex: "1", "'abc'").
-                    var rowValues = SplitRawByComma(rawBlock);
-                    valuesRaw.Add(rowValues);
-                    valuesExpr.Add([.. rowValues.Select(TryParseScalar)]);
-                }
-
-                if (IsSymbol(Peek(), ","))
-                {
-                    Consume();
-                    continue;
-                }
-                break;
-            }
+            ParseInsertValuesRows(valuesRaw, valuesExpr);
         }
         else if (IsWord(Peek(), "SELECT") || IsWord(Peek(), "WITH"))
         {
@@ -320,9 +295,13 @@ internal sealed class SqlQueryParser
         if (valuesRaw.Count == 0 && insertSelect is null)
             throw new InvalidOperationException("Invalid INSERT statement: expected VALUES or SELECT.");
 
+        ValidateInsertValuesColumnArity(cols, valuesRaw);
+
         // ON DUPLICATE KEY UPDATE
         var onDup = ParseOnDuplicated();
         var returning = ParseOptionalReturningItems();
+
+        EnsureStatementEnd("INSERT");
 
         return new SqlInsertQuery
         {
@@ -341,6 +320,90 @@ internal sealed class SqlQueryParser
         };
     }
 
+    private void ParseInsertValuesRows(List<List<string>> valuesRaw, List<List<SqlExpr?>> valuesExpr)
+    {
+        while (true)
+        {
+            if (IsEnd(Peek()) || IsSymbol(Peek(), ";"))
+            {
+                if (valuesRaw.Count == 0)
+                    throw new InvalidOperationException("INSERT VALUES requires at least one row.");
+
+                return;
+            }
+
+            if (IsSymbol(Peek(), ","))
+                throw new InvalidOperationException("INSERT VALUES has an unexpected comma before row.");
+
+            if (!IsSymbol(Peek(), "("))
+            {
+                if (valuesRaw.Count == 0)
+                    throw new InvalidOperationException("Invalid INSERT statement: expected VALUES row tuple.");
+
+                throw new InvalidOperationException("INSERT VALUES must separate row tuples with commas.");
+            }
+
+            var rawBlock = ReadBalancedParenRawTokens();
+            var rowValuesRaw = SplitRawByComma(rawBlock);
+
+            if (rowValuesRaw.Count == 0)
+                throw new InvalidOperationException("INSERT VALUES row requires at least one expression.");
+
+            if (rowValuesRaw.Any(v => string.IsNullOrWhiteSpace(v)))
+                throw new InvalidOperationException("INSERT VALUES row has an empty expression between commas.");
+
+            var rowValues = rowValuesRaw;
+
+            valuesRaw.Add(rowValues);
+            valuesExpr.Add([.. rowValues.Select(TryParseScalar)]);
+
+            if (IsSymbol(Peek(), ","))
+            {
+                Consume();
+
+                if (IsEnd(Peek()) || IsSymbol(Peek(), ";"))
+                    throw new InvalidOperationException("INSERT VALUES has a trailing comma without row tuple.");
+
+                continue;
+            }
+
+            if (IsSymbol(Peek(), "("))
+                throw new InvalidOperationException("INSERT VALUES must separate row tuples with commas.");
+
+            return;
+        }
+    }
+
+    private static void ValidateInsertValuesColumnArity(IReadOnlyList<string> cols, IReadOnlyList<List<string>> valuesRaw)
+    {
+        if (valuesRaw.Count == 0)
+            return;
+
+        var expectedRowArity = valuesRaw[0].Count;
+        for (var rowIndex = 1; rowIndex < valuesRaw.Count; rowIndex++)
+        {
+            var row = valuesRaw[rowIndex];
+            if (row.Count == expectedRowArity)
+                continue;
+
+            throw new InvalidOperationException(
+                $"INSERT VALUES row {rowIndex + 1} expression count ({row.Count}) does not match row 1 expression count ({expectedRowArity}).");
+        }
+
+        if (cols.Count == 0)
+            return;
+
+        for (var rowIndex = 0; rowIndex < valuesRaw.Count; rowIndex++)
+        {
+            var row = valuesRaw[rowIndex];
+            if (row.Count == cols.Count)
+                continue;
+
+            throw new InvalidOperationException(
+                $"INSERT column count ({cols.Count}) does not match VALUES row {rowIndex + 1} expression count ({row.Count}).");
+        }
+    }
+
     private List<string> ParseCols()
     {
         if (!IsSymbol(Peek(), "("))
@@ -348,15 +411,39 @@ internal sealed class SqlQueryParser
 
         var cols = new List<string>();
         Consume(); // (
-        while (!IsSymbol(Peek(), ")"))
-        {
-            cols.Add(ExpectIdentifier());
-            if (IsSymbol(Peek(), ",")) Consume();
-            else break;
-        }
-        ExpectSymbol(")");
 
-        return cols;
+        while (true)
+        {
+            if (IsEnd(Peek()) || IsSymbol(Peek(), ";"))
+                throw new InvalidOperationException("INSERT column list was not closed correctly.");
+
+            if (IsSymbol(Peek(), ")"))
+            {
+                if (cols.Count == 0)
+                    throw new InvalidOperationException("INSERT column list requires at least one column.");
+
+                Consume();
+                return cols;
+            }
+
+            if (IsSymbol(Peek(), ","))
+                throw new InvalidOperationException("INSERT column list has an unexpected comma before column.");
+
+            cols.Add(ExpectIdentifier());
+
+            if (IsSymbol(Peek(), ","))
+            {
+                Consume();
+
+                if (IsSymbol(Peek(), ")"))
+                    throw new InvalidOperationException("INSERT column list has a trailing comma without column.");
+
+                continue;
+            }
+
+            if (!IsSymbol(Peek(), ")"))
+                throw new InvalidOperationException("INSERT column list must separate columns with commas.");
+        }
     }
 
     private SqlOnDuplicateKeyUpdate? ParseOnDuplicated()
@@ -396,7 +483,10 @@ internal sealed class SqlQueryParser
             // - [target] WHERE predicate
             ParsePostgreSqlOnConflictTarget();
 
-            ExpectWord("DO");
+            if (!IsWord(Peek(), "DO"))
+                throw new InvalidOperationException("ON CONFLICT requires DO NOTHING or DO UPDATE SET.");
+
+            Consume(); // DO
 
             if (IsWord(Peek(), "NOTHING"))
             {
@@ -404,9 +494,16 @@ internal sealed class SqlQueryParser
                 return new SqlOnDuplicateKeyUpdate([], IsDoNothing: true);
             }
 
-            ExpectWord("UPDATE");
-            ExpectWord("SET");
-            var assigns = ParseAssignmentsList();
+            if (!IsWord(Peek(), "UPDATE"))
+                throw new InvalidOperationException("ON CONFLICT DO must be followed by NOTHING or UPDATE SET.");
+
+            Consume(); // UPDATE
+
+            if (!IsWord(Peek(), "SET"))
+                throw new InvalidOperationException("ON CONFLICT DO UPDATE requires SET assignments.");
+
+            Consume(); // SET
+            var assigns = ParseOnConflictUpdateAssignments();
             string? updateWhereRaw = null;
 
             // PostgreSQL permite: DO UPDATE SET ... WHERE <predicate>
@@ -414,7 +511,9 @@ internal sealed class SqlQueryParser
             if (IsWord(Peek(), "WHERE"))
             {
                 Consume();
-                updateWhereRaw = ReadClauseTextUntilTopLevelStop("RETURNING");
+                updateWhereRaw = NormalizeClauseText(ReadClauseTextUntilTopLevelStop("RETURNING"));
+                if (string.IsNullOrWhiteSpace(updateWhereRaw))
+                    throw new InvalidOperationException("ON CONFLICT DO UPDATE WHERE requires a predicate.");
             }
 
             return new SqlOnDuplicateKeyUpdate(assigns, UpdateWhereRaw: updateWhereRaw);
@@ -430,12 +529,19 @@ internal sealed class SqlQueryParser
         {
             Consume(); // ON
             Consume(); // CONSTRAINT
-            _ = ExpectIdentifier();
+
+            var constraint = Peek();
+            if (constraint.Kind != SqlTokenKind.Identifier)
+                throw new InvalidOperationException("ON CONFLICT ON CONSTRAINT requires a constraint name.");
+
+            Consume(); // constraint name
 
             if (IsWord(Peek(), "WHERE"))
             {
                 Consume();
-                _ = ReadClauseTextUntilTopLevelStop("DO");
+                var targetWhereRaw = NormalizeClauseText(ReadClauseTextUntilTopLevelStop("DO"));
+                if (string.IsNullOrWhiteSpace(targetWhereRaw))
+                    throw new InvalidOperationException("ON CONFLICT target WHERE requires a predicate.");
             }
             return;
         }
@@ -444,22 +550,103 @@ internal sealed class SqlQueryParser
         if (IsSymbol(Peek(), "("))
         {
             Consume(); // (
-            var depth = 1;
-            while (!IsEnd(Peek()) && depth > 0)
-            {
-                var t = Consume();
-                if (IsSymbol(t, "(")) depth++;
-                else if (IsSymbol(t, ")")) depth--;
-            }
-
-            if (depth != 0)
-                throw new InvalidOperationException("ON CONFLICT target não foi fechado corretamente.");
+            ParseOnConflictTargetItems();
 
             if (IsWord(Peek(), "WHERE"))
             {
                 Consume();
-                _ = ReadClauseTextUntilTopLevelStop("DO");
+                var targetWhereRaw = NormalizeClauseText(ReadClauseTextUntilTopLevelStop("DO"));
+                if (string.IsNullOrWhiteSpace(targetWhereRaw))
+                    throw new InvalidOperationException("ON CONFLICT target WHERE requires a predicate.");
             }
+        }
+    }
+
+    private void ParseOnConflictTargetItems()
+    {
+        var items = 0;
+
+        while (true)
+        {
+            if (IsEnd(Peek()))
+                throw new InvalidOperationException("ON CONFLICT target was not closed correctly.");
+
+            if (IsSymbol(Peek(), ")"))
+            {
+                if (items == 0)
+                    throw new InvalidOperationException("ON CONFLICT target requires at least one expression.");
+
+                Consume();
+                return;
+            }
+
+            if (IsSymbol(Peek(), ","))
+                throw new InvalidOperationException("ON CONFLICT target has an unexpected comma before expression.");
+
+            var raw = ReadRawExpressionUntilCommaOrRightParen().Trim();
+            if (string.IsNullOrWhiteSpace(raw))
+                throw new InvalidOperationException("ON CONFLICT target requires at least one expression.");
+
+            _ = SqlExpressionParser.ParseScalar(raw, _dialect);
+            items++;
+
+            if (IsSymbol(Peek(), ","))
+            {
+                Consume();
+
+                if (IsSymbol(Peek(), ")"))
+                    throw new InvalidOperationException("ON CONFLICT target has a trailing comma without expression.");
+
+                continue;
+            }
+
+            if (!IsSymbol(Peek(), ")"))
+                throw new InvalidOperationException("ON CONFLICT target must separate expressions with commas.");
+        }
+    }
+
+
+    private List<SqlAssignment> ParseOnConflictUpdateAssignments()
+    {
+        var list = new List<SqlAssignment>();
+
+        while (true)
+        {
+            if (IsEnd(Peek()) || IsSymbol(Peek(), ";") || IsWord(Peek(), "WHERE") || IsWord(Peek(), "RETURNING"))
+            {
+                if (list.Count == 0)
+                    throw new InvalidOperationException("ON CONFLICT DO UPDATE SET requires at least one assignment.");
+
+                return list;
+            }
+
+            if (IsSymbol(Peek(), ","))
+                throw new InvalidOperationException("ON CONFLICT DO UPDATE SET has an unexpected comma before assignment.");
+
+            var col = ExpectIdentifierWithDots();
+            ExpectSymbol("=");
+
+            var exprRaw = ReadClauseTextUntilTopLevelStop(",", "WHERE", "RETURNING", ";").Trim();
+            if (string.IsNullOrWhiteSpace(exprRaw))
+                throw new InvalidOperationException($"ON CONFLICT DO UPDATE SET assignment for '{col}' requires an expression.");
+
+            _ = SqlExpressionParser.ParseScalar(exprRaw, _dialect);
+            list.Add(new SqlAssignment(col, exprRaw));
+
+            if (IsSymbol(Peek(), ","))
+            {
+                Consume();
+
+                if (IsEnd(Peek()) || IsSymbol(Peek(), ";") || IsWord(Peek(), "WHERE") || IsWord(Peek(), "RETURNING"))
+                    throw new InvalidOperationException("ON CONFLICT DO UPDATE SET has a trailing comma without assignment.");
+
+                continue;
+            }
+
+            if (IsEnd(Peek()) || IsSymbol(Peek(), ";") || IsWord(Peek(), "WHERE") || IsWord(Peek(), "RETURNING"))
+                return list;
+
+            throw new InvalidOperationException("ON CONFLICT DO UPDATE SET must separate assignments with commas.");
         }
     }
 
@@ -480,7 +667,7 @@ internal sealed class SqlQueryParser
 
         ExpectWord("SET");
 
-        var assignsList = ParseAssignmentsList();
+        var assignsList = ParseUpdateAssignmentsList();
         var setList = assignsList.ConvertAll(a => (a.Column, a.ValueRaw));
 
         // SQL Server/PostgreSQL: UPDATE <alias> SET ... FROM ... [WHERE ...]
@@ -499,7 +686,9 @@ internal sealed class SqlQueryParser
         if (IsWord(Peek(), "WHERE"))
         {
             Consume(); // WHERE
-            whereRaw = ReadClauseTextUntilTopLevelStop("RETURNING");
+            whereRaw = NormalizeClauseText(ReadClauseTextUntilTopLevelStop("RETURNING"));
+            if (string.IsNullOrWhiteSpace(whereRaw))
+                throw new InvalidOperationException("UPDATE WHERE requires a predicate.");
         }
         var returning = ParseOptionalReturningItems();
 
@@ -512,6 +701,8 @@ internal sealed class SqlQueryParser
             catch { whereExpr = null; }
 #pragma warning restore CA1031 // Do not catch general exception types
         }
+
+        EnsureStatementEnd("UPDATE");
 
         return new SqlUpdateQuery
         {
@@ -612,7 +803,9 @@ internal sealed class SqlQueryParser
         if (IsWord(Peek(), "WHERE"))
         {
             Consume();
-            whereRaw = ReadClauseTextUntilTopLevelStop("RETURNING");
+            whereRaw = NormalizeClauseText(ReadClauseTextUntilTopLevelStop("RETURNING"));
+            if (string.IsNullOrWhiteSpace(whereRaw))
+                throw new InvalidOperationException("DELETE WHERE requires a predicate.");
         }
         var returning = ParseOptionalReturningItems();
 
@@ -624,6 +817,8 @@ internal sealed class SqlQueryParser
             catch { whereExpr = null; }
 #pragma warning restore CA1031 // Do not catch general exception types
         }
+
+        EnsureStatementEnd("DELETE");
 
         return new SqlDeleteQuery
         {
@@ -869,6 +1064,50 @@ internal sealed class SqlQueryParser
         return sb.ToString();
     }
 
+    private List<SqlAssignment> ParseUpdateAssignmentsList()
+    {
+        var list = new List<SqlAssignment>();
+
+        while (true)
+        {
+            if (IsEnd(Peek()) || IsSymbol(Peek(), ";") || IsWord(Peek(), "WHERE") || IsWord(Peek(), "FROM") || IsWord(Peek(), "RETURNING"))
+            {
+                if (list.Count == 0)
+                    throw new InvalidOperationException("UPDATE SET requires at least one assignment.");
+
+                return list;
+            }
+
+            if (IsSymbol(Peek(), ","))
+                throw new InvalidOperationException("UPDATE SET has an unexpected comma before assignment.");
+
+            var col = ExpectIdentifierWithDots();
+            ExpectSymbol("=");
+
+            var exprRaw = ReadClauseTextUntilTopLevelStop(",", "WHERE", "FROM", "RETURNING", ";").Trim();
+            if (string.IsNullOrWhiteSpace(exprRaw))
+                throw new InvalidOperationException($"UPDATE SET assignment for '{col}' requires an expression.");
+
+            _ = SqlExpressionParser.ParseScalar(exprRaw, _dialect);
+            list.Add(new SqlAssignment(col, exprRaw));
+
+            if (IsSymbol(Peek(), ","))
+            {
+                Consume();
+
+                if (IsEnd(Peek()) || IsSymbol(Peek(), ";") || IsWord(Peek(), "WHERE") || IsWord(Peek(), "FROM") || IsWord(Peek(), "RETURNING"))
+                    throw new InvalidOperationException("UPDATE SET has a trailing comma without assignment.");
+
+                continue;
+            }
+
+            if (IsEnd(Peek()) || IsSymbol(Peek(), ";") || IsWord(Peek(), "WHERE") || IsWord(Peek(), "FROM") || IsWord(Peek(), "RETURNING"))
+                return list;
+
+            throw new InvalidOperationException("UPDATE SET must separate assignments with commas.");
+        }
+    }
+
     private List<SqlAssignment> ParseAssignmentsList()
     {
         var list = new List<SqlAssignment>();
@@ -930,6 +1169,10 @@ internal sealed class SqlQueryParser
             }
             buf.Add(t);
         }
+
+        if (depth != 0)
+            throw new InvalidOperationException("INSERT VALUES row tuple was not closed correctly.");
+
         return TokensToSql(buf);
     }
 
@@ -1271,6 +1514,39 @@ internal sealed class SqlQueryParser
         return items;
     }
 
+    private string ReadRawExpressionUntilCommaOrRightParen()
+    {
+        var buf = new List<SqlToken>();
+        int depth = 0;
+
+        while (!IsEnd(Peek()))
+        {
+            var t = Peek();
+
+            if (depth == 0 && IsSymbol(t, ";"))
+                throw new InvalidOperationException("ON CONFLICT target was not closed correctly.");
+
+            if (depth == 0 && (IsSymbol(t, ",") || IsSymbol(t, ")")))
+                break;
+
+            if (IsSymbol(t, "("))
+                depth++;
+            else if (IsSymbol(t, ")"))
+            {
+                if (depth == 0)
+                    throw new InvalidOperationException("ON CONFLICT target has unbalanced parentheses in expression.");
+                depth--;
+            }
+
+            buf.Add(Consume());
+        }
+
+        if (depth != 0)
+            throw new InvalidOperationException("ON CONFLICT target has unbalanced parentheses in expression.");
+
+        return TokensToSql(buf);
+    }
+
     private string ReadRawExpressionUntilCommaOrTerminator()
     {
         var buf = new List<SqlToken>();
@@ -1286,10 +1562,17 @@ internal sealed class SqlQueryParser
             if (IsSymbol(t, "("))
                 depth++;
             else if (IsSymbol(t, ")"))
+            {
+                if (depth == 0)
+                    throw new InvalidOperationException("RETURNING has unbalanced parentheses in expression.");
                 depth--;
+            }
 
             buf.Add(Consume());
         }
+
+        if (depth != 0)
+            throw new InvalidOperationException("RETURNING has unbalanced parentheses in expression.");
 
         return TokensToSql(buf);
     }
@@ -2432,6 +2715,30 @@ internal sealed class SqlQueryParser
 
         throw new FormatException($"The input string '{parameterToken}' was not in a correct format.");
     }
+    private static string NormalizeClauseText(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return string.Empty;
+
+        var txt = raw.Trim();
+        if (txt.EndsWith(";", StringComparison.Ordinal))
+            txt = txt[..^1].TrimEnd();
+
+        return txt;
+    }
+
+    private void EnsureStatementEnd(string statementName)
+    {
+        if (IsSymbol(Peek(), ";"))
+            Consume();
+
+        if (!IsEnd(Peek()))
+        {
+            var t = Peek();
+            throw new InvalidOperationException($"Unexpected token after {statementName}: {t.Kind} '{t.Text}'");
+        }
+    }
+
     private void ExpectEndOrUnionBoundary()
     {
         // Após um SELECT completo, só é válido terminar o statement ou seguir com UNION.


### PR DESCRIPTION
### Motivation
- Improve robustness and user-facing diagnostics of the SQL parser for DML constructs by detecting malformed syntax early and returning actionable messages. 
- Normalize statement boundaries (including trailing `;`) and preserve dialect gating (e.g., keep PostgreSQL features blocked for SQL Server). 
- Prevent silent/partial parses that could lead to incorrect ASTs or downstream runtime surprises. 
- Add broad parser coverage for many edge cases encountered in CI and real-world SQL.

### Description
- Introduced stricter parsing and validations for `INSERT VALUES`, including row tuple boundaries, empty expressions, leading/trailing commas, unclosed parentheses, separation of tuples by commas, and column/row arity checks via `ParseInsertValuesRows` and `ValidateInsertValuesColumnArity`.
- Hardened `ON CONFLICT` handling with new target parsing/validation (`ParseOnConflictTargetItems`) and robust `DO UPDATE SET` assignment parsing (`ParseOnConflictUpdateAssignments`), including checks for missing `DO`, missing `SET`, empty/leading/trailing commas, missing expressions, `WHERE` predicate presence, and `ON CONSTRAINT` name requirement.
- Tightened `RETURNING` parsing to detect unbalanced parentheses and nested-expression boundaries, plus preserved `;` as a statement terminator using helpers like `ReadRawExpressionUntilCommaOrTerminator`, `ReadRawExpressionUntilCommaOrRightParen`, and `ReadBalancedParenRawTokens` (now erroring on unclosed tuples).
- Strengthened `UPDATE`/`DELETE` parsing with validated `SET`/assignment lists (`ParseUpdateAssignmentsList`), `WHERE` predicate presence checks, and `EnsureStatementEnd` to reject unexpected trailing tokens after statements.
- Added `NormalizeClauseText` to strip terminal semicolons before clause validation and kept dialect gates intact by throwing `NotSupportedException` where appropriate (SQL Server tests continue to validate gating).
- Numerous unit tests added across `DbSqlLikeMem.Npgsql.Test` and `DbSqlLikeMem.SqlServer.Test` covering many malformed and valid scenarios for `INSERT`, `UPDATE`, `DELETE`, `ON CONFLICT`, and `RETURNING`, plus a nested-expression returning test and various unexpected-trailer cases.

### Testing
- Ran the parser unit test suites in `DbSqlLikeMem.Npgsql.Test` and `DbSqlLikeMem.SqlServer.Test` which exercise the new error paths and valid parsing scenarios. All newly added parser tests executed and passed. 
- Existing parser tests for `SELECT`/pagination/within-group remained green as part of the suite run. 
- Dialect gate tests were executed to ensure `NotSupportedException` remains for SQL Server when PostgreSQL-only constructs are used and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a8b4d158832ca84b9aec4422fb67)